### PR TITLE
Fix potential null pointer dereference on macOS

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -594,6 +594,7 @@ public:
                       auto w =
                           (cocoa_wkwebview_engine *)objc_getAssociatedObject(
                               self, "webview");
+                      assert(w);
                       w->on_message((const char *)objc_msgSend(
                           objc_msgSend(msg, "body"_sel), "UTF8String"_sel));
                     }),


### PR DESCRIPTION
[Infer](https://github.com/facebook/infer) reports that there is a potential null pointer dereference:

```
webview.h:597: error: NULL_DEREFERENCE
  pointer `w` last assigned on line 594 could be null and is dereferenced at line 597, column 23.
  595.                             (cocoa_wkwebview_engine *)objc_getAssociatedObject(
  596.                                 self, "webview");
  597. >                       w->on_message((const char *)objc_msgSend(
  598.                             objc_msgSend(msg, "body"_sel), "UTF8String"_sel));
  599.                       }),

```

According to the declaration of `objc_getAssociatedObject`, it can potentially return `null`:

```
OBJC_EXPORT id _Nullable
objc_getAssociatedObject(id _Nonnull object, const void * _Nonnull key)
    OBJC_AVAILABLE(10.6, 3.1, 9.0, 1.0, 2.0);
```

This shouldn't happen since `objc_setAssociatedObject(delegate, "webview", (id)this, OBJC_ASSOCIATION_ASSIGN);` is called shortly after, but if for some reason it's `null` it could cause weird behavior