### PR TITLE
Simplify set_size on macOS

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -672,18 +672,12 @@ public:
     }
     objc_msgSend(m_window, "setStyleMask:"_sel, style);
 
-    struct {
-      CGFloat width;
-      CGFloat height;
-    } size;
     if (hints == WEBVIEW_HINT_MIN) {
-      size.width = width;
-      size.height = height;
-      objc_msgSend(m_window, "setContentMinSize:"_sel, size);
+      objc_msgSend(m_window, "setContentMinSize:"_sel,
+                   CGSizeMake(width, height));
     } else if (hints == WEBVIEW_HINT_MAX) {
-      size.width = width;
-      size.height = height;
-      objc_msgSend(m_window, "setContentMaxSize:"_sel, size);
+      objc_msgSend(m_window, "setContentMaxSize:"_sel,
+                   CGSizeMake(width, height));
     } else {
       objc_msgSend(m_window, "setFrame:display:animate:"_sel,
                    CGRectMake(0, 0, width, height), 1, 0);


### PR DESCRIPTION
This PR simplifies `set_size`. Creating a struct called `size` and setting `width` and `height` properties seems a bit unnecessary when the `CGSizeMake` API does the same thing:

![image](https://user-images.githubusercontent.com/19519564/85196357-cefa1580-b2a7-11ea-8aaa-06f89306eaf4.png)


![image](https://user-images.githubusercontent.com/19519564/85196311-5c893580-b2a7-11ea-837a-7fa8f5dea219.png)
