### PR TITLE
Run CI pipeline on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI Pipeline
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-linux:


### PR DESCRIPTION
It seems like the build/test workflow does not run on PRs. If we enable it on PRs, contributors (and maintainers) can be confident that everything builds properly before something is merged to `master`﻿
