### PR TITLE
Allow JS to access clipboard

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -933,7 +933,8 @@ private:
         public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,        
         public ICoreWebView2WebMessageReceivedEventHandler,
         public ICoreWebView2PermissionRequestedEventHandler {
-    using webview2_com_handler_cb_t = std::function<void(ICoreWebView2Controller *)>;
+    using webview2_com_handler_cb_t =
+        std::function<void(ICoreWebView2Controller *)>;
 
   public:
     webview2_com_handler(HWND hwnd, msg_cb_t msgCb,

--- a/webview.h
+++ b/webview.h
@@ -975,7 +975,8 @@ private:
       CoTaskMemFree(message);
       return S_OK;
     }
-    HRESULT STDMETHODCALLTYPE Invoke(ICoreWebView2* sender, ICoreWebView2PermissionRequestedEventArgs* args) {
+    HRESULT STDMETHODCALLTYPE Invoke(
+        ICoreWebView2* sender, ICoreWebView2PermissionRequestedEventArgs* args) {
       COREWEBVIEW2_PERMISSION_KIND kind;
       args->get_PermissionKind(&kind);
       if (kind == COREWEBVIEW2_PERMISSION_KIND_CLIPBOARD_READ) {

--- a/webview.h
+++ b/webview.h
@@ -469,9 +469,10 @@ public:
     gtk_container_add(GTK_CONTAINER(m_window), GTK_WIDGET(m_webview));
     gtk_widget_grab_focus(GTK_WIDGET(m_webview));
 
+    WebKitSettings *settings =
+        webkit_web_view_get_settings(WEBKIT_WEB_VIEW(m_webview));
+    webkit_settings_set_javascript_can_access_clipboard(settings, true);
     if (debug) {
-      WebKitSettings *settings =
-          webkit_web_view_get_settings(WEBKIT_WEB_VIEW(m_webview));
       webkit_settings_set_enable_write_console_messages_to_stdout(settings,
                                                                   true);
       webkit_settings_set_enable_developer_extras(settings, true);
@@ -626,6 +627,14 @@ public:
                    objc_msgSend("NSNumber"_cls, "numberWithBool:"_sel, 1),
                    "developerExtrasEnabled"_str);
     }
+    objc_msgSend(objc_msgSend(config, "preferences"_sel),
+                 "setValue:forKey:"_sel,
+                 objc_msgSend("NSNumber"_cls, "numberWithBool:"_sel, 1),
+                 "javaScriptCanAccessClipboard"_str);
+    objc_msgSend(objc_msgSend(config, "preferences"_sel),
+                 "setValue:forKey:"_sel,
+                 objc_msgSend("NSNumber"_cls, "numberWithBool:"_sel, 1),
+                 "DOMPasteAllowed"_str);
     objc_msgSend(m_webview, "initWithFrame:configuration:"_sel,
                  CGRectMake(0, 0, 0, 0), config);
     objc_msgSend(m_manager, "addScriptMessageHandler:name:"_sel, delegate,

--- a/webview.h
+++ b/webview.h
@@ -975,8 +975,9 @@ private:
       CoTaskMemFree(message);
       return S_OK;
     }
-    HRESULT STDMETHODCALLTYPE Invoke(
-        ICoreWebView2* sender, ICoreWebView2PermissionRequestedEventArgs* args) {
+    HRESULT STDMETHODCALLTYPE
+    Invoke(ICoreWebView2* sender,
+           ICoreWebView2PermissionRequestedEventArgs* args) {
       COREWEBVIEW2_PERMISSION_KIND kind;
       args->get_PermissionKind(&kind);
       if (kind == COREWEBVIEW2_PERMISSION_KIND_CLIPBOARD_READ) {

--- a/webview.h
+++ b/webview.h
@@ -930,7 +930,7 @@ private:
 
   class webview2_com_handler
       : public ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler,
-        public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,        
+        public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,
         public ICoreWebView2WebMessageReceivedEventHandler,
         public ICoreWebView2PermissionRequestedEventHandler {
     using webview2_com_handler_cb_t =
@@ -976,8 +976,8 @@ private:
       return S_OK;
     }
     HRESULT STDMETHODCALLTYPE
-    Invoke(ICoreWebView2* sender,
-           ICoreWebView2PermissionRequestedEventArgs* args) {
+    Invoke(ICoreWebView2 *sender,
+           ICoreWebView2PermissionRequestedEventArgs *args) {
       COREWEBVIEW2_PERMISSION_KIND kind;
       args->get_PermissionKind(&kind);
       if (kind == COREWEBVIEW2_PERMISSION_KIND_CLIPBOARD_READ) {

--- a/webview.h
+++ b/webview.h
@@ -927,7 +927,8 @@ private:
   class webview2_com_handler
       : public ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler,
         public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,        
-        public ICoreWebView2WebMessageReceivedEventHandler {
+        public ICoreWebView2WebMessageReceivedEventHandler,
+        public ICoreWebView2PermissionRequestedEventHandler {
     using webview2_com_handler_cb_t = std::function<void(ICoreWebView2Controller *)>;
 
   public:
@@ -949,6 +950,7 @@ private:
       EventRegistrationToken token;
       controller->get_CoreWebView2(&webview);
       webview->add_WebMessageReceived(this, &token);
+      webview->add_PermissionRequested(this, &token);
 
       m_cb(controller);
       return S_OK;
@@ -962,6 +964,14 @@ private:
       sender->PostWebMessageAsString(message);
       
       CoTaskMemFree(message);
+      return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE Invoke(ICoreWebView2* sender, ICoreWebView2PermissionRequestedEventArgs* args) {
+      COREWEBVIEW2_PERMISSION_KIND kind;
+      args->get_PermissionKind(&kind);
+      if (kind == COREWEBVIEW2_PERMISSION_KIND_CLIPBOARD_READ) {
+        args->put_State(COREWEBVIEW2_PERMISSION_STATE_ALLOW);
+      }
       return S_OK;
     }
 


### PR DESCRIPTION
This PR enables JavaScript clipboard access for Linux, MacOS & Edge Chromium on Windows.

For Linux & macOS it enables both `document.execCommand("paste)` & `navigator.clipboard`, however for Edge Chromium only the latter.

I have not been able to find any info about enabling clipboard access for EdgeHTML so I assume it only works with a custom implementation. Since the Webview Runtime is dropping Q3 and will make the EdgeHTML integration obsolete it doesn't seem worth the effort though.