### PR TITLE
Run clang-format as part of CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,15 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build and run tests
         run: ./script/build.bat
+
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run clang-format
+        uses: DoozyX/clang-format-lint-action@v0.6
+        with:
+          source: '.'
+          extensions: 'h,cc'
+          clangFormatVersion: 9
+          style: file

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: DoozyX/clang-format-lint-action@v0.6
         with:
           source: '.'
+          exclude: './script'
           extensions: 'h,cc'
           clangFormatVersion: 9
           style: file

--- a/webview.h
+++ b/webview.h
@@ -585,7 +585,8 @@ public:
                  NSApplicationActivationPolicyRegular);
 
     // Delegate
-    auto cls = objc_allocateClassPair((Class) "NSResponder"_cls, "AppDelegate", 0);
+    auto cls =
+        objc_allocateClassPair((Class) "NSResponder"_cls, "AppDelegate", 0);
     class_addProtocol(cls, objc_getProtocol("NSTouchBarProvider"));
     class_addMethod(cls, "applicationShouldTerminateAfterLastWindowClosed:"_sel,
                     (IMP)(+[](id, SEL, id) -> BOOL { return 1; }), "c@:@");
@@ -731,10 +732,10 @@ using browser_engine = cocoa_wkwebview_engine;
 //
 
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <stdlib.h>
 #include <Shlwapi.h>
 #include <codecvt>
+#include <stdlib.h>
+#include <windows.h>
 
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "Shlwapi.lib")
@@ -850,20 +851,22 @@ public:
 
     char currentExePath[MAX_PATH];
     GetModuleFileNameA(NULL, currentExePath, MAX_PATH);
-    char* currentExeName = PathFindFileNameA(currentExePath);
+    char *currentExeName = PathFindFileNameA(currentExePath);
 
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wideCharConverter;
-    std::wstring userDataFolder = wideCharConverter.from_bytes(std::getenv("APPDATA"));
+    std::wstring userDataFolder =
+        wideCharConverter.from_bytes(std::getenv("APPDATA"));
     std::wstring currentExeNameW = wideCharConverter.from_bytes(currentExeName);
 
     HRESULT res = CreateCoreWebView2EnvironmentWithOptions(
         nullptr, (userDataFolder + L"/" + currentExeNameW).c_str(), nullptr,
-        new webview2_com_handler(wnd, cb, [&](ICoreWebView2Controller *controller) {
-          m_controller = controller;
-          m_controller->get_CoreWebView2(&m_webview);
-          m_webview->AddRef();
-          flag.clear();
-        }));
+        new webview2_com_handler(wnd, cb,
+                                 [&](ICoreWebView2Controller *controller) {
+                                   m_controller = controller;
+                                   m_controller->get_CoreWebView2(&m_webview);
+                                   m_webview->AddRef();
+                                   flag.clear();
+                                 }));
     if (res != S_OK) {
       CoUninitialize();
       return false;
@@ -917,23 +920,27 @@ private:
 
   class webview2_com_handler
       : public ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler,
-        public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,        
+        public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,
         public ICoreWebView2WebMessageReceivedEventHandler {
-    using webview2_com_handler_cb_t = std::function<void(ICoreWebView2Controller *)>;
+    using webview2_com_handler_cb_t =
+        std::function<void(ICoreWebView2Controller *)>;
 
   public:
-    webview2_com_handler(HWND hwnd, msg_cb_t msgCb, webview2_com_handler_cb_t cb)
+    webview2_com_handler(HWND hwnd, msg_cb_t msgCb,
+                         webview2_com_handler_cb_t cb)
         : m_window(hwnd), m_msgCb(msgCb), m_cb(cb) {}
     ULONG STDMETHODCALLTYPE AddRef() { return 1; }
     ULONG STDMETHODCALLTYPE Release() { return 1; }
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID *ppv) {
       return S_OK;
     }
-    HRESULT STDMETHODCALLTYPE Invoke(HRESULT res, ICoreWebView2Environment *env) {
+    HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
+                                     ICoreWebView2Environment *env) {
       env->CreateCoreWebView2Controller(m_window, this);
       return S_OK;
     }
-    HRESULT STDMETHODCALLTYPE Invoke(HRESULT res, ICoreWebView2Controller *controller) {
+    HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
+                                     ICoreWebView2Controller *controller) {
       controller->AddRef();
 
       ICoreWebView2 *webview;
@@ -944,14 +951,15 @@ private:
       m_cb(controller);
       return S_OK;
     }
-    HRESULT STDMETHODCALLTYPE Invoke(ICoreWebView2* sender, ICoreWebView2WebMessageReceivedEventArgs* args) {
+    HRESULT STDMETHODCALLTYPE Invoke(
+        ICoreWebView2 *sender, ICoreWebView2WebMessageReceivedEventArgs *args) {
       LPWSTR message;
       args->TryGetWebMessageAsString(&message);
 
       std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> wideCharConverter;
       m_msgCb(wideCharConverter.to_bytes(message));
       sender->PostWebMessageAsString(message);
-      
+
       CoTaskMemFree(message);
       return S_OK;
     }
@@ -968,11 +976,9 @@ public:
   win32_edge_engine(bool debug, void *window) {
     if (window == nullptr) {
       HINSTANCE hInstance = GetModuleHandle(nullptr);
-      HICON icon = (HICON) LoadImage(
-        hInstance, IDI_APPLICATION, IMAGE_ICON,
-        GetSystemMetrics(SM_CXSMICON), 
-        GetSystemMetrics(SM_CYSMICON), 
-        LR_DEFAULTCOLOR);
+      HICON icon = (HICON)LoadImage(
+          hInstance, IDI_APPLICATION, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),
+          GetSystemMetrics(SM_CYSMICON), LR_DEFAULTCOLOR);
 
       WNDCLASSEX wc;
       ZeroMemory(&wc, sizeof(WNDCLASSEX));
@@ -1100,8 +1106,8 @@ private:
   virtual void on_message(const std::string msg) = 0;
 
   HWND m_window;
-  POINT m_minsz = POINT { 0, 0 };
-  POINT m_maxsz = POINT { 0, 0 };
+  POINT m_minsz = POINT{0, 0};
+  POINT m_maxsz = POINT{0, 0};
   DWORD m_main_thread = GetCurrentThreadId();
   std::unique_ptr<webview::browser> m_browser =
       std::make_unique<webview::edge_chromium>();
@@ -1140,12 +1146,13 @@ public:
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
   void bind(const std::string name, sync_binding_t fn) {
-    bind(name,
-         [](std::string seq, std::string req, void *arg) {
-           auto pair = static_cast<sync_binding_ctx_t *>(arg);
-           pair->first->resolve(seq, 0, pair->second(req));
-         },
-         new sync_binding_ctx_t(this, fn));
+    bind(
+        name,
+        [](std::string seq, std::string req, void *arg) {
+          auto pair = static_cast<sync_binding_ctx_t *>(arg);
+          pair->first->resolve(seq, 0, pair->second(req));
+        },
+        new sync_binding_ctx_t(this, fn));
   }
 
   void bind(const std::string name, binding_t f, void *arg) {


### PR DESCRIPTION
To enforce the code style, `clang-format` should be run on PRs