### PR TITLE
Add webview_destroy to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ int main() {
   webview::webview w(true, nullptr);
   w.set_title("Minimal example");
   w.set_size(480, 320, WEBVIEW_HINT_NONE);
-	w.navigate("https://en.m.wikipedia.org/wiki/Main_Page");
-	w.run();
+  w.navigate("https://en.m.wikipedia.org/wiki/Main_Page");
+  w.run();
+  w.destroy();
   return 0;
 }
 ```
@@ -147,6 +148,7 @@ int main() {
 	webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
 	webview_navigate(w, "https://en.m.wikipedia.org/wiki/Main_Page");
 	webview_run(w);
+	webview_destroy(w);
 	return 0;
 }
 ```


### PR DESCRIPTION
Previously webview_destroy was not called in either the C++ example or the C example. Now it is called in both, following the documentation in webview.h