### PR TITLE
Add `inline` to functions without them

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1227,53 +1227,53 @@ private:
 };
 } // namespace webview
 
-WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
+WEBVIEW_API inline webview_t webview_create(int debug, void *wnd) {
   return new webview::webview(debug, wnd);
 }
 
-WEBVIEW_API void webview_destroy(webview_t w) {
+WEBVIEW_API inline void webview_destroy(webview_t w) {
   delete static_cast<webview::webview *>(w);
 }
 
-WEBVIEW_API void webview_run(webview_t w) {
+WEBVIEW_API inline void webview_run(webview_t w) {
   static_cast<webview::webview *>(w)->run();
 }
 
-WEBVIEW_API void webview_terminate(webview_t w) {
+WEBVIEW_API inline void webview_terminate(webview_t w) {
   static_cast<webview::webview *>(w)->terminate();
 }
 
-WEBVIEW_API void webview_dispatch(webview_t w, void (*fn)(webview_t, void *),
+WEBVIEW_API inline void webview_dispatch(webview_t w, void (*fn)(webview_t, void *),
                                   void *arg) {
   static_cast<webview::webview *>(w)->dispatch([=]() { fn(w, arg); });
 }
 
-WEBVIEW_API void *webview_get_window(webview_t w) {
+WEBVIEW_API inline void *webview_get_window(webview_t w) {
   return static_cast<webview::webview *>(w)->window();
 }
 
-WEBVIEW_API void webview_set_title(webview_t w, const char *title) {
+WEBVIEW_API inline void webview_set_title(webview_t w, const char *title) {
   static_cast<webview::webview *>(w)->set_title(title);
 }
 
-WEBVIEW_API void webview_set_size(webview_t w, int width, int height,
+WEBVIEW_API inline void webview_set_size(webview_t w, int width, int height,
                                   int hints) {
   static_cast<webview::webview *>(w)->set_size(width, height, hints);
 }
 
-WEBVIEW_API void webview_navigate(webview_t w, const char *url) {
+WEBVIEW_API inline void webview_navigate(webview_t w, const char *url) {
   static_cast<webview::webview *>(w)->navigate(url);
 }
 
-WEBVIEW_API void webview_init(webview_t w, const char *js) {
+WEBVIEW_API inline void webview_init(webview_t w, const char *js) {
   static_cast<webview::webview *>(w)->init(js);
 }
 
-WEBVIEW_API void webview_eval(webview_t w, const char *js) {
+WEBVIEW_API inline void webview_eval(webview_t w, const char *js) {
   static_cast<webview::webview *>(w)->eval(js);
 }
 
-WEBVIEW_API void webview_bind(webview_t w, const char *name,
+WEBVIEW_API inline void webview_bind(webview_t w, const char *name,
                               void (*fn)(const char *seq, const char *req,
                                          void *arg),
                               void *arg) {
@@ -1285,7 +1285,7 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
       arg);
 }
 
-WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
+WEBVIEW_API inline void webview_return(webview_t w, const char *seq, int status,
                                 const char *result) {
   static_cast<webview::webview *>(w)->resolve(seq, status, result);
 }


### PR DESCRIPTION
Header-only libraries normally have all functions declared inline to allow for multiple includes