### PR TITLE
Fixing terminate called - stoul()

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -132,7 +132,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 #include <string>
 #include <utility>
 #include <vector>
-
+#include <sstream>
 #include <cstring>
 
 namespace webview {
@@ -153,14 +153,20 @@ inline std::string url_encode(const std::string s) {
   return encoded;
 }
 
-inline std::string url_decode(const std::string s) {
+inline std::string url_decode(const std::string s){
   std::string decoded;
-  for (unsigned int i = 0; i < s.length(); i++) {
-    if (s[i] == '%') {
-      int n;
-      n = std::stoul(s.substr(i + 1, 2), nullptr, 16);
-      decoded = decoded + static_cast<char>(n);
-      i = i + 2;
+  for (unsigned int i = 0; i < s.length(); i++){
+    if (s[i] == '%'){
+      std::istringstream iss(s);
+		  long number;
+      if (!(iss >> number).fail()){
+          unsigned long n;
+          n = std::stoul(s.substr(i + 1, 2), nullptr, 16);
+          decoded = decoded + static_cast<char>(n);
+          i = i + 2;
+      } else {
+        decoded = decoded + s[i];
+      }
     } else if (s[i] == '+') {
       decoded = decoded + ' ';
     } else {


### PR DESCRIPTION
OS: Debian
GCC: 6.3.0

**1:** Clone..
**2:** Add `%` to the HTML code in main.cc
**3:** Build `c++ main.cc ``pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0`` -o webview-example`
**4:** Run ./webview-example
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoul
Aborted
```