### PR TITLE
Add window_set_fullscreen Window API

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1266,12 +1266,13 @@ public:
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
   void bind(const std::string name, sync_binding_t fn) {
-    bind(name,
-         [](std::string seq, std::string req, void *arg) {
-           auto pair = static_cast<sync_binding_ctx_t *>(arg);
-           pair->first->resolve(seq, 0, pair->second(req));
-         },
-         new sync_binding_ctx_t(this, fn));
+    bind(
+        name,
+        [](std::string seq, std::string req, void *arg) {
+          auto pair = static_cast<sync_binding_ctx_t *>(arg);
+          pair->first->resolve(seq, 0, pair->second(req));
+        },
+        new sync_binding_ctx_t(this, fn));
   }
 
   void bind(const std::string name, binding_t f, void *arg) {

--- a/webview.h
+++ b/webview.h
@@ -33,6 +33,7 @@ extern "C" {
 #endif
 
 typedef void *webview_t;
+typedef void *window_t;
 
 // Creates a new webview instance. If debug is non-zero - developer tools will
 // be enabled (if the platform supports them). Window parameter can be a
@@ -483,7 +484,7 @@ public:
 
     gtk_widget_show_all(m_window);
   }
-  void *window() { return (void *)m_window; }
+  window_t window() { return &m_window; }
   void run() { gtk_main(); }
   void terminate() { gtk_main_quit(); }
   void dispatch(std::function<void()> f) {
@@ -543,6 +544,27 @@ private:
 using browser_engine = gtk_webkit_engine;
 
 } // namespace webview
+
+namespace window {
+class linux_window {
+public:
+  linux_window(void *wnd) {
+    m_window = static_cast<GtkWidget*>(wnd);
+  }
+
+  void set_fullscreen(bool fullscreen) {
+    if (fullscreen) {
+      gtk_window_fullscreen(GTK_WINDOW(m_window));
+    } else {
+      gtk_window_unfullscreen(GTK_WINDOW(m_window));
+    }
+  }
+private:
+  GtkWidget *m_window;
+};
+
+using native_window = linux_window;
+} // namespace window
 
 #elif defined(WEBVIEW_COCOA)
 
@@ -1149,7 +1171,6 @@ public:
   }
 
   void set_fullscreen(bool fullscreen) {
-    // TODO set fullscreen
     saved_style = GetWindowLong(m_window, GWL_STYLE);
     saved_ex_style = GetWindowLong(m_window, GWL_EXSTYLE);
     GetWindowRect(m_window, &saved_rect);

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -37,6 +37,8 @@ static void test_c_api() {
   webview_navigate(w, "https://github.com/zserge/webview");
   webview_dispatch(w, cb_assert_arg, (void *)"arg");
   webview_dispatch(w, cb_terminate, nullptr);
+  auto wnd = webview_get_window(w);
+  window_set_fullscreen(wnd, true);
   webview_run(w);
   webview_destroy(w);
 }

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -37,8 +37,8 @@ static void test_c_api() {
   webview_navigate(w, "https://github.com/zserge/webview");
   webview_dispatch(w, cb_assert_arg, (void *)"arg");
   webview_dispatch(w, cb_terminate, nullptr);
-  auto wnd = webview_get_window(w);
-  window_set_fullscreen(wnd, true);
+  window_t wnd = webview_get_window(w);
+  window_set_fullscreen(wnd, 1);
   webview_run(w);
   webview_destroy(w);
 }


### PR DESCRIPTION
This is the first attempt to introduce a window api structure start with setting fullscreen.
Users can get the window handle from `webview_get_window()` and use it with any window api with prefix of `window_*`.