### PR TITLE
Fix README mention of non-existing C++ destroy() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ int main() {
   w.set_size(480, 320, WEBVIEW_HINT_NONE);
   w.navigate("https://en.m.wikipedia.org/wiki/Main_Page");
   w.run();
-  w.destroy();
   return 0;
 }
 ```


### PR DESCRIPTION
Introduced with 7d93e90a9565a016f5ef65ca810f97a99bf6b44c, README mentions a call to the `destroy()` in the C++ example.
This method does not exist:

```c++
error: ‘class webview::webview’ has no member named ‘destroy’
   36 |     w.destroy();
      |       ^~~~~~~
```