### PR TITLE
feat: add Proxy for linux

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -127,6 +127,8 @@ type WebView interface {
 	// f must be a function
 	// f must return either value and error or just error
 	Bind(name string, f interface{}) error
+
+	Proxy(proxyUri string, ignoreHosts []string)
 }
 
 type webview struct {
@@ -320,4 +322,19 @@ func (w *webview) Bind(name string, f interface{}) error {
 	defer C.free(unsafe.Pointer(cname))
 	C.CgoWebViewBind(w.w, cname, C.uintptr_t(index))
 	return nil
+}
+
+func (w *webview) Proxy(proxyUri string, ignoreHosts []string) {
+	cProxyUri := C.CString(proxyUri)
+	defer C.free(unsafe.Pointer(cProxyUri))
+
+	if len(ignoreHosts) > 0 {
+		cIgnoreHosts := make([]*C.char, len(ignoreHosts))
+		for i, v := range ignoreHosts {
+			cIgnoreHosts[i] = C.CString(v)
+		}
+		C.webview_proxy_new(w.w, cProxyUri, (**C.char)(unsafe.Pointer(&cIgnoreHosts[0])))
+	} else {
+		C.webview_proxy_new(w.w, cProxyUri, nil)
+	}
 }

--- a/webview.h
+++ b/webview.h
@@ -107,7 +107,8 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result);
 
-WEBVIEW_API void webview_proxy_new(webview_t w, const char *default_proxy_uri, const char* const * ignoreHosts);
+WEBVIEW_API void webview_proxy_new(webview_t w, const char *default_proxy_uri,
+                                   const char *const *ignoreHosts);
 
 #ifdef __cplusplus
 }
@@ -498,8 +499,12 @@ public:
     gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());
   }
 
-  void network_proxy_settings_new(const std::string default_proxy_uri, const char * const * ignoreHosts) {
-     webkit_web_context_set_network_proxy_settings(webkit_web_context_get_default(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, webkit_network_proxy_settings_new(default_proxy_uri.c_str(), ignoreHosts));
+  void network_proxy_settings_new(const std::string default_proxy_uri,
+                                  const char *const *ignoreHosts) {
+    webkit_web_context_set_network_proxy_settings(
+        webkit_web_context_get_default(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM,
+        webkit_network_proxy_settings_new(default_proxy_uri.c_str(),
+                                          ignoreHosts));
   }
 
   void set_size(int width, int height, int hints) {
@@ -699,7 +704,8 @@ public:
                    CGRectMake(0, 0, width, height), 1, 0);
     }
   }
-  void network_proxy_settings_new(const std::string default_proxy_uri, const char * const * ignoreHosts) {
+  void network_proxy_settings_new(const std::string default_proxy_uri,
+                                  const char *const *ignoreHosts) {
     printf("[macOS]TODO: network_proxy_settings_new\n");
   }
   void navigate(const std::string url) {
@@ -1129,7 +1135,8 @@ public:
     }
   }
 
-  void network_proxy_settings_new(const std::string default_proxy_uri, const char * const * ignoreHosts) {
+  void network_proxy_settings_new(const std::string default_proxy_uri,
+                                  const char *const *ignoreHosts) {
     printf("[windows]TODO: network_proxy_settings_new\n");
   }
   void navigate(const std::string url) { m_browser->navigate(url); }
@@ -1302,8 +1309,10 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
   static_cast<webview::webview *>(w)->resolve(seq, status, result);
 }
 
-WEBVIEW_API void webview_proxy_new(webview_t w, const char *default_proxy_uri, const char* const * ignoreHosts) {
-  static_cast<webview::webview *>(w)->network_proxy_settings_new(default_proxy_uri, ignoreHosts);
+WEBVIEW_API void webview_proxy_new(webview_t w, const char *default_proxy_uri,
+                                   const char *const *ignoreHosts) {
+  static_cast<webview::webview *>(w)->network_proxy_settings_new(
+      default_proxy_uri, ignoreHosts);
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview.h
+++ b/webview.h
@@ -107,6 +107,8 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result);
 
+WEBVIEW_API void webview_proxy_new(webview_t w, const char *default_proxy_uri, const char* const * ignoreHosts);
+
 #ifdef __cplusplus
 }
 #endif
@@ -496,6 +498,10 @@ public:
     gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());
   }
 
+  void network_proxy_settings_new(const std::string default_proxy_uri, const char * const * ignoreHosts) {
+     webkit_web_context_set_network_proxy_settings(webkit_web_context_get_default(), WEBKIT_NETWORK_PROXY_MODE_CUSTOM, webkit_network_proxy_settings_new(default_proxy_uri.c_str(), ignoreHosts));
+  }
+
   void set_size(int width, int height, int hints) {
     gtk_window_set_resizable(GTK_WINDOW(m_window), hints != WEBVIEW_HINT_FIXED);
     if (hints == WEBVIEW_HINT_NONE) {
@@ -692,6 +698,9 @@ public:
       objc_msgSend(m_window, "setFrame:display:animate:"_sel,
                    CGRectMake(0, 0, width, height), 1, 0);
     }
+  }
+  void network_proxy_settings_new(const std::string default_proxy_uri, const char * const * ignoreHosts) {
+    printf("[macOS]TODO: network_proxy_settings_new\n");
   }
   void navigate(const std::string url) {
     auto nsurl = objc_msgSend(
@@ -1120,6 +1129,9 @@ public:
     }
   }
 
+  void network_proxy_settings_new(const std::string default_proxy_uri, const char * const * ignoreHosts) {
+    printf("[windows]TODO: network_proxy_settings_new\n");
+  }
   void navigate(const std::string url) { m_browser->navigate(url); }
   void eval(const std::string js) { m_browser->eval(js); }
   void init(const std::string js) { m_browser->init(js); }
@@ -1288,6 +1300,10 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result) {
   static_cast<webview::webview *>(w)->resolve(seq, status, result);
+}
+
+WEBVIEW_API void webview_proxy_new(webview_t w, const char *default_proxy_uri, const char* const * ignoreHosts) {
+  static_cast<webview::webview *>(w)->network_proxy_settings_new(default_proxy_uri, ignoreHosts);
 }
 
 #endif /* WEBVIEW_HEADER */


### PR DESCRIPTION
https://webkitgtk.org/reference/webkit2gtk/stable/WebKitNetworkProxySettings.html

test code:
```
package main

import (
	"github.com/webview/webview"
)

func main() {
	w := webview.New(true)
	defer w.Destroy()

	w.SetTitle("ProxyTest")
	w.SetSize(800, 600, webview.HintNone)
	//w.Proxy("http://127.0.0.1:8118", nil)
	//w.Proxy("http://127.0.0.1:8118", []string{"whatismyipaddress.com"})
	//w.Proxy("socks://127.0.0.1:7777", nil)
	w.Proxy("socks://127.0.0.1:7777", []string{"whatismyipaddress.com"})
	w.Navigate("https://whatismyipaddress.com/")
	w.Run()
}
```