### PR TITLE
ci: Build both architectures on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Build and run tests
+      - name: Build and run tests (x86_64)
         run: ./script/build.sh
+        env:
+          MACOS_TARGET_ARCH: x86_64
+        
+      - name: Build (arm64)
+        run: ./script/build.sh
+        env:
+          MACOS_TARGET_ARCH: arm64
+          # We can't run the tests yet as GitHub doesn't have arm64 runners
+          SKIP_TESTS: true
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         run: xvfb-run ./script/build.sh
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v1
       - name: Build and run tests (x86_64)

--- a/script/build.sh
+++ b/script/build.sh
@@ -2,10 +2,15 @@
 
 set -e
 
+# Support targeting other architectures on macOS
+if [ -z "$MACOS_TARGET_ARCH" ]; then
+    MACOS_TARGET_ARCH="x86_64"
+fi
+
 DIR="$(cd "$(dirname "$0")/../" && pwd)"
 
 if [ "$(uname)" = "Darwin" ]; then
-	FLAGS="-DWEBVIEW_COCOA -std=c++11 -Wall -Wextra -pedantic -framework WebKit"
+	FLAGS="-DWEBVIEW_COCOA -std=c++11 -Wall -Wextra -pedantic -framework WebKit -arch $MACOS_TARGET_ARCH"
 else
 	FLAGS="-DWEBVIEW_GTK -std=c++11 -Wall -Wextra -pedantic $(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0)"
 fi
@@ -34,12 +39,16 @@ c++ main.cc $FLAGS -o webview
 echo "Building test app"
 c++ webview_test.cc $FLAGS -o webview_test
 
-echo "Running tests"
-./webview_test
-
-if command -v go >/dev/null 2>&1 ; then
-	echo "Running Go tests"
-	CGO_ENABLED=1 go test
+if [ "$SKIP_TESTS" = true ]; then
+	echo "Skipping tests"
 else
-	echo "SKIP: Go tests"
+	echo "Running tests"
+	./webview_test
+
+	if command -v go >/dev/null 2>&1 ; then
+		echo "Running Go tests"
+		CGO_ENABLED=1 go test
+	else
+		echo "SKIP: Go tests"
+	fi
 fi


### PR DESCRIPTION
- Updates the build script so we can pass the `-arch` argument to `clang`
- Builds both architectures on CI (we can't run `arm64` tests yet)