### PR TITLE
Use COINIT_APARTMENTTHREADED

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -907,7 +907,7 @@ private:
 class edge_chromium : public browser {
 public:
   bool embed(HWND wnd, bool debug, msg_cb_t cb) override {
-    CoInitializeEx(nullptr, 0);
+    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
     flag.test_and_set();
 


### PR DESCRIPTION
Fixes crash on Windows 10 when using webview2. The current version of webview2 checks that COM was initialized in Single Threaded Apartment mode, and fails on init if not (see [thread here](https://github.com/MicrosoftEdge/WebView2Feedback/issues/447)). 