### PR TITLE
added support for new requirements CoInit (single thread) initialize

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -907,7 +907,9 @@ private:
 class edge_chromium : public browser {
 public:
   bool embed(HWND wnd, bool debug, msg_cb_t cb) override {
-    CoInitializeEx(nullptr, 0);
+
+    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
     flag.test_and_set();
 
@@ -920,15 +922,26 @@ public:
         wideCharConverter.from_bytes(std::getenv("APPDATA"));
     std::wstring currentExeNameW = wideCharConverter.from_bytes(currentExeName);
 
-    HRESULT res = CreateCoreWebView2EnvironmentWithOptions(
-        nullptr, (userDataFolder + L"/" + currentExeNameW).c_str(), nullptr,
-        new webview2_com_handler(wnd, cb,
-                                 [&](ICoreWebView2Controller *controller) {
-                                   m_controller = controller;
-                                   m_controller->get_CoreWebView2(&m_webview);
-                                   m_webview->AddRef();
-                                   flag.clear();
-                                 }));
+    auto webview2ComHandler = new webview2_com_handler(wnd, cb,
+        [&](ICoreWebView2Controller* controller) {
+            m_controller = controller;
+            m_controller->get_CoreWebView2(&m_webview);
+            m_webview->AddRef();
+            flag.clear();
+        });
+
+    HRESULT res = createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
+
+    //"HRESULT - 0x80010106 - Cannot change thread mode after it is set. "
+    if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106)
+    {
+        CoUninitialize();
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+
+        res = createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
+    }
+
+
     if (res != S_OK) {
       CoUninitialize();
       return false;
@@ -992,6 +1005,12 @@ private:
     webview2_com_handler(HWND hwnd, msg_cb_t msgCb,
                          webview2_com_handler_cb_t cb)
         : m_window(hwnd), m_msgCb(msgCb), m_cb(cb) {}
+
+    HRESULT getLastEnvironmentCompleteResult() const
+    {
+        return lastEnvironmentCompleteResult;
+    }
+
     ULONG STDMETHODCALLTYPE AddRef() { return 1; }
     ULONG STDMETHODCALLTYPE Release() { return 1; }
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID *ppv) {
@@ -999,8 +1018,16 @@ private:
     }
     HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                      ICoreWebView2Environment *env) {
-      env->CreateCoreWebView2Controller(m_window, this);
-      return S_OK;
+
+        lastEnvironmentCompleteResult = res;
+
+        if (res == S_OK)
+        {
+            env->CreateCoreWebView2Controller(m_window, this);
+            return S_OK;
+        }
+      
+      return S_FALSE;
     }
     HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                      ICoreWebView2Controller *controller) {
@@ -1042,7 +1069,13 @@ private:
     HWND m_window;
     msg_cb_t m_msgCb;
     webview2_com_handler_cb_t m_cb;
+    HRESULT lastEnvironmentCompleteResult;
   };
+
+  HRESULT createEnviroment(const std::wstring& userDataFolder, const std::wstring& currentExeNameW, webview2_com_handler* webview2ComHandler)
+  {
+      return CreateCoreWebView2EnvironmentWithOptions(nullptr, (userDataFolder + L"/" + currentExeNameW).c_str(), nullptr,  webview2ComHandler);
+  }
 };
 
 class win32_edge_engine {

--- a/webview.h
+++ b/webview.h
@@ -922,8 +922,8 @@ public:
         wideCharConverter.from_bytes(std::getenv("APPDATA"));
     std::wstring currentExeNameW = wideCharConverter.from_bytes(currentExeName);
 
-    auto webview2ComHandler = new webview2_com_handler(wnd, cb,
-        [&](ICoreWebView2Controller* controller) {
+    auto webview2ComHandler = new webview2_com_handler(
+        wnd, cb, [&](ICoreWebView2Controller* controller) {
             m_controller = controller;
             m_controller->get_CoreWebView2(&m_webview);
             m_webview->AddRef();
@@ -933,12 +933,10 @@ public:
     HRESULT res = createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
 
     //"HRESULT - 0x80010106 - Cannot change thread mode after it is set. "
-    if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106)
-    {
+    if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106) {
         CoUninitialize();
         CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-
-        res = createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
+        res = createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);     
     }
 
 
@@ -1006,9 +1004,8 @@ private:
                          webview2_com_handler_cb_t cb)
         : m_window(hwnd), m_msgCb(msgCb), m_cb(cb) {}
 
-    HRESULT getLastEnvironmentCompleteResult() const
-    {
-        return lastEnvironmentCompleteResult;
+    HRESULT getLastEnvironmentCompleteResult() const {
+       return lastEnvironmentCompleteResult;
     }
 
     ULONG STDMETHODCALLTYPE AddRef() { return 1; }
@@ -1072,8 +1069,7 @@ private:
     HRESULT lastEnvironmentCompleteResult;
   };
 
-  HRESULT createEnviroment(const std::wstring& userDataFolder, const std::wstring& currentExeNameW, webview2_com_handler* webview2ComHandler)
-  {
+  HRESULT createEnviroment(const std::wstring& userDataFolder, const std::wstring& currentExeNameW, webview2_com_handler* webview2ComHandler) {
       return CreateCoreWebView2EnvironmentWithOptions(nullptr, (userDataFolder + L"/" + currentExeNameW).c_str(), nullptr,  webview2ComHandler);
   }
 };


### PR DESCRIPTION
Fixes crash on Windows 10 when using webview2 edge runtime. There is at least [one pull request ](https://github.com/webview/webview/pull/539#issue-576169836) with attempt to fix this critical issue. I suggest support both ways in same time at this moment with this pull request and see later as edge become more stable.