### PR TITLE
Added support for new requirements CoInit (single thread) initialize

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -937,7 +937,7 @@ public:
                                    webview2ComHandler);
 
     // "HRESULT - 0x80010106 - Cannot change thread mode after it is set."
-    if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106) {xs
+    if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106) {
         CoUninitialize();
         if(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED) != S_OK) {
           delete webview2ComHandler;

--- a/webview.h
+++ b/webview.h
@@ -933,7 +933,7 @@ public:
         });
 
     HRESULT res =
-        createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
+        createEnvironment(userDataFolder, currentExeNameW, webview2ComHandler);
 
     // "HRESULT - 0x80010106 - Cannot change thread mode after it is set."
     if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106) {
@@ -943,7 +943,7 @@ public:
         return false;
       }
       res =
-          createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
+          createEnvironment(userDataFolder, currentExeNameW, webview2ComHandler);
     }
 
     if (res != S_OK) {
@@ -1076,7 +1076,7 @@ private:
     HRESULT lastEnvironmentCompleteResult;
   };
 
-  HRESULT createEnviroment(const std::wstring &userDataFolder,
+  HRESULT createEnvironment(const std::wstring &userDataFolder,
                            const std::wstring &currentExeNameW,
                            webview2_com_handler *webview2ComHandler) const {
     return CreateCoreWebView2EnvironmentWithOptions(

--- a/webview.h
+++ b/webview.h
@@ -935,8 +935,8 @@ public:
     HRESULT res =
         createEnvironment(userDataFolder, currentExeNameW, webview2ComHandler);
 
-    // "HRESULT - 0x80010106 - Cannot change thread mode after it is set."
-    if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106) {
+    // "HRESULT - RPC_E_CHANGED_MODE - Cannot change thread mode after it is set."
+    if (webview2ComHandler->getLastEnvironmentCompleteResult() == RPC_E_CHANGED_MODE) {
       CoUninitialize();
       if (CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED) != S_OK) {
         delete webview2ComHandler;

--- a/webview.h
+++ b/webview.h
@@ -942,8 +942,8 @@ public:
         delete webview2ComHandler;
         return false;
       }
-      res =
-          createEnvironment(userDataFolder, currentExeNameW, webview2ComHandler);
+      res = createEnvironment(userDataFolder, currentExeNameW,
+                              webview2ComHandler);
     }
 
     if (res != S_OK) {

--- a/webview.h
+++ b/webview.h
@@ -907,7 +907,7 @@ private:
 class edge_chromium : public browser {
 public:
   bool embed(HWND wnd, bool debug, msg_cb_t cb) override {
-    if(CoInitializeEx(nullptr, COINIT_MULTITHREADED) != S_OK) {
+    if (CoInitializeEx(nullptr, COINIT_MULTITHREADED) != S_OK) {
       return false;
     }
 
@@ -925,27 +925,25 @@ public:
 
     // TODO: Maybe we need to implement memory cleanup?
     auto webview2ComHandler = new webview2_com_handler(
-        wnd, cb, [&](ICoreWebView2Controller* controller) {
-            m_controller = controller;
-            m_controller->get_CoreWebView2(&m_webview);
-            m_webview->AddRef();
-            flag.clear();
+        wnd, cb, [&](ICoreWebView2Controller *controller) {
+          m_controller = controller;
+          m_controller->get_CoreWebView2(&m_webview);
+          m_webview->AddRef();
+          flag.clear();
         });
 
-    HRESULT res = createEnviroment(userDataFolder, 
-                                   currentExeNameW, 
-                                   webview2ComHandler);
+    HRESULT res =
+        createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
 
     // "HRESULT - 0x80010106 - Cannot change thread mode after it is set."
     if (webview2ComHandler->getLastEnvironmentCompleteResult() == 0x80010106) {
-        CoUninitialize();
-        if(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED) != S_OK) {
-          delete webview2ComHandler;
-          return false;
-        }
-        res = createEnviroment(userDataFolder, 
-                               currentExeNameW, 
-                               webview2ComHandler);     
+      CoUninitialize();
+      if (CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED) != S_OK) {
+        delete webview2ComHandler;
+        return false;
+      }
+      res =
+          createEnviroment(userDataFolder, currentExeNameW, webview2ComHandler);
     }
 
     if (res != S_OK) {
@@ -1015,7 +1013,7 @@ private:
         : m_window(hwnd), m_msgCb(msgCb), m_cb(cb) {}
 
     HRESULT getLastEnvironmentCompleteResult() const {
-       return lastEnvironmentCompleteResult;
+      return lastEnvironmentCompleteResult;
     }
 
     ULONG STDMETHODCALLTYPE AddRef() { return 1; }
@@ -1026,14 +1024,13 @@ private:
     HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                      ICoreWebView2Environment *env) {
 
-        lastEnvironmentCompleteResult = res;
+      lastEnvironmentCompleteResult = res;
 
-        if (res == S_OK)
-        {
-            env->CreateCoreWebView2Controller(m_window, this);
-            return S_OK;
-        }
-      
+      if (res == S_OK) {
+        env->CreateCoreWebView2Controller(m_window, this);
+        return S_OK;
+      }
+
       return S_FALSE;
     }
     HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,

--- a/webview.h
+++ b/webview.h
@@ -1077,8 +1077,8 @@ private:
   };
 
   HRESULT createEnvironment(const std::wstring &userDataFolder,
-                           const std::wstring &currentExeNameW,
-                           webview2_com_handler *webview2ComHandler) const {
+                            const std::wstring &currentExeNameW,
+                            webview2_com_handler *webview2ComHandler) const {
     return CreateCoreWebView2EnvironmentWithOptions(
         nullptr, (userDataFolder + L"/" + currentExeNameW).c_str(), nullptr,
         webview2ComHandler);

--- a/webview.h
+++ b/webview.h
@@ -936,7 +936,8 @@ public:
         createEnvironment(userDataFolder, currentExeNameW, webview2ComHandler);
 
     // "HRESULT - RPC_E_CHANGED_MODE - Cannot change thread mode after it is set."
-    if (webview2ComHandler->getLastEnvironmentCompleteResult() == RPC_E_CHANGED_MODE) {
+    if (webview2ComHandler->getLastEnvironmentCompleteResult() ==
+        RPC_E_CHANGED_MODE) {
       CoUninitialize();
       if (CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED) != S_OK) {
         delete webview2ComHandler;


### PR DESCRIPTION
Fixes crash on Windows 10 when using webview2 edge runtime. There is at least [one pull request](https://github.com/webview/webview/pull/539#issue-576169836) with attempt to fix this critical issue. I suggest support both ways in same time at this moment with this pull request and see later as edge become more stable.