### PR TITLE
feat: set frame shadow by default

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -706,6 +706,7 @@ public:
                                           m_webview);
     ((void (*)(id, SEL, id))objc_msgSend)(m_window, "makeKeyAndOrderFront:"_sel,
                                           nullptr);
+    ((void (*)(id, SEL, int))objc_msgSend)(m_window, "setHasShadow:"_sel, 1);
   }
   ~cocoa_wkwebview_engine() { close(); }
   void *window() { return (void *)m_window; }


### PR DESCRIPTION
Set the frame shadow that looks more like a 'native' app.

FYI: I did not know about C, but https://github.com/webview/webview/issues/354#issuecomment-688874059 helps me to add frame shadow.