### PR TITLE
Create add_event_listener function [gtk]

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -552,6 +552,11 @@ public:
                                    NULL, NULL);
   }
 
+  template <class T, typename... Types>
+  T add_event_listener(const char* event, void (*f)(Types...)) {
+    g_signal_connect(WEBKIT_WEB_VIEW(m_webview), event, G_CALLBACK(f), this);
+  }
+
 private:
   virtual void on_message(const std::string msg) = 0;
   GtkWidget *m_window;


### PR DESCRIPTION
This is a simple hook into the g_signal_connect function for gtk. The programmer can pass in an event name and a callback to handle a signal emitted from the gtk window, or the webview. Before this commit, the only way to handle an event would be to hack each handler into the `gtk_webkit_engine` class itself.

Here is a simple example of two callbacks:
```cpp
void load_changed_callback(WebKitWebView *web_view, WebKitLoadEvent load_event, gpointer user_data) {
  switch (load_event) {
  case WEBKIT_LOAD_STARTED:
      std::cout << "Load Started URI: " << webkit_web_view_get_uri(web_view) << '\n';
      break;
  case WEBKIT_LOAD_FINISHED:
      std::cout << "Get Finished URI: " << webkit_web_view_get_uri(web_view) << '\n';
      break;
  }
}

void destroy_window_callback(GtkWidget* widget, GtkWidget* window) {
  cout << "window destroyed\n";
}
```
We can add these event handlers like so:
```cpp
w.add_event_listener<void>("load-changed", load_changed_callback);
w.add_event_listener<void>("destroy", destroy_window_callback);
```
Different function signatures? No problem! `add_event_listener` is generic.

All event handlers have to be platform-dependent - I don't see any way around that. The `load_changed_callback` I wrote as an example will not work for whatever the equivalent event is on MacOS or Windows. The only way to make these event handlers cross-platform is to define a few for the user to choose from, write them for each platform, and call it a day. Since this library does not expose *any* events for the user to handle at all, I thought this was a good starting point.

If I get positive feedback on this, I will read up on how I can port it to Windows. I'm happy to answer any questions.