### PR TITLE
Resolved rpc promises should not stay in the window._rpc array.

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1277,11 +1277,11 @@ public:
   void resolve(const std::string seq, int status, const std::string result) {
     dispatch([=]() {
       if (status == 0) {
-        eval("window._rpc[" + seq + "].resolve(" + result + "); window._rpc[" +
-             seq + "] = undefined");
+        eval("window._rpc[" + seq + "].resolve(" + result + "); delete window._rpc[" +
+             seq + "]");
       } else {
-        eval("window._rpc[" + seq + "].reject(" + result + "); window._rpc[" +
-             seq + "] = undefined");
+        eval("window._rpc[" + seq + "].reject(" + result + "); delete window._rpc[" +
+             seq + "]");
       }
     });
   }

--- a/webview.h
+++ b/webview.h
@@ -1277,11 +1277,11 @@ public:
   void resolve(const std::string seq, int status, const std::string result) {
     dispatch([=]() {
       if (status == 0) {
-        eval("window._rpc[" + seq + "].resolve(" + result + "); delete window._rpc[" +
-             seq + "]");
+        eval("window._rpc[" + seq + "].resolve(" + result +
+             "); delete window._rpc[" + seq + "]");
       } else {
-        eval("window._rpc[" + seq + "].reject(" + result + "); delete window._rpc[" +
-             seq + "]");
+        eval("window._rpc[" + seq + "].reject(" + result +
+             "); delete window._rpc[" + seq + "]");
       }
     });
   }


### PR DESCRIPTION
Resolved RPC promises were undefined. Now, they are completely deleted.

Before:
`window._rpc == { 1: undefined, 2: undefined, 3: <pending>, nextSeq: 4 }`

After:
`window._rpc == { 3: <pending>, nextSeq: 4 }`