### PR TITLE
Use C compiler for C example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,13 @@ $ c++ main.cc -mwindows -L./dll/x64 -lwebview -lWebView2Loader -o webview-exampl
 ```
 
 ### C:
+
 ```c
-// main .c
+// main.c
+#define WEBVIEW_HEADER
 #include "webview.h"
+#include <stddef.h>
+
 #ifdef WIN32
 int WINAPI WinMain(HINSTANCE hInt, HINSTANCE hPrevInst, LPSTR lpCmdLine,
                    int nCmdShow) {
@@ -151,16 +155,26 @@ int main() {
 	return 0;
 }
 ```
+
+Define C++ flags for the platform:
+
+```sh
+# Linux
+$ CPPFLAGS="`pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -lstdc++"
+# MacOS
+$ CPPFLAGS="-std=c++11 -framework WebKit"
+# Windows (x64)
+$ CPPFLAGS="-mwindows -L./dll/x64 -lwebview -lWebView2Loader"
+```
+
 Build it:
 
-```bash
-# Linux
-$ g++ main.c `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -o webview-example
-# MacOS
-$ g++ main.c -std=c++11 -framework WebKit -o webview-example
-# Windows (x64)
-$ g++ main.c -mwindows -L./dll/x64 -lwebview -lWebView2Loader -o webview-example.exe
+```sh
+$ g++ -c $CPPFLAGS webview.cc -o webview.o  # build webview
+$ gcc -c main.c -o main.o  # build C program
+$ g++ main.o webview.o $CPPFLAGS -o webview-example  # link them together
 ```
+
 
 On Windows it is possible to use webview library directly when compiling with cl.exe, but WebView2Loader.dll is still required. To use MinGW you may dynamically link prebuilt webview.dll (this approach is used in Cgo bindings).
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ $ gcc -c main.c -o main.o  # build C program
 $ g++ main.o webview.o $CPPFLAGS -o webview-example  # link them together
 ```
 
+For a complete C example see: https://github.com/petabyt/webviewc
+
 
 On Windows it is possible to use webview library directly when compiling with cl.exe, but WebView2Loader.dll is still required. To use MinGW you may dynamically link prebuilt webview.dll (this approach is used in Cgo bindings).
 


### PR DESCRIPTION
This documents [@petabyt's approach](https://github.com/petabyt/webviewc) for compiling webview with a C++ compiler and the C program with a C compiler, then linking them together. This requires setting WEBVIEW_HEADER in C to tell gcc to only use the header and ignore the rest of webview.h, which is in C++, so gcc can't compile it.

The explanation is much longer than before, because there are now more steps. To simplify it, we first set an environment variable for platform-specific C++ flags and keep the build process the same for Linux, macOS, and Linux.

This approach is better than using a C++ compiler to compile C++, since C and C++ have some discrepancies. It also has the added bonus of faster incremental and initial compilation.

The results are identical as before, with a webview-example built in the working directory.

Resolves #618 and obsoletes #626 (thank you @petabyt for coming up with this solution!)