### PR TITLE
Create unbind function

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1278,7 +1278,7 @@ public:
   }
 
   void unbind(const std::string name) {
-    if(bindings.find(name) != bindings.end()) {
+    if (bindings.find(name) != bindings.end()) {
       auto js = "delete window['" + name + "'];";
       init(js);
       eval(js);

--- a/webview.h
+++ b/webview.h
@@ -100,6 +100,9 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
                                          void *arg),
                               void *arg);
 
+// Removes a native C callback that was previously set by webview_bind.
+WEBVIEW_API void webview_unbind(webview_t w, const char *name);
+
 // Allows to return a value from the native binding. Original request pointer
 // must be provided to help internal RPC engine match requests with responses.
 // If status is zero - result is expected to be a valid JSON result value.
@@ -1248,7 +1251,7 @@ public:
           auto pair = static_cast<sync_binding_ctx_t *>(arg);
           pair->first->resolve(seq, 0, pair->second(req));
         },
-        new sync_binding_ctx_t(this, fn));
+        0);
   }
 
   void bind(const std::string name, binding_t f, void *arg) {
@@ -1272,6 +1275,17 @@ public:
     })())";
     init(js);
     bindings[name] = new binding_ctx_t(new binding_t(f), arg);
+  }
+
+  void unbind(const std::string name) {
+    if(bindings.find(name) != bindings.end()) {
+      auto js = "delete window['" + name + "'];";
+      init(js);
+      eval(js);
+      delete bindings[name]->first;
+      delete bindings[name];
+      bindings.erase(name);
+    }
   }
 
   void resolve(const std::string seq, int status, const std::string result) {
@@ -1357,6 +1371,10 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
         fn(seq.c_str(), req.c_str(), arg);
       },
       arg);
+}
+
+WEBVIEW_API void webview_unbind(webview_t w, const char *name) {
+  static_cast<webview::webview *>(w)->unbind(name);
 }
 
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,


### PR DESCRIPTION
Line 1251 fixes a preexisting memory leak. That line dynamically allocates a pointer which we **never** use. Since it is passed as a `void*`, we cannot free that memory. Deleting a void pointer is undefined behavior.

The rest of the code is based on https://github.com/CptWesley/webview/commit/9e8794dc67f56d6c7dc060e85d10b77a98e626c3, though I needed to fix some memory leaks.
This library provides a way to bind JS and C functions, but it does not allow the user to unbind. As noted in issue https://github.com/webview/webview/issues/644, that is a security issue, so I believe this PR should be merged.