### PR TITLE
Add NetBSD compatibility to Go bindings

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -1,8 +1,8 @@
 package webview
 
 /*
-#cgo linux openbsd freebsd CXXFLAGS: -DWEBVIEW_GTK -std=c++11
-#cgo linux openbsd freebsd pkg-config: gtk+-3.0 webkit2gtk-4.0
+#cgo linux openbsd freebsd netbsd CXXFLAGS: -DWEBVIEW_GTK -std=c++11
+#cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.0
 
 #cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
 #cgo darwin LDFLAGS: -framework WebKit


### PR DESCRIPTION
This adds NetBSD to the list of compatible targets for the Go bindings. It uses webkit-gtk like Linux, OpenBSD, and FreeBSD already do.

This allows using `go get` directly on NetBSD without having to modify the bindings.

Resolves #548 