### PR TITLE
Don't decode HTML when passed as data URI

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1227,7 +1227,7 @@ public:
                                url_encode("<html><body>Hello</body></html>"));
       return;
     }
-    std::string html = html_from_uri(url);
+    std::string html = html_from_uri(url_encode(url));
     if (html != "") {
       browser_engine::navigate("data:text/html," + url_encode(html));
     } else {

--- a/webview.h
+++ b/webview.h
@@ -889,13 +889,8 @@ public:
   }
 
   void navigate(const std::string url) override {
-    std::string html = html_from_uri(url);
-    if (html != "") {
-      m_webview.NavigateToString(winrt::to_hstring(html));
-    } else {
-      Uri uri(winrt::to_hstring(url));
-      m_webview.Navigate(uri);
-    }
+    Uri uri(winrt::to_hstring(url));
+    m_webview.Navigate(uri);
   }
 
   void init(const std::string js) override {
@@ -1227,12 +1222,7 @@ public:
                                url_encode("<html><body>Hello</body></html>"));
       return;
     }
-    std::string html = html_from_uri(url_encode(url));
-    if (html != "") {
-      browser_engine::navigate("data:text/html," + url_encode(html));
-    } else {
-      browser_engine::navigate(url);
-    }
+    browser_engine::navigate(url);
   }
 
   using binding_t = std::function<void(std::string, std::string, void *)>;


### PR DESCRIPTION
Fixes part of #643 by encoding HTML data URIs before converting and then passing onto the webview. Previously, it would encode it *after* it was applicable. 