### PR TITLE
add_navigate_listener

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -840,7 +840,6 @@ using browser_engine = cocoa_wkwebview_engine;
 
 // EdgeHTML headers and libs
 #include <objbase.h>
-//#include <wrl.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Web.UI.Interop.h>
@@ -950,7 +949,6 @@ private:
 class edge_chromium : public browser {
 public:
   bool embed(HWND wnd, bool debug, msg_cb_t cb) override {
-
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
     flag.test_and_set();
 


### PR DESCRIPTION
This is my first stab at creating several cross-platform event listeners! I do not have a Mac, so this only works on Linux GTK and Windows webview2. Hopefully this will inspire someone to port it to Mac.

The add_navigate_listener is a dead-simple function. When a new webpage has loaded, this listener calls whatever handler the user specified and passes it the current url. Here is an example:

```cpp
void navigate_callback(const char* url) {
  std::cout << url << '\n';
  // any additional logic with the url here.
  // maybe if url is not https, navigate away.
}
...
// now pass the callback to the webview listener
w.add_navigate_listener(navigate_callback);
```

Feedback appreciated!