### PR TITLE
Get url

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -856,6 +856,7 @@ public:
   virtual void eval(const std::string js) = 0;
   virtual void init(const std::string js) = 0;
   virtual void resize(HWND) = 0;
+  virtual std::string get_url() = 0;
 };
 
 //
@@ -926,6 +927,8 @@ public:
     m_webview.Bounds(bounds);
   }
 
+  std::string get_url() { return ""; };
+
 private:
   WebViewControl m_webview = nullptr;
   std::string init_js = "";
@@ -994,6 +997,15 @@ public:
   void eval(const std::string js) override {
     auto wjs = winrt::to_hstring(js);
     m_webview->ExecuteScript(wjs.c_str(), nullptr);
+  }
+
+  std::string get_url() {
+    PWSTR uri;
+    m_webview->get_Source(&uri);
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+    std::string converted_url = converter.to_bytes(uri);
+    CoTaskMemFree(uri);
+    return converted_url;
   }
 
 private:
@@ -1194,6 +1206,7 @@ public:
   void navigate(const std::string url) { m_browser->navigate(url); }
   void eval(const std::string js) { m_browser->eval(js); }
   void init(const std::string js) { m_browser->init(js); }
+  std::string get_url() { m_browser->get_url(); }
 
 private:
   virtual void on_message(const std::string msg) = 0;

--- a/webview.h
+++ b/webview.h
@@ -534,6 +534,10 @@ public:
     }
   }
 
+  std::string get_url() {
+    return webkit_web_view_get_uri(WEBKIT_WEB_VIEW(m_webview));
+  }
+
   void navigate(const std::string url) {
     webkit_web_view_load_uri(WEBKIT_WEB_VIEW(m_webview), url.c_str());
   }

--- a/webview.h
+++ b/webview.h
@@ -1206,7 +1206,7 @@ public:
   void navigate(const std::string url) { m_browser->navigate(url); }
   void eval(const std::string js) { m_browser->eval(js); }
   void init(const std::string js) { m_browser->init(js); }
-  std::string get_url() { m_browser->get_url(); }
+  std::string get_url() { return m_browser->get_url(); }
 
 private:
   virtual void on_message(const std::string msg) = 0;


### PR DESCRIPTION
Another simple pull request for another simple cross-platform API. Not implemented for MacOs because I don't have one. Stub only for EdgeHtml since we are discussing removing it.
`std::string get_url()` returns the current URL.