### PR TITLE
Remove EdgeHTML

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -810,14 +810,13 @@ using browser_engine = cocoa_wkwebview_engine;
 //
 // ====================================================================
 //
-// This implementation uses Win32 API to create a native window. It can
-// use either EdgeHTML or Edge/Chromium backend as a browser engine.
+// This implementation uses Win32 API to create a native window. It
+// uses Edge/Chromium webview2 backend as a browser engine.
 //
 // ====================================================================
 //
 
 #define WIN32_LEAN_AND_MEAN
-#include <codecvt>
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <stdlib.h>
@@ -829,16 +828,152 @@ using browser_engine = cocoa_wkwebview_engine;
 #pragma comment(lib, "Shlwapi.lib")
 #pragma comment(lib, "windowsapp")
 #pragma comment(lib, "shell32.lib")
-#pragma comment(lib, "ole32.lib")
-#pragma comment(lib, "oleaut32.lib")
 
 namespace webview {
 
 using msg_cb_t = std::function<void(const std::string)>;
 using namespace winrt;
 
-class edge_chromium {
+class win32_edge_engine {
 public:
+  win32_edge_engine(bool debug, void *window) {
+    if (window == nullptr) {
+      HINSTANCE hInstance = GetModuleHandle(nullptr);
+      HICON icon = (HICON)LoadImage(
+          hInstance, IDI_APPLICATION, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),
+          GetSystemMetrics(SM_CYSMICON), LR_DEFAULTCOLOR);
+
+      WNDCLASSEXW wc;
+      ZeroMemory(&wc, sizeof(WNDCLASSEX));
+      wc.cbSize = sizeof(WNDCLASSEX);
+      wc.hInstance = hInstance;
+      wc.lpszClassName = L"webview";
+      wc.hIcon = icon;
+      wc.hIconSm = icon;
+      wc.lpfnWndProc =
+          (WNDPROC)(+[](HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) -> LRESULT {
+            auto w = (win32_edge_engine *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+            switch (msg) {
+            case WM_SIZE:
+              w->resize(hwnd);
+              break;
+            case WM_CLOSE:
+              DestroyWindow(hwnd);
+              break;
+            case WM_DESTROY:
+              w->terminate();
+              break;
+            case WM_GETMINMAXINFO: {
+              auto lpmmi = (LPMINMAXINFO)lp;
+              if (w == nullptr) {
+                return 0;
+              }
+              if (w->m_maxsz.x > 0 && w->m_maxsz.y > 0) {
+                lpmmi->ptMaxSize = w->m_maxsz;
+                lpmmi->ptMaxTrackSize = w->m_maxsz;
+              }
+              if (w->m_minsz.x > 0 && w->m_minsz.y > 0) {
+                lpmmi->ptMinTrackSize = w->m_minsz;
+              }
+            } break;
+            default:
+              return DefWindowProcW(hwnd, msg, wp, lp);
+            }
+            return 0;
+          });
+      RegisterClassExW(&wc);
+      m_window = CreateWindowW(L"webview", L"", WS_OVERLAPPEDWINDOW,
+                               CW_USEDEFAULT, CW_USEDEFAULT, 640, 480, nullptr,
+                               nullptr, GetModuleHandle(nullptr), nullptr);
+      SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
+    } else {
+      m_window = *(static_cast<HWND *>(window));
+    }
+
+    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+    ShowWindow(m_window, SW_SHOW);
+    UpdateWindow(m_window);
+    SetFocus(m_window);
+
+    auto cb =
+        std::bind(&win32_edge_engine::on_message, this, std::placeholders::_1);
+
+    embed(m_window, debug, cb);
+    resize(m_window);
+  }
+
+  void run() {
+    MSG msg;
+    BOOL res;
+    while ((res = GetMessage(&msg, nullptr, 0, 0)) != -1) {
+      if (msg.hwnd) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+        continue;
+      }
+      if (msg.message == WM_APP) {
+        auto f = (dispatch_fn_t *)(msg.lParam);
+        (*f)();
+        delete f;
+      } else if (msg.message == WM_QUIT) {
+        return;
+      }
+    }
+  }
+  void *window() { return (void *)m_window; }
+  void terminate() { PostQuitMessage(0); }
+  void dispatch(dispatch_fn_t f) {
+    PostThreadMessage(m_main_thread, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
+  }
+
+  void set_title(const std::string title) {
+    SetWindowTextW(m_window, winrt::to_hstring(title).c_str());
+  }
+
+  void set_size(int width, int height, int hints) {
+    auto style = GetWindowLong(m_window, GWL_STYLE);
+    if (hints == WEBVIEW_HINT_FIXED) {
+      style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
+    } else {
+      style |= (WS_THICKFRAME | WS_MAXIMIZEBOX);
+    }
+    SetWindowLong(m_window, GWL_STYLE, style);
+
+    if (hints == WEBVIEW_HINT_MAX) {
+      m_maxsz.x = width;
+      m_maxsz.y = height;
+    } else if (hints == WEBVIEW_HINT_MIN) {
+      m_minsz.x = width;
+      m_minsz.y = height;
+    } else {
+      RECT r;
+      r.left = r.top = 0;
+      r.right = width;
+      r.bottom = height;
+      AdjustWindowRect(&r, WS_OVERLAPPEDWINDOW, 0);
+      SetWindowPos(
+          m_window, NULL, r.left, r.top, r.right - r.left, r.bottom - r.top,
+          SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_FRAMECHANGED);
+      resize(m_window);
+    }
+  }
+
+  void navigate(const std::string url) {
+    auto wurl = winrt::to_hstring(url);
+    m_webview->Navigate(wurl.c_str());
+  }
+
+  void init(const std::string js) {
+    auto wjs = winrt::to_hstring(js);
+    m_webview->AddScriptToExecuteOnDocumentCreated(wjs.c_str(), nullptr);
+  }
+
+  void eval(const std::string js) {
+    auto wjs = winrt::to_hstring(js);
+    m_webview->ExecuteScript(wjs.c_str(), nullptr);
+  }
+
+private:
   bool embed(HWND wnd, bool debug, msg_cb_t cb) {
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
     flag.test_and_set();
@@ -884,22 +1019,12 @@ public:
     m_controller->put_Bounds(bounds);
   }
 
-  void navigate(const std::string url) {
-    auto wurl = winrt::to_hstring(url);
-    m_webview->Navigate(wurl.c_str());
-  }
+  virtual void on_message(const std::string msg) = 0;
 
-  void init(const std::string js) {
-    auto wjs = winrt::to_hstring(js);
-    m_webview->AddScriptToExecuteOnDocumentCreated(wjs.c_str(), nullptr);
-  }
-
-  void eval(const std::string js) {
-    auto wjs = winrt::to_hstring(js);
-    m_webview->ExecuteScript(wjs.c_str(), nullptr);
-  }
-
-private:
+  HWND m_window;
+  POINT m_minsz = POINT{0, 0};
+  POINT m_maxsz = POINT{0, 0};
+  DWORD m_main_thread = GetCurrentThreadId();
   ICoreWebView2 *m_webview = nullptr;
   ICoreWebView2Controller *m_controller = nullptr;
 
@@ -964,145 +1089,6 @@ private:
     msg_cb_t m_msgCb;
     webview2_com_handler_cb_t m_cb;
   };
-};
-
-class win32_edge_engine {
-public:
-  win32_edge_engine(bool debug, void *window) {
-    if (window == nullptr) {
-      HINSTANCE hInstance = GetModuleHandle(nullptr);
-      HICON icon = (HICON)LoadImage(
-          hInstance, IDI_APPLICATION, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),
-          GetSystemMetrics(SM_CYSMICON), LR_DEFAULTCOLOR);
-
-      WNDCLASSEXW wc;
-      ZeroMemory(&wc, sizeof(WNDCLASSEX));
-      wc.cbSize = sizeof(WNDCLASSEX);
-      wc.hInstance = hInstance;
-      wc.lpszClassName = L"webview";
-      wc.hIcon = icon;
-      wc.hIconSm = icon;
-      wc.lpfnWndProc =
-          (WNDPROC)(+[](HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) -> LRESULT {
-            auto w = (win32_edge_engine *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
-            switch (msg) {
-            case WM_SIZE:
-              w->m_browser->resize(hwnd);
-              break;
-            case WM_CLOSE:
-              DestroyWindow(hwnd);
-              break;
-            case WM_DESTROY:
-              w->terminate();
-              break;
-            case WM_GETMINMAXINFO: {
-              auto lpmmi = (LPMINMAXINFO)lp;
-              if (w == nullptr) {
-                return 0;
-              }
-              if (w->m_maxsz.x > 0 && w->m_maxsz.y > 0) {
-                lpmmi->ptMaxSize = w->m_maxsz;
-                lpmmi->ptMaxTrackSize = w->m_maxsz;
-              }
-              if (w->m_minsz.x > 0 && w->m_minsz.y > 0) {
-                lpmmi->ptMinTrackSize = w->m_minsz;
-              }
-            } break;
-            default:
-              return DefWindowProcW(hwnd, msg, wp, lp);
-            }
-            return 0;
-          });
-      RegisterClassExW(&wc);
-      m_window = CreateWindowW(L"webview", L"", WS_OVERLAPPEDWINDOW,
-                               CW_USEDEFAULT, CW_USEDEFAULT, 640, 480, nullptr,
-                               nullptr, GetModuleHandle(nullptr), nullptr);
-      SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
-    } else {
-      m_window = *(static_cast<HWND *>(window));
-    }
-
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
-    ShowWindow(m_window, SW_SHOW);
-    UpdateWindow(m_window);
-    SetFocus(m_window);
-
-    auto cb =
-        std::bind(&win32_edge_engine::on_message, this, std::placeholders::_1);
-
-    m_browser->embed(m_window, debug, cb);
-    m_browser->resize(m_window);
-  }
-
-  void run() {
-    MSG msg;
-    BOOL res;
-    while ((res = GetMessage(&msg, nullptr, 0, 0)) != -1) {
-      if (msg.hwnd) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-        continue;
-      }
-      if (msg.message == WM_APP) {
-        auto f = (dispatch_fn_t *)(msg.lParam);
-        (*f)();
-        delete f;
-      } else if (msg.message == WM_QUIT) {
-        return;
-      }
-    }
-  }
-  void *window() { return (void *)m_window; }
-  void terminate() { PostQuitMessage(0); }
-  void dispatch(dispatch_fn_t f) {
-    PostThreadMessage(m_main_thread, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
-  }
-
-  void set_title(const std::string title) {
-    SetWindowTextW(m_window, winrt::to_hstring(title).c_str());
-  }
-
-  void set_size(int width, int height, int hints) {
-    auto style = GetWindowLong(m_window, GWL_STYLE);
-    if (hints == WEBVIEW_HINT_FIXED) {
-      style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
-    } else {
-      style |= (WS_THICKFRAME | WS_MAXIMIZEBOX);
-    }
-    SetWindowLong(m_window, GWL_STYLE, style);
-
-    if (hints == WEBVIEW_HINT_MAX) {
-      m_maxsz.x = width;
-      m_maxsz.y = height;
-    } else if (hints == WEBVIEW_HINT_MIN) {
-      m_minsz.x = width;
-      m_minsz.y = height;
-    } else {
-      RECT r;
-      r.left = r.top = 0;
-      r.right = width;
-      r.bottom = height;
-      AdjustWindowRect(&r, WS_OVERLAPPEDWINDOW, 0);
-      SetWindowPos(
-          m_window, NULL, r.left, r.top, r.right - r.left, r.bottom - r.top,
-          SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_FRAMECHANGED);
-      m_browser->resize(m_window);
-    }
-  }
-
-  void navigate(const std::string url) { m_browser->navigate(url); }
-  void eval(const std::string js) { m_browser->eval(js); }
-  void init(const std::string js) { m_browser->init(js); }
-
-private:
-  virtual void on_message(const std::string msg) = 0;
-
-  HWND m_window;
-  POINT m_minsz = POINT{0, 0};
-  POINT m_maxsz = POINT{0, 0};
-  DWORD m_main_thread = GetCurrentThreadId();
-  std::unique_ptr<webview::edge_chromium> m_browser =
-      std::make_unique<webview::edge_chromium>();
 };
 
 using browser_engine = win32_edge_engine;

--- a/webview.h
+++ b/webview.h
@@ -822,19 +822,12 @@ using browser_engine = cocoa_wkwebview_engine;
 #include <shlwapi.h>
 #include <stdlib.h>
 #include <windows.h>
+#include <winrt/Windows.Foundation.h>
+#include "webview2.h"
 
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "Shlwapi.lib")
-
-// EdgeHTML headers and libs
-#include <objbase.h>
-#include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Web.UI.Interop.h>
 #pragma comment(lib, "windowsapp")
-
-// Edge/Chromium headers and libs
-#include "webview2.h"
 #pragma comment(lib, "shell32.lib")
 #pragma comment(lib, "ole32.lib")
 #pragma comment(lib, "oleaut32.lib")
@@ -842,19 +835,8 @@ using browser_engine = cocoa_wkwebview_engine;
 namespace webview {
 
 using msg_cb_t = std::function<void(const std::string)>;
-
-
-//
-// EdgeHTML browser engine
-//
 using namespace winrt;
-using namespace Windows::Foundation;
-using namespace Windows::Web::UI;
-using namespace Windows::Web::UI::Interop;
 
-//
-// Edge/Chromium browser engine
-//
 class edge_chromium {
 public:
   bool embed(HWND wnd, bool debug, msg_cb_t cb) {
@@ -1005,7 +987,7 @@ public:
             auto w = (win32_edge_engine *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
             switch (msg) {
             case WM_SIZE:
-              //w->m_browser->resize(hwnd);
+              w->m_browser->resize(hwnd);
               break;
             case WM_CLOSE:
               DestroyWindow(hwnd);

--- a/webview.h
+++ b/webview.h
@@ -831,12 +831,13 @@ using browser_engine = cocoa_wkwebview_engine;
 //
 
 #define WIN32_LEAN_AND_MEAN
-#include "webview2.h"
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <stdlib.h>
 #include <windows.h>
 #include <winrt/Windows.Foundation.h>
+
+#include "webview2.h"
 
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "Shlwapi.lib")

--- a/webview.h
+++ b/webview.h
@@ -831,12 +831,12 @@ using browser_engine = cocoa_wkwebview_engine;
 //
 
 #define WIN32_LEAN_AND_MEAN
+#include "webview2.h"
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <stdlib.h>
 #include <windows.h>
 #include <winrt/Windows.Foundation.h>
-#include "webview2.h"
 
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "Shlwapi.lib")


### PR DESCRIPTION
This will resolve #678.

I think we need to merge https://github.com/webview/webview/pull/684 and https://github.com/webview/webview/pull/666 first. Otherwise, EdgeHTML support seems up-to-date to me. If we decide to, this PR will reduce the scope of our library and will leave users who want to support EdgeHTML with a working API (after merging what I suggest above).

Note: after we merge this, any open PR that affects windows will have to update their PR. We should double-check their status first.