### PR TITLE
Define WEBVIEW_GTK on other Unix platforms

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -122,7 +122,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 #if !defined(WEBVIEW_GTK) && !defined(WEBVIEW_COCOA) && !defined(WEBVIEW_EDGE)
 #if defined(__APPLE__)
 #define WEBVIEW_COCOA
-#elif defined (__unix__)
+#elif defined(__unix__)
 #define WEBVIEW_GTK
 #elif defined(_WIN32)
 #define WEBVIEW_EDGE

--- a/webview.h
+++ b/webview.h
@@ -120,10 +120,10 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 #ifndef WEBVIEW_HEADER
 
 #if !defined(WEBVIEW_GTK) && !defined(WEBVIEW_COCOA) && !defined(WEBVIEW_EDGE)
-#if defined(__linux__)
-#define WEBVIEW_GTK
-#elif defined(__APPLE__)
+#if defined(__APPLE__)
 #define WEBVIEW_COCOA
+#elif defined (__unix__)
+#define WEBVIEW_GTK
 #elif defined(_WIN32)
 #define WEBVIEW_EDGE
 #else


### PR DESCRIPTION
Previously, compiling on various BSDs required setting WEBVIEW_GTK
directly. This automatically defines WEBVIEW_GTK Unix platforms
(after checking for Apple, in case macOS defines `__unix__`).

The Go bindings already do this for various Unix systems.

Resolves #431