### PR TITLE
Use reference to const string

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -16,11 +16,11 @@ int main()
   w.set_title("Example");
   w.set_size(480, 320, WEBVIEW_HINT_NONE);
   w.set_size(180, 120, WEBVIEW_HINT_MIN);
-  w.bind("noop", [](std::string s) -> std::string {
+  w.bind("noop", [](const std::string &s) -> std::string {
     std::cout << s << std::endl;
     return s;
   });
-  w.bind("add", [](std::string s) -> std::string {
+  w.bind("add", [](const std::string &s) -> std::string {
     auto a = std::stoi(webview::json_parse(s, "", 0));
     auto b = std::stoi(webview::json_parse(s, "", 1));
     return std::to_string(a + b);

--- a/webview.h
+++ b/webview.h
@@ -165,7 +165,7 @@ static inline char hex2char(const char *p) {
   return hex2nibble(p[0]) * 16 + hex2nibble(p[1]);
 }
 
-inline std::string url_encode(const std::string s) {
+inline std::string url_encode(const std::string &s) {
   std::string encoded;
   for (unsigned int i = 0; i < s.length(); i++) {
     auto c = s[i];
@@ -180,7 +180,7 @@ inline std::string url_encode(const std::string s) {
   return encoded;
 }
 
-inline std::string url_decode(const std::string st) {
+inline std::string url_decode(const std::string &st) {
   std::string decoded;
   const char *s = st.c_str();
   size_t length = strlen(s);
@@ -197,7 +197,7 @@ inline std::string url_decode(const std::string st) {
   return decoded;
 }
 
-inline std::string html_from_uri(const std::string s) {
+inline std::string html_from_uri(const std::string &s) {
   if (s.substr(0, 15) == "data:text/html,") {
     return url_decode(s.substr(15));
   }
@@ -343,7 +343,7 @@ inline int json_parse_c(const char *s, size_t sz, const char *key, size_t keysz,
   return -1;
 }
 
-inline std::string json_escape(std::string s) {
+inline std::string json_escape(const std::string &s) {
   // TODO: implement
   return '"' + s + '"';
 }
@@ -403,7 +403,7 @@ inline int json_unescape(const char *s, size_t n, char *out) {
   return r;
 }
 
-inline std::string json_parse(const std::string s, const std::string key,
+inline std::string json_parse(const std::string &s, const std::string &key,
                               const int index) {
   const char *value;
   size_t value_sz;
@@ -519,7 +519,7 @@ public:
                     [](void *f) { delete static_cast<dispatch_fn_t *>(f); });
   }
 
-  void set_title(const std::string title) {
+  void set_title(const std::string &title) {
     gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());
   }
 
@@ -540,15 +540,15 @@ public:
     }
   }
 
-  void navigate(const std::string url) {
+  void navigate(const std::string &url) {
     webkit_web_view_load_uri(WEBKIT_WEB_VIEW(m_webview), url.c_str());
   }
 
-  void set_html(const std::string html) {
+  void set_html(const std::string &html) {
     webkit_web_view_load_html(WEBKIT_WEB_VIEW(m_webview), html.c_str(), NULL);
   }
 
-  void init(const std::string js) {
+  void init(const std::string &js) {
     WebKitUserContentManager *manager =
         webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(m_webview));
     webkit_user_content_manager_add_script(
@@ -557,13 +557,13 @@ public:
                      WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, NULL, NULL));
   }
 
-  void eval(const std::string js) {
+  void eval(const std::string &js) {
     webkit_web_view_run_javascript(WEBKIT_WEB_VIEW(m_webview), js.c_str(), NULL,
                                    NULL, NULL);
   }
 
 private:
-  virtual void on_message(const std::string msg) = 0;
+  virtual void on_message(const std::string &msg) = 0;
   GtkWidget *m_window;
   GtkWidget *m_webview;
 };
@@ -741,7 +741,7 @@ public:
                        delete f;
                      }));
   }
-  void set_title(const std::string title) {
+  void set_title(const std::string &title) {
     ((void (*)(id, SEL, id))objc_msgSend)(
         m_window, "setTitle:"_sel,
         ((id(*)(id, SEL, const char *))objc_msgSend)(
@@ -769,7 +769,7 @@ public:
     }
     ((void (*)(id, SEL))objc_msgSend)(m_window, "center"_sel);
   }
-  void navigate(const std::string url) {
+  void navigate(const std::string &url) {
     auto nsurl = ((id(*)(id, SEL, id))objc_msgSend)(
         "NSURL"_cls, "URLWithString:"_sel,
         ((id(*)(id, SEL, const char *))objc_msgSend)(
@@ -780,14 +780,14 @@ public:
         ((id(*)(id, SEL, id))objc_msgSend)("NSURLRequest"_cls,
                                            "requestWithURL:"_sel, nsurl));
   }
-  void set_html(const std::string html) {
+  void set_html(const std::string &html) {
     ((void (*)(id, SEL, id, id))objc_msgSend)(
         m_webview, "loadHTMLString:baseURL:"_sel,
         ((id(*)(id, SEL, const char *))objc_msgSend)(
             "NSString"_cls, "stringWithUTF8String:"_sel, html.c_str()),
         nullptr);
   }
-  void init(const std::string js) {
+  void init(const std::string &js) {
     // Equivalent Obj-C:
     // [m_manager addUserScript:[[WKUserScript alloc] initWithSource:[NSString stringWithUTF8String:js.c_str()] injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]]
     ((void (*)(id, SEL, id))objc_msgSend)(
@@ -799,7 +799,7 @@ public:
                 "NSString"_cls, "stringWithUTF8String:"_sel, js.c_str()),
             WKUserScriptInjectionTimeAtDocumentStart, 1));
   }
-  void eval(const std::string js) {
+  void eval(const std::string &js) {
     ((void (*)(id, SEL, id, id))objc_msgSend)(
         m_webview, "evaluateJavaScript:completionHandler:"_sel,
         ((id(*)(id, SEL, const char *))objc_msgSend)(
@@ -808,7 +808,7 @@ public:
   }
 
 private:
-  virtual void on_message(const std::string msg) = 0;
+  virtual void on_message(const std::string &msg) = 0;
   void close() { ((void (*)(id, SEL))objc_msgSend)(m_window, "close"_sel); }
   id m_window;
   id m_webview;
@@ -941,7 +941,7 @@ public:
     PostThreadMessage(m_main_thread, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
   }
 
-  void set_title(const std::string title) {
+  void set_title(const std::string &title) {
     SetWindowTextW(m_window, winrt::to_hstring(title).c_str());
   }
 
@@ -973,22 +973,22 @@ public:
     }
   }
 
-  void navigate(const std::string url) {
+  void navigate(const std::string &url) {
     auto wurl = winrt::to_hstring(url);
     m_webview->Navigate(wurl.c_str());
   }
 
-  void init(const std::string js) {
+  void init(const std::string &js) {
     auto wjs = winrt::to_hstring(js);
     m_webview->AddScriptToExecuteOnDocumentCreated(wjs.c_str(), nullptr);
   }
 
-  void eval(const std::string js) {
+  void eval(const std::string &js) {
     auto wjs = winrt::to_hstring(js);
     m_webview->ExecuteScript(wjs.c_str(), nullptr);
   }
 
-  void set_html(const std::string html) {
+  void set_html(const std::string &html) {
     auto html2 = winrt::to_hstring("data:text/html," + url_encode(html));
     m_webview->Navigate(html2.c_str());
   }
@@ -1039,7 +1039,7 @@ private:
     m_controller->put_Bounds(bounds);
   }
 
-  virtual void on_message(const std::string msg) = 0;
+  virtual void on_message(const std::string &msg) = 0;
 
   HWND m_window;
   POINT m_minsz = POINT{0, 0};
@@ -1123,7 +1123,7 @@ public:
   webview(bool debug = false, void *wnd = nullptr)
       : browser_engine(debug, wnd) {}
 
-  void navigate(const std::string url) {
+  void navigate(const std::string &url) {
     if (url == "") {
       browser_engine::navigate("data:text/html," +
                                url_encode("<html><body>Hello</body></html>"));
@@ -1138,17 +1138,17 @@ public:
   using sync_binding_t = std::function<std::string(std::string)>;
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
-  void bind(const std::string name, sync_binding_t fn) {
+  void bind(const std::string &name, sync_binding_t fn) {
     bind(
         name,
-        [](std::string seq, std::string req, void *arg) {
+        [](const std::string &seq, const std::string &req, void *arg) {
           auto pair = static_cast<sync_binding_ctx_t *>(arg);
           pair->first->resolve(seq, 0, pair->second(req));
         },
         new sync_binding_ctx_t(this, fn));
   }
 
-  void bind(const std::string name, binding_t f, void *arg) {
+  void bind(const std::string &name, binding_t f, void *arg) {
     auto js = "(function() { var name = '" + name + "';" + R"(
       var RPC = window._rpc = (window._rpc || {nextSeq: 1});
       window[name] = function() {
@@ -1171,7 +1171,7 @@ public:
     bindings[name] = new binding_ctx_t(new binding_t(f), arg);
   }
 
-  void unbind(const std::string name) {
+  void unbind(const std::string &name) {
     if (bindings.find(name) != bindings.end()) {
       auto js = "delete window['" + name + "'];";
       init(js);
@@ -1183,7 +1183,7 @@ public:
     }
   }
 
-  void resolve(const std::string seq, int status, const std::string result) {
+  void resolve(const std::string &seq, int status, const std::string &result) {
     dispatch([=]() {
       if (status == 0) {
         eval("window._rpc[" + seq + "].resolve(" + result +
@@ -1196,7 +1196,7 @@ public:
   }
 
 private:
-  void on_message(const std::string msg) {
+  void on_message(const std::string &msg) {
     auto seq = json_parse(msg, "id", 0);
     auto name = json_parse(msg, "method", 0);
     auto args = json_parse(msg, "params", 0);
@@ -1266,7 +1266,7 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
                               void *arg) {
   static_cast<webview::webview *>(w)->bind(
       name,
-      [=](std::string seq, std::string req, void *arg) {
+      [=](const std::string &seq, const std::string &req, void *arg) {
         fn(seq.c_str(), req.c_str(), arg);
       },
       arg);

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -45,15 +45,15 @@ static void test_c_api() {
 // TEST: ensure that JS code can call native code and vice versa.
 // =================================================================
 struct test_webview : webview::browser_engine {
-  using cb_t = std::function<void(test_webview *, int, const std::string)>;
+  using cb_t = std::function<void(test_webview *, int, const std::string &)>;
   test_webview(cb_t cb) : webview::browser_engine(true, nullptr), m_cb(cb) {}
-  void on_message(const std::string msg) override { m_cb(this, i++, msg); }
+  void on_message(const std::string &msg) override { m_cb(this, i++, msg); }
   int i = 0;
   cb_t m_cb;
 };
 
 static void test_bidir_comms() {
-  test_webview browser([](test_webview *w, int i, const std::string msg) {
+  test_webview browser([](test_webview *w, int i, const std::string &msg) {
     std::cout << msg << std::endl;
     switch (i) {
     case 0:


### PR DESCRIPTION
I would like to propose changing parameters of type `std::string` to `const std::string&` because it is generally a good practice.