### PR TITLE
Do not display "Hello" when URL is empty

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1126,7 +1126,7 @@ public:
   void navigate(const std::string url) {
     if (url == "") {
       browser_engine::navigate("data:text/html," +
-                               url_encode("<html><body>Hello</body></html>"));
+                               url_encode("<html><body></body></html>"));
       return;
     }
     browser_engine::navigate(url);


### PR DESCRIPTION
I suggest this change to avoid compiling the word "Hello" into the executable consuming the library and because it is an unwanted side effect.

While I find it questionable that an empty URL should be permitted, I do not have strong opinions about it.

Preferably I would like to avoid embedding the string `<html><body></body></html>`.