### PR TITLE
Fix multiple definitions error

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -115,9 +115,6 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 
 #ifdef __cplusplus
 }
-#endif
-
-#ifndef WEBVIEW_HEADER
 
 #if !defined(WEBVIEW_GTK) && !defined(WEBVIEW_COCOA) && !defined(WEBVIEW_EDGE)
 #if defined(__APPLE__)
@@ -1210,6 +1207,8 @@ private:
 };
 } // namespace webview
 
+#ifndef WEBVIEW_HEADER
+
 WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
   return new webview::webview(debug, wnd);
 }
@@ -1282,5 +1281,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 }
 
 #endif /* WEBVIEW_HEADER */
+
+#endif /* __cplusplus */
 
 #endif /* WEBVIEW_H */


### PR DESCRIPTION
Currently there is a problem for library consumers where the non-inline C API function definitions can cause errors due to multiple definitions.

From the name `WEBVIEW_HEADER` I would make an assumption as a library consumer that the purpose of this definition is to only expose declarations/definitions that can be used safely without side effects. Unfortunately defining `WEBVIEW_HEADER` currently has the side effect of hiding the C++ API.

This PR brings a minimum amount of changes for solving the problem:

|New behavior|
|-|
|Always expose C API function declarations.|
|Always expose C++ API in C++ mode, and never expose it in C mode. This is safe because functions defined in class definitions are implicitly inline and the free functions used by the classes are marked as inline.|
|Never expose C API function definitions in C mode because they are implemented in C++.|
|Expose C API function definitions in C++ mode unless `WEBVIEW_HEADER` is defined.|

This way `WEBVIEW_HEADER` no effect when compiling in C mode.

If we still want to conditionally hide the C API function definitions then my personal preference is to invert the condition, e.g. by defining `WEBVIEW_IMPLEMENTATION` instead of not defining `WEBVIEW_HEADER`, even though that introduces changes for library consumers.

## Usage

I suggest that library consumers define `WEBVIEW_HEADER` globally so that the C API function definitions are hidden by default.

Place this in a C++ source file to define the C API function definitions if there is a need to consume the C API in C++ mode:

```cpp
#undef WEBVIEW_HEADER
#include <webview.h>
```

Those who use CMake and FetchContent could do something like this paired with the snippet above:

```
[...]
add_library(webview INTERFACE)
target_include_directories(webview INTERFACE ${webview_SOURCE_DIR} ${WEBKIT2GTK_INCLUDE_DIRS})
target_link_libraries(webview INTERFACE ${WEBKIT2GTK_LIBRARIES})
target_compile_features(webview INTERFACE cxx_std_11)
target_compile_definitions(webview INTERFACE WEBVIEW_HEADER)
[...]
```

Alternatively, do something like this instead of both of the examples above:

```
[...]
add_library(webview STATIC ${webview_SOURCE_DIR}/webview.cc)
target_include_directories(webview PUBLIC ${webview_SOURCE_DIR} ${WEBKIT2GTK_INCLUDE_DIRS})
target_link_libraries(webview PUBLIC ${WEBKIT2GTK_LIBRARIES})
target_compile_features(webview PUBLIC cxx_std_11)
target_compile_definitions(webview INTERFACE WEBVIEW_HEADER)
[...]
```