### PR TITLE
Fix encoding of data URL in C example

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,7 +19,7 @@ int main() {
 	webview_set_title(w, "Webview Example");
 	webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
 	webview_bind(w, "myFunc", myFunc, NULL);
-	webview_navigate(w, "data:text/html, <button onclick='myFunc(\"Foo bar\")'>Click Me</button>");
+	webview_navigate(w, "data:text/html,%3Cbutton%20onclick%3D%27myFunc%28%22Foo%20bar%22%29%27%3EClick%20Me%3C%2Fbutton%3E");
 	webview_run(w);
 	webview_destroy(w);
 	return 0;


### PR DESCRIPTION
[According to mdn web docs](https://developer.mozilla.org/en-US/docs/Web%20%20/HTTP/Basics_of_HTTP/Data_URIs), reserved characters (RFC 3986), spaces, newlines, or other non-printable characters must be encoded.

This fixes the C example displaying a blank page instead of the button on macOS (tested 10.15.7).

Before change:

<img width="196" alt="before" src="https://user-images.githubusercontent.com/1543854/163734560-6238aaeb-c381-4363-a894-39ad0a9ae086.png">

After change:

<img width="205" alt="after" src="https://user-images.githubusercontent.com/1543854/163734505-14391b7e-0352-4bfa-accb-116cc07663cf.png">
