### PR TITLE
Fix implicitly capturing "this" in lambda function

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1186,7 +1186,7 @@ public:
   }
 
   void resolve(const std::string &seq, int status, const std::string &result) {
-    dispatch([=]() {
+    dispatch([seq, status, result, this]() {
       if (status == 0) {
         eval("window._rpc[" + seq + "].resolve(" + result +
              "); delete window._rpc[" + seq + "]");


### PR DESCRIPTION
Fixes the following warning (GCC) in C++20 mode:

```
implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Werror=deprecated]
    dispatch([=]() {
```

`[=, this]` only became available since C++20:

```
explicit by-copy capture of ‘this’ with by-copy capture default only available with ‘-std=c++20’ or ‘-std=gnu++20’ [-Werror=c++20-extensions]
    dispatch([=, this]() {
```

This PR explicitly captures everything and eliminates the original warning.

Is there any other way to do this?