### PR TITLE
Remove unused hex/URL decode code

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -144,27 +144,6 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 namespace webview {
 using dispatch_fn_t = std::function<void()>;
 
-// Convert ASCII hex digit to a nibble (four bits, 0 - 15).
-//
-// Use unsigned to avoid signed overflow UB.
-static inline unsigned char hex2nibble(unsigned char c) {
-  if (c >= '0' && c <= '9') {
-    return c - '0';
-  } else if (c >= 'a' && c <= 'f') {
-    return 10 + (c - 'a');
-  } else if (c >= 'A' && c <= 'F') {
-    return 10 + (c - 'A');
-  }
-  return 0;
-}
-
-// Convert ASCII hex string (two characters) to byte.
-//
-// E.g., "0B" => 0x0B, "af" => 0xAF.
-static inline char hex2char(const char *p) {
-  return hex2nibble(p[0]) * 16 + hex2nibble(p[1]);
-}
-
 inline std::string url_encode(const std::string &s) {
   std::string encoded;
   for (unsigned int i = 0; i < s.length(); i++) {
@@ -178,30 +157,6 @@ inline std::string url_encode(const std::string &s) {
     }
   }
   return encoded;
-}
-
-inline std::string url_decode(const std::string &st) {
-  std::string decoded;
-  const char *s = st.c_str();
-  size_t length = strlen(s);
-  for (unsigned int i = 0; i < length; i++) {
-    if (s[i] == '%') {
-      decoded.push_back(hex2char(s + i + 1));
-      i = i + 2;
-    } else if (s[i] == '+') {
-      decoded.push_back(' ');
-    } else {
-      decoded.push_back(s[i]);
-    }
-  }
-  return decoded;
-}
-
-inline std::string html_from_uri(const std::string &s) {
-  if (s.substr(0, 15) == "data:text/html,") {
-    return url_decode(s.substr(15));
-  }
-  return "";
 }
 
 inline int json_parse_c(const char *s, size_t sz, const char *key, size_t keysz,


### PR DESCRIPTION
This PR removes code related to hex/URL decoding, and is an attempt to resolve concerns raised in the following PR that instead optimizes hex decoding:

  * https://github.com/webview/webview/pull/739