### PR TITLE
Optimize URL/percent encoding

### DIFF
--- a/webview_test.cc
+++ b/webview_test.cc
@@ -108,13 +108,45 @@ static void run_with_timeout(std::function<void()> fn, int timeout_ms) {
   timeout_thread.join();
 }
 
+// =================================================================
+// TEST: ensure that percent-encoding works.
+// =================================================================
+static void test_percent_encode() {
+  using webview::percent_encode;
+  // Generate a string with all the possible ASCII characters
+  std::string input(256, '\0');
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    input[i] = static_cast<char>(i);
+  }
+  static auto output = "%00%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F"
+                       "%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F"
+                       "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F"
+                       "%30%31%32%33%34%35%36%37%38%39%3A%3B%3C%3D%3E%3F"
+                       "%40%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%4E%4F"
+                       "%50%51%52%53%54%55%56%57%58%59%5A%5B%5C%5D%5E%5F"
+                       "%60%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%6E%6F"
+                       "%70%71%72%73%74%75%76%77%78%79%7A%7B%7C%7D%7E%7F"
+                       "%80%81%82%83%84%85%86%87%88%89%8A%8B%8C%8D%8E%8F"
+                       "%90%91%92%93%94%95%96%97%98%99%9A%9B%9C%9D%9E%9F"
+                       "%A0%A1%A2%A3%A4%A5%A6%A7%A8%A9%AA%AB%AC%AD%AE%AF"
+                       "%B0%B1%B2%B3%B4%B5%B6%B7%B8%B9%BA%BB%BC%BD%BE%BF"
+                       "%C0%C1%C2%C3%C4%C5%C6%C7%C8%C9%CA%CB%CC%CD%CE%CF"
+                       "%D0%D1%D2%D3%D4%D5%D6%D7%D8%D9%DA%DB%DC%DD%DE%DF"
+                       "%E0%E1%E2%E3%E4%E5%E6%E7%E8%E9%EA%EB%EC%ED%EE%EF"
+                       "%F0%F1%F2%F3%F4%F5%F6%F7%F8%F9%FA%FB%FC%FD%FE%FF";
+  assert(percent_encode(input) == output);
+  assert(percent_encode("foo") == "%66%6F%6F");
+  assert(percent_encode("フー") == "%E3%83%95%E3%83%BC");
+  assert(percent_encode("æøå") == "%C3%A6%C3%B8%C3%A5");
+}
+
 int main(int argc, char *argv[]) {
   std::unordered_map<std::string, std::function<void()>> all_tests = {
       {"terminate", test_terminate},
       {"c_api", test_c_api},
       {"bidir_comms", test_bidir_comms},
       {"json", test_json},
-  };
+      {"percent_encode", test_percent_encode}};
   // Without arguments run all tests, one-by-one by forking itself.
   // With a single argument - run the requested test
   if (argc == 1) {


### PR DESCRIPTION
This work replaces the `url_encode` function with a dumber `percent_encode` function that is optimized for code execution:

  * Characters are always percent-encoded which eliminates branch/comparison instructions inside the loop over the input string.
  * All memory for the resulting string is allocated upfront since the amount required can be calculated trivially.
  * Encoding is trivial enough to not need snprintf.

The runtime efficiency improvement over the existing code is quite significant for long strings at the cost of more memory reserved for the resulting string.

On my machine the new code performs about 148 times better with a small (16.4 KB) but real-world minified HTML document with embedded styles and scripts.

Here is a comparison of the generated code: https://godbolt.org/z/s9dTeGj9G

To be fair, it would be good to measure the performance of the new encode function paired with each browser engine's decode function or just where applicable in order to prove the increased (or decreased) performance when every character is encoded and then decoded, but that is a bit much for me this time.

All I know at the moment is that the new function by itself is more efficient than the existing function for this particular use case.

If there are concerns about the new function then I can try to instead optimize the `url_encode` function while keeping the current internal detail regarding encoding. In any case, I would prefer some level of optimization here because the function is called directly by `*set_html` when running on Windows.