### PR TITLE
Use set_html instead of navigate with blank URL

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1089,8 +1089,7 @@ public:
 
   void navigate(const std::string &url) {
     if (url == "") {
-      browser_engine::navigate("data:text/html," +
-                               url_encode("<html><body></body></html>"));
+      browser_engine::set_html("<html><body></body></html>");
       return;
     }
     browser_engine::navigate(url);


### PR DESCRIPTION
This changes navigate to use the new method of injecting HTML, which
chooses the most appropriate method for the platform, instead of
navigating to an HTML data URL.