### PR TITLE
Move implementation details into separate namespace

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -21,8 +21,8 @@ int main()
     return s;
   });
   w.bind("add", [](const std::string &s) -> std::string {
-    auto a = std::stoi(webview::json_parse(s, "", 0));
-    auto b = std::stoi(webview::json_parse(s, "", 1));
+    auto a = std::stoi(webview::detail::json_parse(s, "", 0));
+    auto b = std::stoi(webview::detail::json_parse(s, "", 1));
     return std::to_string(a + b);
   });
   w.set_html(R"V0G0N(

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -82,7 +82,7 @@ static void test_bidir_comms() {
 // TEST: ensure that JSON parsing works.
 // =================================================================
 static void test_json() {
-  auto J = webview::json_parse;
+  auto J = webview::detail::json_parse;
   assert(J(R"({"foo":"bar"})", "foo", -1) == "bar");
   assert(J(R"({"foo":""})", "foo", -1) == "");
   assert(J(R"({"foo": {"bar": 1}})", "foo", -1) == R"({"bar": 1})");


### PR DESCRIPTION
With this PR I wish to discuss how we can hide details that are not meant to be part of the public API. It is also an initial suggestion for how it could be done.

I made an attempt to keep backward compatibility while emitting warnings when a deprecated function is used.

A warning may look something like the following.

```
main.cc: In lambda function:
main.cc:24:33: warning: ‘std::string webview::json_parse(const string&, const string&, int)’ is deprecated: Private API should not be used [-Wdeprecated-declarations]
   24 |     auto a = std::stoi(webview::json_parse(s, "", 0));
      |                                 ^~~~~~~~~~
```

```
main.cc:24:33: warning: 'json_parse' is deprecated: Private API should not be used [-Wdeprecated-declarations]
    auto a = std::stoi(webview::json_parse(s, "", 0));
                                ^
```

```
D:\a\webview\webview\script\..\main.cc(24): warning C4996: 'webview::json_parse': Private API should not be used
```

Related:

  * #742
