### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /script/nuget.exe
 webview
 webview_test
+webview-example
+*.o
+
+examples/scrape/scrape


### PR DESCRIPTION
Tells git to ignore webview-example, all .o files, and the new example binary. These are generated files added later than the last update of `.gitignore`.