### PR TITLE
Add more JSON parsing tests

### DIFF
--- a/webview_test.cc
+++ b/webview_test.cc
@@ -83,11 +83,35 @@ static void test_bidir_comms() {
 // =================================================================
 static void test_json() {
   auto J = webview::json_parse;
+  // Valid input with expected output
   assert(J(R"({"foo":"bar"})", "foo", -1) == "bar");
   assert(J(R"({"foo":""})", "foo", -1) == "");
+  assert(J(R"({"foo":{}")", "foo", -1) == "{}");
   assert(J(R"({"foo": {"bar": 1}})", "foo", -1) == R"({"bar": 1})");
   assert(J(R"(["foo", "bar", "baz"])", "", 0) == "foo");
   assert(J(R"(["foo", "bar", "baz"])", "", 2) == "baz");
+  // Valid UTF-8 with expected output
+  assert(J(R"({"フー":"バー"})", "フー", -1) == "バー");
+  assert(J(R"(["フー", "バー", "バズ"])", "", 2) == "バズ");
+  // Invalid input with valid output - should probably fail
+  assert(J(R"({"foo":"bar")", "foo", -1) == "bar");
+  // Valid input with other invalid parameters - should fail
+  assert(J(R"([])", "", 0) == "");
+  assert(J(R"({})", "foo", -1) == "");
+  assert(J(R"(["foo", "bar", "baz"])", "", -1) == "");
+  assert(J(R"(["foo"])", "", 1234) == "");
+  assert(J(R"(["foo"])", "", -1234) == "");
+  // Invalid input - should fail
+  assert(J(R"()", "", 0) == "");
+  assert(J(R"()", "foo", -1) == "");
+  assert(J(R"({"foo":")", "foo", -1) == "");
+  assert(J(R"({"foo":{)", "foo", -1) == "");
+  assert(J(R"({"foo":{")", "foo", -1) == "");
+  assert(J(R"(}")", "foo", -1) == "");
+  assert(J(R"({}}")", "foo", -1) == "");
+  assert(J(R"("foo)", "foo", -1) == "");
+  assert(J(R"(foo)", "foo", -1) == "");
+  assert(J(R"({{[[""foo""]]}})", "", 1234) == "");
 }
 
 static void run_with_timeout(std::function<void()> fn, int timeout_ms) {

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -102,8 +102,8 @@ static void test_json() {
   assert(J(R"(["foo"])", "", 1234) == "");
   assert(J(R"(["foo"])", "", -1234) == "");
   // Invalid input - should fail
-  assert(J(R"()", "", 0) == "");
-  assert(J(R"()", "foo", -1) == "");
+  assert(J("", "", 0) == "");
+  assert(J("", "foo", -1) == "");
   assert(J(R"({"foo":")", "foo", -1) == "");
   assert(J(R"({"foo":{)", "foo", -1) == "");
   assert(J(R"({"foo":{")", "foo", -1) == "");

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -112,6 +112,8 @@ static void test_json() {
   assert(J(R"("foo)", "foo", -1) == "");
   assert(J(R"(foo)", "foo", -1) == "");
   assert(J(R"({{[[""foo""]]}})", "", 1234) == "");
+  assert(J("bad", "", 0) == "");
+  assert(J("bad", "foo", -1) == "");
 }
 
 static void run_with_timeout(std::function<void()> fn, int timeout_ms) {


### PR DESCRIPTION
I am not sure what kind of quality we are aiming for regarding the current JSON implementation but eventually I think it would be nice to tidy up a bit. I added some more tests to get a better idea of what to expect from the current implementation.