### PR TITLE
Support old Windows

### DIFF
--- a/script/build.bat
+++ b/script/build.bat
@@ -85,6 +85,7 @@ cl %warning_params% ^
 
 echo Building webview_test.exe (x64)
 cl %warning_params% ^
+	/utf-8 ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^

--- a/webview.h
+++ b/webview.h
@@ -866,6 +866,7 @@ namespace detail {
 
 using msg_cb_t = std::function<void(const std::string)>;
 
+// Converts a narrow (UTF-8-encoded) string into a wide (UTF-16-encoded) string.
 std::wstring widen_string(const std::string &narrow_string) {
   if (narrow_string.empty()) {
     return std::wstring();
@@ -887,6 +888,7 @@ std::wstring widen_string(const std::string &narrow_string) {
   return std::wstring();
 }
 
+// Converts a wide (UTF-16-encoded) string into a narrow (UTF-8-encoded) string.
 std::string narrow_string(const std::wstring &wide_string) {
   if (wide_string.empty()) {
     return std::string();
@@ -910,6 +912,7 @@ std::string narrow_string(const std::wstring &wide_string) {
   return std::string();
 }
 
+// Holds a symbol name and associated type for code clarity.
 template <typename T> class library_symbol {
 public:
   using type = T;
@@ -921,6 +924,8 @@ private:
   const char *m_name;
 };
 
+// Loads a native shared library and allows one to get addresses for those
+// symbols.
 class native_library {
 public:
   explicit native_library(const wchar_t *name) : m_handle(LoadLibraryW(name)) {}
@@ -937,8 +942,10 @@ public:
   native_library(native_library &&other) = default;
   native_library &operator=(native_library &&other) = default;
 
+  // Returns true if the library is currently loaded; otherwise false.
   operator bool() const { return is_loaded(); }
 
+  // Get the address for the specified symbol or nullptr if not found.
   template <typename Symbol>
   typename Symbol::type get(const Symbol &symbol) const {
     if (is_loaded()) {
@@ -948,6 +955,7 @@ public:
     return nullptr;
   }
 
+  // Returns true if the library is currently loaded; otherwise false.
   bool is_loaded() const { return !!m_handle; }
 
 private:

--- a/webview.h
+++ b/webview.h
@@ -867,21 +867,21 @@ namespace detail {
 using msg_cb_t = std::function<void(const std::string)>;
 
 // Converts a narrow (UTF-8-encoded) string into a wide (UTF-16-encoded) string.
-std::wstring widen_string(const std::string &narrow_string) {
-  if (narrow_string.empty()) {
+std::wstring widen_string(const std::string &input) {
+  if (input.empty()) {
     return std::wstring();
   }
   UINT cp = CP_UTF8;
   DWORD flags = MB_ERR_INVALID_CHARS;
-  auto narrow_string_c = narrow_string.c_str();
-  auto narrow_string_length = static_cast<int>(narrow_string.size());
-  auto required_length = MultiByteToWideChar(cp, flags, narrow_string_c,
-                                             narrow_string_length, nullptr, 0);
+  auto input_c = input.c_str();
+  auto input_length = static_cast<int>(input.size());
+  auto required_length =
+      MultiByteToWideChar(cp, flags, input_c, input_length, nullptr, 0);
   if (required_length > 0) {
-    std::wstring wide_string(static_cast<std::size_t>(required_length), '\0');
-    if (MultiByteToWideChar(cp, flags, narrow_string_c, narrow_string_length,
-                            wide_string.data(), required_length) > 0) {
-      return wide_string;
+    std::wstring output(static_cast<std::size_t>(required_length), '\0');
+    if (MultiByteToWideChar(cp, flags, input_c, input_length, output.data(),
+                            required_length) > 0) {
+      return output;
     }
   }
   // Failed to convert string from UTF-8 to UTF-16
@@ -889,23 +889,21 @@ std::wstring widen_string(const std::string &narrow_string) {
 }
 
 // Converts a wide (UTF-16-encoded) string into a narrow (UTF-8-encoded) string.
-std::string narrow_string(const std::wstring &wide_string) {
-  if (wide_string.empty()) {
+std::string narrow_string(const std::wstring &input) {
+  if (input.empty()) {
     return std::string();
   }
   UINT cp = CP_UTF8;
   DWORD flags = WC_ERR_INVALID_CHARS;
-  auto wide_string_c = wide_string.c_str();
-  auto wide_string_length = static_cast<int>(wide_string.size());
-  auto required_length =
-      WideCharToMultiByte(cp, flags, wide_string_c, wide_string_length, nullptr,
-                          0, nullptr, nullptr);
+  auto input_c = input.c_str();
+  auto input_length = static_cast<int>(input.size());
+  auto required_length = WideCharToMultiByte(cp, flags, input_c, input_length,
+                                             nullptr, 0, nullptr, nullptr);
   if (required_length > 0) {
-    std::string narrow_string(static_cast<std::size_t>(required_length), '\0');
-    if (WideCharToMultiByte(cp, flags, wide_string_c, wide_string_length,
-                            narrow_string.data(), required_length, nullptr,
-                            nullptr) > 0) {
-      return narrow_string;
+    std::string output(static_cast<std::size_t>(required_length), '\0');
+    if (WideCharToMultiByte(cp, flags, input_c, input_length, output.data(),
+                            required_length, nullptr, nullptr) > 0) {
+      return output;
     }
   }
   // Failed to convert string from UTF-16 to UTF-8

--- a/webview.h
+++ b/webview.h
@@ -878,8 +878,8 @@ std::wstring widen_string(const std::string &input) {
   auto required_length =
       MultiByteToWideChar(cp, flags, input_c, input_length, nullptr, 0);
   if (required_length > 0) {
-    std::wstring output(static_cast<std::size_t>(required_length), '\0');
-    if (MultiByteToWideChar(cp, flags, input_c, input_length, output.data(),
+    std::wstring output(static_cast<std::size_t>(required_length), L'\0');
+    if (MultiByteToWideChar(cp, flags, input_c, input_length, &output[0],
                             required_length) > 0) {
       return output;
     }
@@ -901,7 +901,7 @@ std::string narrow_string(const std::wstring &input) {
                                              nullptr, 0, nullptr, nullptr);
   if (required_length > 0) {
     std::string output(static_cast<std::size_t>(required_length), '\0');
-    if (WideCharToMultiByte(cp, flags, input_c, input_length, output.data(),
+    if (WideCharToMultiByte(cp, flags, input_c, input_length, &output[0],
                             required_length, nullptr, nullptr) > 0) {
       return output;
     }

--- a/webview.h
+++ b/webview.h
@@ -899,7 +899,7 @@ public:
   using type = T;
 
   constexpr explicit library_symbol(const char *name) : m_name(name) {}
-  const char *get_name() const { return m_name; }
+  constexpr const char *get_name() const { return m_name; }
 
 private:
   const char *m_name;

--- a/webview.h
+++ b/webview.h
@@ -848,24 +848,145 @@ using browser_engine = detail::cocoa_wkwebview_engine;
 //
 
 #define WIN32_LEAN_AND_MEAN
+#include <shellscalingapi.h>
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <stdlib.h>
 #include <windows.h>
-#include <winrt/Windows.Foundation.h>
 
 #include "webview2.h"
 
-#pragma comment(lib, "user32.lib")
-#pragma comment(lib, "Shlwapi.lib")
-#pragma comment(lib, "windowsapp")
+#pragma comment(lib, "ole32.lib")
 #pragma comment(lib, "shell32.lib")
+#pragma comment(lib, "shlwapi.lib")
+#pragma comment(lib, "user32.lib")
 
 namespace webview {
 namespace detail {
 
 using msg_cb_t = std::function<void(const std::string)>;
-using namespace winrt;
+
+std::wstring widen_string(const std::string &narrow_string) {
+  if (narrow_string.empty()) {
+    return std::wstring();
+  }
+  UINT cp = CP_UTF8;
+  DWORD flags = MB_ERR_INVALID_CHARS;
+  auto narrow_string_c = narrow_string.c_str();
+  auto narrow_string_length = static_cast<int>(narrow_string.size());
+  auto required_length = MultiByteToWideChar(cp, flags, narrow_string_c,
+                                             narrow_string_length, nullptr, 0);
+  if (required_length > 0) {
+    std::wstring wide_string(static_cast<std::size_t>(required_length), '\0');
+    if (MultiByteToWideChar(cp, flags, narrow_string_c, narrow_string_length,
+                            wide_string.data(), required_length) > 0) {
+      return wide_string;
+    }
+  }
+  // Failed to convert string from UTF-8 to UTF-16
+  return std::wstring();
+}
+
+std::string narrow_string(const std::wstring &wide_string) {
+  if (wide_string.empty()) {
+    return std::string();
+  }
+  UINT cp = CP_UTF8;
+  DWORD flags = WC_ERR_INVALID_CHARS;
+  auto wide_string_c = wide_string.c_str();
+  auto wide_string_length = static_cast<int>(wide_string.size());
+  auto required_length =
+      WideCharToMultiByte(cp, flags, wide_string_c, wide_string_length, nullptr,
+                          0, nullptr, nullptr);
+  if (required_length > 0) {
+    std::string narrow_string(static_cast<std::size_t>(required_length), '\0');
+    if (WideCharToMultiByte(cp, flags, wide_string_c, wide_string_length,
+                            narrow_string.data(), required_length, nullptr,
+                            nullptr) > 0) {
+      return narrow_string;
+    }
+  }
+  // Failed to convert string from UTF-16 to UTF-8
+  return std::string();
+}
+
+template <typename T> class library_symbol {
+public:
+  using type = T;
+
+  constexpr explicit library_symbol(const char *name) : m_name(name) {}
+  const char *get_name() const { return m_name; }
+
+private:
+  const char *m_name;
+};
+
+class native_library {
+public:
+  explicit native_library(const wchar_t *name) : m_handle(LoadLibraryW(name)) {}
+
+  ~native_library() {
+    if (m_handle) {
+      FreeLibrary(m_handle);
+      m_handle = nullptr;
+    }
+  }
+
+  native_library(const native_library &other) = delete;
+  native_library &operator=(const native_library &other) = delete;
+  native_library(native_library &&other) = default;
+  native_library &operator=(native_library &&other) = default;
+
+  operator bool() const { return is_loaded(); }
+
+  template <typename Symbol>
+  typename Symbol::type get(const Symbol &symbol) const {
+    if (is_loaded()) {
+      return reinterpret_cast<typename Symbol::type>(
+          GetProcAddress(m_handle, symbol.get_name()));
+    }
+    return nullptr;
+  }
+
+  bool is_loaded() const { return !!m_handle; }
+
+private:
+  HMODULE m_handle = nullptr;
+};
+
+struct user32_symbols {
+  static constexpr auto SetProcessDpiAwarenessContext =
+      library_symbol<decltype(&SetProcessDpiAwarenessContext)>(
+          "SetProcessDpiAwarenessContext");
+  static constexpr auto SetProcessDPIAware =
+      library_symbol<decltype(&SetProcessDPIAware)>("SetProcessDPIAware");
+};
+
+struct shcore_symbols {
+  static constexpr auto SetProcessDpiAwareness =
+      library_symbol<decltype(&SetProcessDpiAwareness)>(
+          "SetProcessDpiAwareness");
+};
+
+bool enable_dpi_awareness() {
+  auto user32 = native_library(L"user32.dll");
+  if (auto fn = user32.get(user32_symbols::SetProcessDpiAwarenessContext)) {
+    if (fn(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE)) {
+      return true;
+    }
+    return GetLastError() == ERROR_ACCESS_DENIED;
+  }
+  if (auto shcore = native_library(L"shcore.dll")) {
+    if (auto fn = shcore.get(shcore_symbols::SetProcessDpiAwareness)) {
+      auto result = fn(PROCESS_PER_MONITOR_DPI_AWARE);
+      return result == S_OK || result == E_ACCESSDENIED;
+    }
+  }
+  if (auto fn = user32.get(user32_symbols::SetProcessDPIAware)) {
+    return !!fn();
+  }
+  return true;
+}
 
 class win32_edge_engine {
 public:
@@ -926,7 +1047,7 @@ public:
       m_window = *(static_cast<HWND *>(window));
     }
 
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+    enable_dpi_awareness();
     ShowWindow(m_window, SW_SHOW);
     UpdateWindow(m_window);
     SetFocus(m_window);
@@ -966,7 +1087,7 @@ public:
   }
 
   void set_title(const std::string &title) {
-    SetWindowTextW(m_window, winrt::to_hstring(title).c_str());
+    SetWindowTextW(m_window, widen_string(title).c_str());
   }
 
   void set_size(int width, int height, int hints) {
@@ -998,23 +1119,22 @@ public:
   }
 
   void navigate(const std::string &url) {
-    auto wurl = winrt::to_hstring(url);
+    auto wurl = widen_string(url);
     m_webview->Navigate(wurl.c_str());
   }
 
   void init(const std::string &js) {
-    auto wjs = winrt::to_hstring(js);
+    auto wjs = widen_string(js);
     m_webview->AddScriptToExecuteOnDocumentCreated(wjs.c_str(), nullptr);
   }
 
   void eval(const std::string &js) {
-    auto wjs = winrt::to_hstring(js);
+    auto wjs = widen_string(js);
     m_webview->ExecuteScript(wjs.c_str(), nullptr);
   }
 
   void set_html(const std::string &html) {
-    auto html2 =
-        winrt::to_hstring("data:text/html," + detail::percent_encode(html));
+    auto html2 = widen_string("data:text/html," + detail::percent_encode(html));
     m_webview->Navigate(html2.c_str());
   }
 
@@ -1112,7 +1232,7 @@ private:
         ICoreWebView2 *sender, ICoreWebView2WebMessageReceivedEventArgs *args) {
       LPWSTR message;
       args->TryGetWebMessageAsString(&message);
-      m_msgCb(winrt::to_string(message));
+      m_msgCb(narrow_string(message));
       sender->PostWebMessageAsString(message);
 
       CoTaskMemFree(message);

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -4,6 +4,7 @@
 #include "webview.h"
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <thread>
@@ -166,13 +167,57 @@ static void test_percent_encode() {
   assert(percent_encode("æøå") == "%C3%A6%C3%B8%C3%A5");
 }
 
+#if _WIN32
+// =================================================================
+// TEST: ensure that narrow/wide string conversion works on Windows.
+// =================================================================
+static void test_win32_narrow_wide_string_conversion() {
+  using namespace webview::detail;
+  assert(widen_string("") == L"");
+  assert(narrow_string(L"") == "");
+  assert(widen_string("foo") == L"foo");
+  assert(narrow_string(L"foo") == "foo");
+  assert(widen_string("フー") == L"フー");
+  assert(narrow_string(L"フー") == "フー");
+  assert(widen_string("æøå") == L"æøå");
+  assert(narrow_string(L"æøå") == "æøå");
+  // Unicode number for the smiley face below: U+1F600
+  assert(widen_string("😀") == L"😀");
+  assert(narrow_string(L"😀") == "😀");
+  // Ensure that elements of wide string are correct
+  {
+    auto s = widen_string("😀");
+    assert(s.size() == 2);
+    assert(static_cast<std::uint16_t>(s[0]) == 0xD83D);
+    assert(static_cast<std::uint16_t>(s[1]) == 0xDE00);
+  }
+  // Ensure that elements of narrow string are correct
+  {
+    auto s = narrow_string(L"😀");
+    assert(s.size() == 4);
+    assert(static_cast<std::uint8_t>(s[0]) == 0xf0);
+    assert(static_cast<std::uint8_t>(s[1]) == 0x9f);
+    assert(static_cast<std::uint8_t>(s[2]) == 0x98);
+    assert(static_cast<std::uint8_t>(s[3]) == 0x80);
+  }
+  // Null-characters must also be converted
+  assert(widen_string(std::string(2, '\0')) == std::wstring(2, L'\0'));
+  assert(narrow_string(std::wstring(2, L'\0')) == std::string(2, '\0'));
+}
+#endif
+
 int main(int argc, char *argv[]) {
   std::unordered_map<std::string, std::function<void()>> all_tests = {
-      {"terminate", test_terminate},
-      {"c_api", test_c_api},
-      {"bidir_comms", test_bidir_comms},
-      {"json", test_json},
-      {"percent_encode", test_percent_encode}};
+    {"terminate", test_terminate},
+    {"c_api", test_c_api},
+    {"bidir_comms", test_bidir_comms},
+    {"json", test_json},
+    {"percent_encode", test_percent_encode},
+#if _WIN32
+    {"win32_narrow_wide_string_conversion",
+     test_win32_narrow_wide_string_conversion},
+#endif
+  };
   // Without arguments run all tests, one-by-one by forking itself.
   // With a single argument - run the requested test
   if (argc == 1) {

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -208,16 +208,15 @@ static void test_win32_narrow_wide_string_conversion() {
 
 int main(int argc, char *argv[]) {
   std::unordered_map<std::string, std::function<void()>> all_tests = {
-    {"terminate", test_terminate},
-    {"c_api", test_c_api},
-    {"bidir_comms", test_bidir_comms},
-    {"json", test_json},
-    {"percent_encode", test_percent_encode},
+      {"terminate", test_terminate},
+      {"c_api", test_c_api},
+      {"bidir_comms", test_bidir_comms},
+      {"json", test_json},
+      {"percent_encode", test_percent_encode}};
 #if _WIN32
-    {"win32_narrow_wide_string_conversion",
-     test_win32_narrow_wide_string_conversion},
+  all_tests.emplace("win32_narrow_wide_string_conversion",
+                    test_win32_narrow_wide_string_conversion);
 #endif
-  };
   // Without arguments run all tests, one-by-one by forking itself.
   // With a single argument - run the requested test
   if (argc == 1) {


### PR DESCRIPTION
Adds support for Windows 7 through 8.1 changing the following:

* Use available DPI awareness API instead of API that is only available since Windows 10.
* Remove usage of WinRT and umbrella library only available since Windows 10.

This PR closes #752.

## Screenshots

The screenshots below show one of the example apps included with this library running on Windows 7, 8 and 10 with 100% scaling and 150% scaling.

### Windows 7

![win7_100_scaling](https://user-images.githubusercontent.com/1543854/170534294-5f3d5aa7-2182-47f3-91b3-0f69a66c4dac.png)
![win7_150_scaling](https://user-images.githubusercontent.com/1543854/170534312-60147ad9-d1de-49f5-9294-2c24d138b26a.png)

### Windows 8.1

![win8_100_scaling](https://user-images.githubusercontent.com/1543854/170534310-76d863fd-85a4-4337-b7aa-e98452f59a07.png)
![win8_150_scaling](https://user-images.githubusercontent.com/1543854/170534308-79ef3ffd-6752-43c7-a9eb-de649603bb9a.png)

### Windows 10

![win10_100_scaling](https://user-images.githubusercontent.com/1543854/170534304-90b8df1f-3200-4d1d-9e21-371e700e1317.png)
![win10_150 _scaling](https://user-images.githubusercontent.com/1543854/170534302-601afd91-27a4-428a-a150-28990fa033a8.png)

### Windows 11

The app looks nearly identical to how it looks on Windows 10.

![win11_100_scaling](https://user-images.githubusercontent.com/1543854/170564590-99476f28-febe-4fd5-b46e-f9b950f4c509.png)
![win11_150_scaling](https://user-images.githubusercontent.com/1543854/170564584-8c0ea27c-ca63-49d5-a861-9ec834afe228.png)