### PR TITLE
Enable tests on Windows

### DIFF
--- a/script/build.bat
+++ b/script/build.bat
@@ -90,6 +90,8 @@ cl %warning_params% ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit \b
 
+"%build_dir%\webview_test.exe" || exit \b
+
 echo Running Go tests
 cd /D %src_dir%
 set CGO_ENABLED=1

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -193,7 +193,7 @@ int main(int argc, char *argv[]) {
   if (argc == 2) {
     auto it = all_tests.find(argv[1]);
     if (it != all_tests.end()) {
-      run_with_timeout(it->second, 5000);
+      run_with_timeout(it->second, 60000);
       return 0;
     }
   }


### PR DESCRIPTION
This PR enables tests in the build script for Windows which allows the tests to run as part of the CI process.

This required increasing the test timeout from the current 5 seconds because the time between calling `CreateCoreWebView2EnvironmentWithOptions` and invocation of `ICoreWebView2CreateCoreWebView2ControllerCompletedHandler` can be more than 5 seconds when running on GitHub Actions. I have seen it take just over 25 seconds.

I would like to know why it takes so long but I have not yet been able to figure it out. I am unable to reproduce it locally. Maybe it is simply due to lack of resources on GitHub Actions but it would be nice to confirm it.

In any case I think that slow tests are better than no tests.