### PR TITLE
Show window after WebView2 has been initialized

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -927,8 +927,7 @@ public:
     }
 
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
-    ShowWindow(m_window, SW_SHOW);
-    UpdateWindow(m_window);
+    // If this is not here then we don't get the controller
     SetFocus(m_window);
 
     auto cb =
@@ -936,6 +935,9 @@ public:
 
     embed(m_window, debug, cb);
     resize(m_window);
+    m_controller->put_IsVisible(TRUE);
+    ShowWindow(m_window, SW_SHOW);
+    UpdateWindow(m_window);
     m_controller->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
   }
 


### PR DESCRIPTION
This PR aims to improve user experience for Windows users when starting an application.

I have included screen captures of how the C++ example app's window looks during initialization on before and after the changes in this PR.

The old behavior is to show a blank window immediately and then wait for WebView2 to load. The example below shows that the window has the initial hardcoded size of 640x480 until WebView2 has finished loading. That looks strange.

The new behavior keeps the window hidden until WebView2 has finished loading which reduces the amount of time the window has its initial size.

If the library could allow specifying an initial window size then that could be another way to improve user experience although a blank window would still be xvisible for a longer period of time.

This PR is a result of trial and error so I would appreciate feedback on this solution and how it could be done better.

## Screenshots

Warning: Animated images with flickering.

<details>
<summary>Before change</summary>

![before](https://user-images.githubusercontent.com/1543854/170830691-96ba3a61-6750-4d27-a4cf-599b1ddc5197.gif)

</details>

<details>
<summary>Afterchange</summary>

![after](https://user-images.githubusercontent.com/1543854/170830690-65ab97b6-748c-43e5-aea0-ac404c710a3f.gif)

</details>