### PR TITLE
Fix window shadow on macOS

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -643,10 +643,11 @@ public:
     // Main window
     if (window == nullptr) {
       m_window = ((id(*)(id, SEL))objc_msgSend)("NSWindow"_cls, "alloc"_sel);
+      unsigned int style = NSWindowStyleMaskTitled;
       m_window =
           ((id(*)(id, SEL, CGRect, int, unsigned long, int))objc_msgSend)(
               m_window, "initWithContentRect:styleMask:backing:defer:"_sel,
-              CGRectMake(0, 0, 0, 0), 0, NSBackingStoreBuffered, 0);
+              CGRectMake(0, 0, 0, 0), style, NSBackingStoreBuffered, 0);
     } else {
       m_window = (id)window;
     }


### PR DESCRIPTION
Fixes the main window not having a shadow by specifying `NSWindowStyleMaskTitled` when creating the window.

Setting the style only in `set_size` is not enough, and removing it from `set_size` also removes the title bar which is undesired.

Conclusion: Specify `NSWindowStyleMaskTitled` both when creating the window and when setting the style mask in `set_size` so that the shadow is enabled correctly for the window.

This PR closes #674.