### PR TITLE
Fix resource leaks causing hang on Windows

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1050,7 +1050,21 @@ public:
     m_controller->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
   }
 
-  virtual ~win32_edge_engine() = default;
+  virtual ~win32_edge_engine() {
+    if (m_webview) {
+      m_webview->Release();
+      m_webview = nullptr;
+    }
+    if (m_controller) {
+      m_controller->Release();
+      m_controller = nullptr;
+    }
+  }
+
+  win32_edge_engine(const win32_edge_engine &other) = delete;
+  win32_edge_engine &operator=(const win32_edge_engine &other) = delete;
+  win32_edge_engine(win32_edge_engine &&other) = delete;
+  win32_edge_engine &operator=(win32_edge_engine &&other) = delete;
 
   void run() {
     MSG msg;
@@ -1143,15 +1157,17 @@ private:
     wchar_t userDataFolder[MAX_PATH];
     PathCombineW(userDataFolder, dataPath, currentExeName);
 
+    auto handler = new webview2_com_handler(
+        wnd, cb,
+        [&](ICoreWebView2Controller *controller, ICoreWebView2 *webview) {
+          controller->AddRef();
+          webview->AddRef();
+          m_controller = controller;
+          m_webview = webview;
+          flag.clear();
+        });
     HRESULT res = CreateCoreWebView2EnvironmentWithOptions(
-        nullptr, userDataFolder, nullptr,
-        new webview2_com_handler(wnd, cb,
-                                 [&](ICoreWebView2Controller *controller) {
-                                   m_controller = controller;
-                                   m_controller->get_CoreWebView2(&m_webview);
-                                   m_webview->AddRef();
-                                   flag.clear();
-                                 }));
+        nullptr, userDataFolder, nullptr, handler);
     if (res != S_OK) {
       return false;
     }
@@ -1188,14 +1204,27 @@ private:
         public ICoreWebView2WebMessageReceivedEventHandler,
         public ICoreWebView2PermissionRequestedEventHandler {
     using webview2_com_handler_cb_t =
-        std::function<void(ICoreWebView2Controller *)>;
+        std::function<void(ICoreWebView2Controller *, ICoreWebView2 *webview)>;
 
   public:
     webview2_com_handler(HWND hwnd, msg_cb_t msgCb,
                          webview2_com_handler_cb_t cb)
         : m_window(hwnd), m_msgCb(msgCb), m_cb(cb) {}
-    ULONG STDMETHODCALLTYPE AddRef() { return 1; }
-    ULONG STDMETHODCALLTYPE Release() { return 1; }
+
+    virtual ~webview2_com_handler() = default;
+    webview2_com_handler(const webview2_com_handler &other) = delete;
+    webview2_com_handler &operator=(const webview2_com_handler &other) = delete;
+    webview2_com_handler(webview2_com_handler &&other) = delete;
+    webview2_com_handler &operator=(webview2_com_handler &&other) = delete;
+
+    ULONG STDMETHODCALLTYPE AddRef() { return ++m_ref_count; }
+    ULONG STDMETHODCALLTYPE Release() {
+      if (m_ref_count > 1) {
+        return --m_ref_count;
+      }
+      delete this;
+      return 0;
+    }
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID *ppv) {
       return S_OK;
     }
@@ -1206,15 +1235,13 @@ private:
     }
     HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                      ICoreWebView2Controller *controller) {
-      controller->AddRef();
-
       ICoreWebView2 *webview;
       ::EventRegistrationToken token;
       controller->get_CoreWebView2(&webview);
       webview->add_WebMessageReceived(this, &token);
       webview->add_PermissionRequested(this, &token);
 
-      m_cb(controller);
+      m_cb(controller, webview);
       return S_OK;
     }
     HRESULT STDMETHODCALLTYPE Invoke(
@@ -1242,6 +1269,7 @@ private:
     HWND m_window;
     msg_cb_t m_msgCb;
     webview2_com_handler_cb_t m_cb;
+    std::atomic<ULONG> m_ref_count = 0;
   };
 };
 


### PR DESCRIPTION
Reference counting is now implemented for webview2_com_handler so that
it can be released properly. The cloned pointers to ICoreWebView2Controller
and ICoreWebView2 are now being released and it is more clear when the
pointers are cloned.

These actions fix an issue where WebView2 initialization can hang for a
variable amount of time and cause tests to time out.

With the old code on my local environment, tests that use WebView2
oftentimes hang for about a minute. We have also seen how the CI job
tends to hang, likely for the same reason.

I do not think that it has anything to do with the tests themselves but
rather the right sequence of events paired with leaks in a short period
of time.

The hang happens after a successful call to
ICoreWebView2Environment::CreateCoreWebView2Controller
and before getting the webview controller in
ICoreWebView2CreateCoreWebView2ControllerCompletedHandler. No browser
instances are created while it is hanging. After some time the browser
instances (msedgewebview2.exe) suddenly appear, we get the controller
and can move on.