### PR TITLE
Exclude all C++ code when compiling in C mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ $ script/build.bat
 
 ```c
 // main.c
-#define WEBVIEW_HEADER
 #include "webview.h"
 #include <stddef.h>
 

--- a/main.c
+++ b/main.c
@@ -2,7 +2,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#define WEBVIEW_HEADER
 #include "webview.h"
 
 void myFunc(const char *seq, const char *req, void *arg) {

--- a/webview.go
+++ b/webview.go
@@ -11,7 +11,6 @@ package webview
 #cgo windows,amd64 LDFLAGS: -L./dll/x64 -lwebview -lWebView2Loader
 #cgo windows,386 LDFLAGS: -L./dll/x86 -lwebview -lWebView2Loader
 
-#define WEBVIEW_HEADER
 #include "webview.h"
 
 #include <stdlib.h>

--- a/webview.h
+++ b/webview.h
@@ -118,7 +118,6 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 
 #ifdef __cplusplus
 }
-#endif
 
 #ifndef WEBVIEW_HEADER
 
@@ -1424,5 +1423,5 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 }
 
 #endif /* WEBVIEW_HEADER */
-
+#endif /* __cplusplus */
 #endif /* WEBVIEW_H */


### PR DESCRIPTION
C++ code will not work anyway when compiling a C program so we can remove the requirement for library users to define `WEBVIEW_HEADER` when compiling C code.

C++ code is still in a `#ifndef WEBVIEW_HEADER` guard to avoid breaking compatibility with existing C++ code that defines `WEBVIEW_HEADER`.