### PR TITLE
Fixes windows size issue when using WEBVIEW_HINT_FIXED

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -505,6 +505,7 @@ public:
       gtk_window_resize(GTK_WINDOW(m_window), width, height);
     } else if (hints == WEBVIEW_HINT_FIXED) {
       gtk_window_set_default_size(GTK_WINDOW(m_window), width, height);
+      gtk_window_resize(GTK_WINDOW(m_window), width, height);
     } else {
       GdkGeometry g;
       g.min_width = g.max_width = width;

--- a/webview.h
+++ b/webview.h
@@ -504,7 +504,7 @@ public:
     if (hints == WEBVIEW_HINT_NONE) {
       gtk_window_resize(GTK_WINDOW(m_window), width, height);
     } else if (hints == WEBVIEW_HINT_FIXED) {
-      gtk_widget_set_size_request(m_window, width, height);
+      gtk_window_set_default_size(GTK_WINDOW(m_window), width, height);
     } else {
       GdkGeometry g;
       g.min_width = g.max_width = width;


### PR DESCRIPTION
There was an issue with window size when using the WEBVIEW_HINT_FIXED flag. The original function targeted widget, not the actual window and because of that, the provided size values were skewed. [gtk_window_set_default_size](https://docs.gtk.org/gtk4/method.Window.set_default_size.html) sets default window size and [gtk_window_set_resizable](https://docs.gtk.org/gtk4/method.Window.set_resizable.html) makes sure that the window cannot be resized. This combination follows the intended functionality.