### PR TITLE
Implement error codes and exceptions for error handling

### DIFF
--- a/webview_test.cc
+++ b/webview_test.cc
@@ -33,6 +33,7 @@ static void cb_terminate(webview_t w, void *arg) {
 static void test_c_api() {
   webview_t w;
   w = webview_create(false, nullptr);
+  assert(w);
   webview_set_size(w, 480, 320, 0);
   webview_set_title(w, "Test");
   webview_navigate(w, "https://github.com/zserge/webview");
@@ -130,7 +131,19 @@ static void run_with_timeout(std::function<void()> fn, int timeout_ms) {
     std::cout << "Exiting due to a timeout." << std::endl;
     exit(1);
   });
-  fn();
+  try {
+    fn();
+  } catch (const webview_exception &e) {
+    std::cout << "A webview exception was thrown with error code " << e.code()
+              << ": " << e.what() << std::endl;
+    exit(1);
+  } catch (const std::exception &e) {
+    std::cout << "An exception was thrown: " << e.what() << std::endl;
+    exit(1);
+  } catch (...) {
+    std::cout << "An unknown exception was thrown." << std::endl;
+    exit(1);
+  }
   flag_running.clear();
   timeout_thread.join();
 }

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -44,6 +44,35 @@ static void test_c_api() {
 }
 
 // =================================================================
+// TEST: ensure that C API can return error codes.
+// =================================================================
+static void test_c_api_error_codes() {
+  webview_error_code_t ec;
+
+  ec = webview_create_with_options(nullptr, nullptr);
+  assert(ec == webview_error_invalid_argument);
+
+  webview_t w;
+  webview_create_options_t options;
+  memset(&options, 0, sizeof(options));
+
+  options.api_version = WEBVIEW_MIN_API_VERSION - 1;
+  ec = webview_create_with_options(&w, &options);
+  assert(ec == webview_error_api_version_too_old);
+
+  options.api_version = WEBVIEW_API_VERSION + 1;
+  ec = webview_create_with_options(&w, &options);
+  assert(ec == webview_error_api_version_too_new);
+
+  options.api_version = WEBVIEW_API_VERSION;
+  ec = webview_create_with_options(&w, &options);
+  assert(ec == webview_error_ok);
+
+  ec = webview_destroy(w);
+  assert(ec == webview_error_ok);
+}
+
+// =================================================================
 // TEST: ensure that JS code can call native code and vice versa.
 // =================================================================
 struct test_webview : webview::browser_engine {
@@ -191,6 +220,7 @@ int main(int argc, char *argv[]) {
   std::unordered_map<std::string, std::function<void()>> all_tests = {
       {"terminate", test_terminate},
       {"c_api", test_c_api},
+      {"c_api_error_codes", test_c_api_error_codes},
       {"bidir_comms", test_bidir_comms},
       {"json", test_json}};
 #if _WIN32


### PR DESCRIPTION
With this PR I wish to propose changing the API and error handling throughout the library in a way that is intended to be backward-compatible for current users of the C API. I think this is a good place to begin discussions and where we should take it from here. I personally think we need to do something like this at some point anyway.

* Change all `void` return types to `webview_error_code_t` for the C API.
  * TODO: Make sure that binary compatibility is guaranteed (1).
* C++ API can now throws exceptions (`webview_exception`).
  * TODO: Should we allow library users to disable C++ exceptions, i.e. optionally not compile them?
* C API returns error codes by catching C++ exceptions and extracting error codes from them.
* Introduce API version checks.
* The new `webview_create_with_options` facilitates expanding the possible options that can be passed to the library, such as initial window size, whether to center the window, etc. We cannot keep adding more options to `webview_create` but there is a use case for doing so. It does not make sense to add more functions for initial options.
* I have improved the error handling for Win32 to begin with one platform and plan to expand to the other ones.

This work allows both C API and C++ API users to handle errors or at the very least detect that an error has occurred and then respond accordingly.

Other things that could be useful:

* Allow users to set an error handler for async code.

Other things to do:

* Update documentation. Needs to document possible error codes and exceptions.

## Simple test

* Compiled the library (DLL) from this PR.
* Compiled the `main.c` example from current `master`.
* Ran the old example successfully using the new DLL.

In this case the example has not been updated for the new API which simulates doing an in-place upgrade of the library without recompiling the program.

To me it makes sense that this works because any error codes shoud be returned by the library in the `rax` (x64) or `eax` (x86) register and will simply be discarded by the caller.

The only thing I am not really sure about yet is if this is guaranteed to be the case all the time. Let's say the program was compiled by a compiler that decided to use those registers for other purposes because it knew at the time that the library used `void` return types. Maybe that is not supposed to happen and maybe it's all good but I would like to know that for sure.