### PR TITLE
Fix Windows CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Add MinGW-w64 to PATH
+        run: echo PATH=%ProgramData%\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%>>%GITHUB_ENV%
+        shell: cmd
       - name: Build and run tests
         run: ./script/build.bat
         shell: cmd

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build and run tests
         run: ./script/build.bat
+        shell: cmd
 
   clang-format:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ set CGO_CXXFLAGS="-I%cd%\libs\webview2\build\native\include"
 set CGO_LDFLAGS="-L%cd%\libs\webview2\build\native\x64"
 ```
 
+> Note: Argument quoting works for Go 1.18 and later. Quotes can be removed if paths have no spaces.
+
 Save the basic Go example into your project directory:
 
 ```sh

--- a/script/build.bat
+++ b/script/build.bat
@@ -133,4 +133,5 @@ echo Running tests
 echo Running Go tests
 cd /D %src_dir%
 set CGO_ENABLED=1
+set "PATH=%PATH%;%src_dir%\dll\x64;%src_dir%\dll\x86"
 go test || exit \b

--- a/script/build.bat
+++ b/script/build.bat
@@ -122,7 +122,7 @@ cl %warning_params% ^
 
 echo Building Go examples
 mkdir build\examples\go
-set CGO_CPPFLAGS="-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
+set CGO_CXXFLAGS="-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
 set CGO_LDFLAGS="-L%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64"
 go build -ldflags="-H windowsgui" -o build\examples\go\basic.exe examples\basic.go || exit /b
 go build -ldflags="-H windowsgui" -o build\examples\go\bind.exe examples\bind.go || exit /b

--- a/script/build.bat
+++ b/script/build.bat
@@ -124,8 +124,11 @@ cl %warning_params% ^
 
 echo Building Go examples
 mkdir build\examples\go
-set CGO_CXXFLAGS="-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
-set CGO_LDFLAGS="-L%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64"
+rem Argument quoting works for Go 1.18 and later but as of 2022-06-26 GitHub Actions has Go 1.17.11.
+rem See https://go-review.googlesource.com/c/go/+/334732/
+rem TODO: Use proper quoting when GHA has Go 1.18 or later.
+set "CGO_CXXFLAGS=-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
+set "CGO_LDFLAGS=-L%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64"
 go build -ldflags="-H windowsgui" -o build\examples\go\basic.exe examples\basic.go || exit /b
 go build -ldflags="-H windowsgui" -o build\examples\go\bind.exe examples\bind.go || exit /b
 

--- a/script/build.bat
+++ b/script/build.bat
@@ -57,7 +57,7 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 		"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x86\WebView2Loader.dll.lib" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
-		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x86\webview.dll" || exit \b
+		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x86\webview.dll" || exit /b
 
 	call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
 	echo "Building webview.dll (x64)"
@@ -66,7 +66,7 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 		"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
-		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x64\webview.dll" || exit \b
+		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x64\webview.dll" || exit /b
 )
 if not exist "%build_dir%\webview.dll" (
 	copy "%src_dir%\dll\x64\webview.dll" %build_dir%
@@ -85,14 +85,14 @@ cl %warning_params% ^
 	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
-	"%src_dir%\examples\basic.cc" /link "/OUT:%build_dir%\examples\cpp\basic.exe" || exit \b
+	"%src_dir%\examples\basic.cc" /link "/OUT:%build_dir%\examples\cpp\basic.exe" || exit /b
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
-	"%src_dir%\examples\bind.cc" /link "/OUT:%build_dir%\examples\cpp\bind.exe" || exit \b
+	"%src_dir%\examples\bind.cc" /link "/OUT:%build_dir%\examples\cpp\bind.exe" || exit /b
 
 echo Building C examples (x64)
 mkdir build\examples\c
@@ -103,7 +103,7 @@ cl %warning_params% ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
 	"%src_dir%\dll\x64\webview.lib" ^
-	"%src_dir%\examples\basic.c" /link "/OUT:%build_dir%\examples\c\basic.exe" || exit \b
+	"%src_dir%\examples\basic.c" /link "/OUT:%build_dir%\examples\c\basic.exe" || exit /b
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
@@ -111,7 +111,7 @@ cl %warning_params% ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
 	"%src_dir%\dll\x64\webview.lib" ^
-	"%src_dir%\examples\bind.c" /link "/OUT:%build_dir%\examples\c\bind.exe" || exit \b
+	"%src_dir%\examples\bind.c" /link "/OUT:%build_dir%\examples\c\bind.exe" || exit /b
 
 echo Building webview_test.exe (x64)
 cl %warning_params% ^
@@ -120,7 +120,7 @@ cl %warning_params% ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
-	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit \b
+	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit /b
 
 echo Building Go examples
 mkdir build\examples\go
@@ -133,10 +133,10 @@ go build -ldflags="-H windowsgui" -o build\examples\go\basic.exe examples\basic.
 go build -ldflags="-H windowsgui" -o build\examples\go\bind.exe examples\bind.go || exit /b
 
 echo Running tests
-"%build_dir%\webview_test.exe" || exit \b
+"%build_dir%\webview_test.exe" || exit /b
 
 echo Running Go tests
 cd /D %src_dir%
 set CGO_ENABLED=1
 set "PATH=%PATH%;%src_dir%\dll\x64;%src_dir%\dll\x86"
-go test || exit \b
+go test || exit /b

--- a/script/build.bat
+++ b/script/build.bat
@@ -3,8 +3,9 @@ setlocal
 
 echo Prepare directories...
 set script_dir=%~dp0
-set src_dir=%script_dir%..
-set build_dir=%script_dir%..\build
+set script_dir=%script_dir:~0,-1%
+set src_dir=%script_dir%\..
+set build_dir=%script_dir%\..\build
 mkdir "%build_dir%"
 
 echo Webview directory: %src_dir%

--- a/script/build.bat
+++ b/script/build.bat
@@ -122,13 +122,16 @@ cl %warning_params% ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit /b
 
-echo Building Go examples
-mkdir build\examples\go
+echo Setting up environment for Go...
 rem Argument quoting works for Go 1.18 and later but as of 2022-06-26 GitHub Actions has Go 1.17.11.
 rem See https://go-review.googlesource.com/c/go/+/334732/
 rem TODO: Use proper quoting when GHA has Go 1.18 or later.
 set "CGO_CXXFLAGS=-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
 set "CGO_LDFLAGS=-L%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64"
+set CGO_ENABLED=1
+
+echo Building Go examples
+mkdir build\examples\go
 go build -ldflags="-H windowsgui" -o build\examples\go\basic.exe examples\basic.go || exit /b
 go build -ldflags="-H windowsgui" -o build\examples\go\bind.exe examples\bind.go || exit /b
 
@@ -137,6 +140,5 @@ echo Running tests
 
 echo Running Go tests
 cd /D %src_dir%
-set CGO_ENABLED=1
 set "PATH=%PATH%;%src_dir%\dll\x64;%src_dir%\dll\x86"
 go test || exit /b

--- a/script/build.bat
+++ b/script/build.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 
 echo Prepare directories...
 set script_dir=%~dp0

--- a/webview.go
+++ b/webview.go
@@ -8,7 +8,7 @@ package webview
 #cgo darwin LDFLAGS: -framework WebKit
 
 #cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++17
-#cgo windows LDFLAGS: -lWebView2Loader -lole32 -lshell32 -lshlwapi -luser32
+#cgo windows LDFLAGS: -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32
 
 #include "webview.h"
 


### PR DESCRIPTION
The Windows CI build has been broken since #773 and it has not been detected because the build has been reported as successful despite the build script exiting with a non-zero exit code.

Builds have worked in my local environment with Go 1.18 which has a fix for an issue with quotes/spaces in environment variables (e.g. `CGO_LDFLAGS`), while GitHub Actions has Go 1.17.11 currently without the [fix for that issue](https://go-review.googlesource.com/c/go/+/334732/).

I have fixed a few other things as well in the build script for Windows.