### PR TITLE
Add exe to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 webview
 webview_test
 webview-example
+*.exe
 *.o
 
 examples/scrape/scrape


### PR DESCRIPTION
Ignores e.g. `nuget.exe` on Windows. I consider this a temporary fix until we tidy up.