### PR TITLE
Fix COM handler reference counting

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1057,6 +1057,10 @@ public:
   }
 
   virtual ~win32_edge_engine() {
+    if (m_com_handler) {
+      m_com_handler->Release();
+      m_com_handler = nullptr;
+    }
     if (m_webview) {
       m_webview->Release();
       m_webview = nullptr;
@@ -1163,7 +1167,7 @@ private:
     wchar_t userDataFolder[MAX_PATH];
     PathCombineW(userDataFolder, dataPath, currentExeName);
 
-    auto handler = new webview2_com_handler(
+    m_com_handler = new webview2_com_handler(
         wnd, cb,
         [&](ICoreWebView2Controller *controller, ICoreWebView2 *webview) {
           controller->AddRef();
@@ -1173,7 +1177,7 @@ private:
           flag.clear();
         });
     HRESULT res = CreateCoreWebView2EnvironmentWithOptions(
-        nullptr, userDataFolder, nullptr, handler);
+        nullptr, userDataFolder, nullptr, m_com_handler);
     if (res != S_OK) {
       return false;
     }
@@ -1196,13 +1200,6 @@ private:
   }
 
   virtual void on_message(const std::string &msg) = 0;
-
-  HWND m_window;
-  POINT m_minsz = POINT{0, 0};
-  POINT m_maxsz = POINT{0, 0};
-  DWORD m_main_thread = GetCurrentThreadId();
-  ICoreWebView2 *m_webview = nullptr;
-  ICoreWebView2Controller *m_controller = nullptr;
 
   class webview2_com_handler
       : public ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler,
@@ -1275,8 +1272,16 @@ private:
     HWND m_window;
     msg_cb_t m_msgCb;
     webview2_com_handler_cb_t m_cb;
-    std::atomic<ULONG> m_ref_count = 0;
+    std::atomic<ULONG> m_ref_count = 1;
   };
+
+  HWND m_window;
+  POINT m_minsz = POINT{0, 0};
+  POINT m_maxsz = POINT{0, 0};
+  DWORD m_main_thread = GetCurrentThreadId();
+  ICoreWebView2 *m_webview = nullptr;
+  ICoreWebView2Controller *m_controller = nullptr;
+  webview2_com_handler *m_com_handler = nullptr;
 };
 
 } // namespace detail


### PR DESCRIPTION
The [reference counting rules](https://docs.microsoft.com/en-us/windows/win32/learnwin32/managing-the-lifetime-of-an-object#reference-counting) of COM objects state that new objects have a reference count of 1.