### PR TITLE
Fix QueryInterface implementation

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1232,7 +1232,11 @@ private:
       return 0;
     }
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID *ppv) {
-      return S_OK;
+      if (!ppv) {
+        return E_POINTER;
+      }
+      *ppv = nullptr;
+      return E_NOINTERFACE;
     }
     HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                      ICoreWebView2Environment *env) {


### PR DESCRIPTION
The COM handler class returned `S_OK` from `QueryInterface` without assigning anything to the return parameter.

The documentation for `IUnknown::QueryInterface` states the following:

* On success, `*ppvObject` contains a pointer to the requested interface.
* If the interface is unsupported, `*ppvObject` is set to `nullptr`.
* Returns `S_OK` if the interface is supported; otherwise `E_NOINTERFACE`.
* Returns `E_POINTER` if `ppvObject` is `nullptr`.

Since we do not return any valid pointer then we might as well return `E_NOINTERFACE`.