### PR TITLE
Webview unbind

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1357,14 +1357,19 @@ public:
   public:
     binding_ctx_t(binding_t *f, void *a, bool s = true)
         : callback(f), arg(a), sync(s) {}
+    // This function is called upon execution of the bound JS function
     binding_t *callback;
+    // This user-supplied argument is passed to the callback
     void *arg;
+    // This boolean expresses whether or not this binding is synchronous or asynchronous
+    // Async bindings require the user to call the resolve function, sync bindings don't
     bool sync;
   };
 
   using sync_binding_t = std::function<std::string(std::string)>;
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
+  // Synchronous bind
   void bind(const std::string &name, sync_binding_t fn) {
     if(bindings.count(name) == 0) {
       bindings[name] =
@@ -1378,6 +1383,7 @@ public:
     }
   }
 
+  // Asynchronous bind
   void bind(const std::string &name, binding_t f, void *arg) {
     if(bindings.count(name) == 0) {
       bindings[name] = new binding_ctx_t(new binding_t(f), arg, false);

--- a/webview.h
+++ b/webview.h
@@ -1371,21 +1371,21 @@ public:
 
   // Synchronous bind
   void bind(const std::string &name, sync_binding_t fn) {
-    if(bindings.count(name) == 0) {
-      bindings[name] =
-        new binding_ctx_t(new binding_t([](const std::string &seq,
-                                           const std::string &req, void *arg) {
-                            auto pair = static_cast<sync_binding_ctx_t *>(arg);
-                            pair->first->resolve(seq, 0, pair->second(req));
-                          }),
-                          new sync_binding_ctx_t(this, fn));
+    if (bindings.count(name) == 0) {
+      bindings[name] = new binding_ctx_t(
+          new binding_t(
+              [](const std::string &seq, const std::string &req, void *arg) {
+                auto pair = static_cast<sync_binding_ctx_t *>(arg);
+                pair->first->resolve(seq, 0, pair->second(req));
+              }),
+          new sync_binding_ctx_t(this, fn));
       bind_js(name);
     }
   }
 
   // Asynchronous bind
   void bind(const std::string &name, binding_t f, void *arg) {
-    if(bindings.count(name) == 0) {
+    if (bindings.count(name) == 0) {
       bindings[name] = new binding_ctx_t(new binding_t(f), arg, false);
       bind_js(name);
     }

--- a/webview.h
+++ b/webview.h
@@ -1366,20 +1366,23 @@ public:
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
   void bind(const std::string &name, sync_binding_t fn) {
-    bindings[name] =
+    if(bindings.count(name) == 0) {
+      bindings[name] =
         new binding_ctx_t(new binding_t([](const std::string &seq,
                                            const std::string &req, void *arg) {
                             auto pair = static_cast<sync_binding_ctx_t *>(arg);
                             pair->first->resolve(seq, 0, pair->second(req));
                           }),
-                          new sync_binding_ctx_t(this, fn), true);
-
-    bind_js(name);
+                          new sync_binding_ctx_t(this, fn));
+      bind_js(name);
+    }
   }
 
   void bind(const std::string &name, binding_t f, void *arg) {
-    bindings[name] = new binding_ctx_t(new binding_t(f), arg, false);
-    bind_js(name);
+    if(bindings.count(name) == 0) {
+      bindings[name] = new binding_ctx_t(new binding_t(f), arg, false);
+      bind_js(name);
+    }
   }
 
   void unbind(const std::string &name) {

--- a/webview.h
+++ b/webview.h
@@ -1355,8 +1355,8 @@ public:
   using binding_t = std::function<void(std::string, std::string, void *)>;
   class binding_ctx_t {
   public:
-    binding_ctx_t(binding_t *f, void *a, bool s = true)
-        : callback(f), arg(a), sync(s) {}
+    binding_ctx_t(binding_t *callback, void *arg, bool sync = true)
+        : callback(callback), arg(arg), sync(sync) {}
     // This function is called upon execution of the bound JS function
     binding_t *callback;
     // This user-supplied argument is passed to the callback

--- a/webview.h
+++ b/webview.h
@@ -1355,7 +1355,8 @@ public:
   using binding_t = std::function<void(std::string, std::string, void *)>;
   class binding_ctx_t {
   public:
-    binding_ctx_t(binding_t *f, void *a, bool s = true) : callback(f), arg(a), sync(s) {}
+    binding_ctx_t(binding_t *f, void *a, bool s = true)
+        : callback(f), arg(a), sync(s) {}
     binding_t *callback;
     void *arg;
     bool sync;
@@ -1365,14 +1366,13 @@ public:
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
   void bind(const std::string &name, sync_binding_t fn) {
-    bindings[name] = new binding_ctx_t(
-      new binding_t([](const std::string &seq, const std::string &req, void *arg) {
-        auto pair = static_cast<sync_binding_ctx_t *>(arg);
-        pair->first->resolve(seq, 0, pair->second(req));
-      }),
-      new sync_binding_ctx_t(this, fn),
-      true
-    );
+    bindings[name] =
+        new binding_ctx_t(new binding_t([](const std::string &seq,
+                                           const std::string &req, void *arg) {
+                            auto pair = static_cast<sync_binding_ctx_t *>(arg);
+                            pair->first->resolve(seq, 0, pair->second(req));
+                          }),
+                          new sync_binding_ctx_t(this, fn), true);
 
     bind_js(name);
   }
@@ -1388,7 +1388,7 @@ public:
       init(js);
       eval(js);
       delete bindings[name]->callback;
-      if(bindings[name]->sync) {
+      if (bindings[name]->sync) {
         delete static_cast<sync_binding_ctx_t *>(bindings[name]->arg);
       }
       delete bindings[name];

--- a/webview.h
+++ b/webview.h
@@ -1353,22 +1353,63 @@ public:
   }
 
   using binding_t = std::function<void(std::string, std::string, void *)>;
-  using binding_ctx_t = std::pair<binding_t *, void *>;
+  class binding_ctx_t {
+  public:
+    binding_ctx_t(binding_t *f, void *a, bool s = true) : callback(f), arg(a), sync(s) {}
+    binding_t *callback;
+    void *arg;
+    bool sync;
+  };
 
   using sync_binding_t = std::function<std::string(std::string)>;
   using sync_binding_ctx_t = std::pair<webview *, sync_binding_t>;
 
   void bind(const std::string &name, sync_binding_t fn) {
-    bind(
-        name,
-        [](const std::string &seq, const std::string &req, void *arg) {
-          auto pair = static_cast<sync_binding_ctx_t *>(arg);
-          pair->first->resolve(seq, 0, pair->second(req));
-        },
-        new sync_binding_ctx_t(this, fn));
+    bindings[name] = new binding_ctx_t(
+      new binding_t([](const std::string &seq, const std::string &req, void *arg) {
+        auto pair = static_cast<sync_binding_ctx_t *>(arg);
+        pair->first->resolve(seq, 0, pair->second(req));
+      }),
+      new sync_binding_ctx_t(this, fn),
+      true
+    );
+
+    bind_js(name);
   }
 
   void bind(const std::string &name, binding_t f, void *arg) {
+    bindings[name] = new binding_ctx_t(new binding_t(f), arg, false);
+    bind_js(name);
+  }
+
+  void unbind(const std::string &name) {
+    if (bindings.find(name) != bindings.end()) {
+      auto js = "delete window['" + name + "'];";
+      init(js);
+      eval(js);
+      delete bindings[name]->callback;
+      if(bindings[name]->sync) {
+        delete static_cast<sync_binding_ctx_t *>(bindings[name]->arg);
+      }
+      delete bindings[name];
+      bindings.erase(name);
+    }
+  }
+
+  void resolve(const std::string &seq, int status, const std::string &result) {
+    dispatch([seq, status, result, this]() {
+      if (status == 0) {
+        eval("window._rpc[" + seq + "].resolve(" + result +
+             "); delete window._rpc[" + seq + "]");
+      } else {
+        eval("window._rpc[" + seq + "].reject(" + result +
+             "); delete window._rpc[" + seq + "]");
+      }
+    });
+  }
+
+private:
+  void bind_js(const std::string &name) {
     auto js = "(function() { var name = '" + name + "';" + R"(
       var RPC = window._rpc = (window._rpc || {nextSeq: 1});
       window[name] = function() {
@@ -1389,34 +1430,8 @@ public:
     })())";
     init(js);
     eval(js);
-    bindings[name] = new binding_ctx_t(new binding_t(f), arg);
   }
 
-  void unbind(const std::string &name) {
-    if (bindings.find(name) != bindings.end()) {
-      auto js = "delete window['" + name + "'];";
-      init(js);
-      eval(js);
-      delete bindings[name]->first;
-      delete static_cast<sync_binding_ctx_t *>(bindings[name]->second);
-      delete bindings[name];
-      bindings.erase(name);
-    }
-  }
-
-  void resolve(const std::string &seq, int status, const std::string &result) {
-    dispatch([seq, status, result, this]() {
-      if (status == 0) {
-        eval("window._rpc[" + seq + "].resolve(" + result +
-             "); delete window._rpc[" + seq + "]");
-      } else {
-        eval("window._rpc[" + seq + "].reject(" + result +
-             "); delete window._rpc[" + seq + "]");
-      }
-    });
-  }
-
-private:
   void on_message(const std::string &msg) {
     auto seq = detail::json_parse(msg, "id", 0);
     auto name = detail::json_parse(msg, "method", 0);
@@ -1425,8 +1440,9 @@ private:
       return;
     }
     auto fn = bindings[name];
-    (*fn->first)(seq, args, fn->second);
+    (*fn->callback)(seq, args, fn->arg);
   }
+
   std::map<std::string, binding_ctx_t *> bindings;
 };
 } // namespace webview


### PR DESCRIPTION
Miss me?

Finally got some time to work on resolving #728.
To test this, add the line `webview_unbind(w, "increment");` in examples/bind.c. Then, compile it. You'll notice it segfaults and crashes as @silversquirl reported.
Now, checkout the changes I made and do the same thing. Make sure to recompile `webview.o`. You'll notice that the app runs as it should, and when clicking the button, nothing happens - score!
I had a previous PR that fixed a memory leak with the sync bindings, but it caused this segfault since the async bindings allow users to supply whatever they want as the `arg` param. Oops. Of course, if the user dynamically allocates a variable and passes it into the async `bind`, they are responsible for cleaning that up upon `unbind`. We don't expect the user to deallocate our sync_binding_ctx_t in the sync `bind` function since we made it internally.

To track async and sync bindings, I changed the `binding_ctx_t ` type to a custom class instead of using the STL pair class. I also separated JS stuff out into it's own function in anticipation of future work to fix up #731.

Feedback appreciated!

P.S. Awesome job figuring out mingw @SteffenL - compilation was a breeze!