### PR TITLE
Check _WIN32 instead of WIN32

### DIFF
--- a/examples/basic.c
+++ b/examples/basic.c
@@ -1,7 +1,11 @@
 #include "webview.h"
 #include <stddef.h>
 
-#ifdef WIN32
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+#ifdef _WIN32
 int WINAPI WinMain(HINSTANCE hInt, HINSTANCE hPrevInst, LPSTR lpCmdLine,
                    int nCmdShow) {
 #else

--- a/examples/basic.cc
+++ b/examples/basic.cc
@@ -1,6 +1,6 @@
 #include "webview.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 int WINAPI WinMain(HINSTANCE hInt, HINSTANCE hPrevInst, LPSTR lpCmdLine,
                    int nCmdShow) {
 #else

--- a/examples/bind.c
+++ b/examples/bind.c
@@ -2,6 +2,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 typedef struct {
   webview_t w;
   unsigned int count;
@@ -33,7 +37,7 @@ void increment(const char *seq, const char *req, void *arg) {
   webview_return(context->w, seq, 0, result);
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 int WINAPI WinMain(HINSTANCE hInt, HINSTANCE hPrevInst, LPSTR lpCmdLine,
                    int nCmdShow) {
 #else

--- a/examples/bind.cc
+++ b/examples/bind.cc
@@ -15,7 +15,7 @@ constexpr const auto html =
   });
 </script>)html";
 
-#ifdef WIN32
+#ifdef _WIN32
 int WINAPI WinMain(HINSTANCE hInt, HINSTANCE hPrevInst, LPSTR lpCmdLine,
                    int nCmdShow) {
 #else


### PR DESCRIPTION
With MSVC, `_WIN32` is always defined while `WIN32` is only defined after including the `Windows.h` header. Since the C examples did not include the Windows header then `WIN32` was not defined and therefore the executable did not use the proper `WinMain` entry point.