### PR TITLE
Refactoring for macOS

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -796,10 +796,7 @@ private:
                     (IMP)(+[](id, SEL, id) -> BOOL { return 1; }), "c@:@");
     class_addMethod(cls, "userContentController:didReceiveScriptMessage:"_sel,
                     (IMP)(+[](id self, SEL, id, id msg) {
-                      auto w =
-                          (cocoa_wkwebview_engine *)objc_getAssociatedObject(
-                              self, "webview");
-                      assert(w);
+                      auto w = get_associated_webview(self);
                       w->on_message(((const char *(*)(id, SEL))objc_msgSend)(
                           ((id(*)(id, SEL))objc_msgSend)(msg, "body"_sel),
                           "UTF8String"_sel));
@@ -811,6 +808,12 @@ private:
   static id get_shared_application() {
     return ((id(*)(id, SEL))objc_msgSend)("NSApplication"_cls,
                                           "sharedApplication"_sel);
+  }
+  static cocoa_wkwebview_engine *get_associated_webview(id object) {
+    auto w =
+        (cocoa_wkwebview_engine *)objc_getAssociatedObject(object, "webview");
+    assert(w);
+    return w;
   }
   id m_window;
   id m_webview;

--- a/webview.h
+++ b/webview.h
@@ -610,8 +610,7 @@ class cocoa_wkwebview_engine {
 public:
   cocoa_wkwebview_engine(bool debug, void *window) {
     // Application
-    id app = ((id(*)(id, SEL))objc_msgSend)("NSApplication"_cls,
-                                            "sharedApplication"_sel);
+    auto app = get_shared_application();
     ((void (*)(id, SEL, long))objc_msgSend)(
         app, "setActivationPolicy:"_sel, NSApplicationActivationPolicyRegular);
     // Delegate
@@ -705,8 +704,7 @@ public:
                                           nullptr);
   }
   void run() {
-    id app = ((id(*)(id, SEL))objc_msgSend)("NSApplication"_cls,
-                                            "sharedApplication"_sel);
+    auto app = get_shared_application();
     dispatch([&]() {
       ((void (*)(id, SEL, BOOL))objc_msgSend)(
           app, "activateIgnoringOtherApps:"_sel, 1);
@@ -809,6 +807,10 @@ private:
                     "v@:@@");
     objc_registerClassPair(cls);
     return ((id(*)(id, SEL))objc_msgSend)((id)cls, "new"_sel);
+  }
+  static id get_shared_application() {
+    return ((id(*)(id, SEL))objc_msgSend)("NSApplication"_cls,
+                                          "sharedApplication"_sel);
   }
   id m_window;
   id m_webview;


### PR DESCRIPTION
Splits some code into functions to improve readability and to avoid duplicate code.

* App delegate creation has been moved into `create_app_delegate()`.
* Retrieval of the shared `NSApplication` instance has been moved into `get_shared_application()`.
* Retrieval of the associated `cocoa_wkwebview_engine` instance from the app delegate has been moved into `get_associated_webview()`.