### PR TITLE
Fix crash when WebView2 runtime not installed

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1026,6 +1026,9 @@ inline bool enable_dpi_awareness() {
 class win32_edge_engine {
 public:
   win32_edge_engine(bool debug, void *window) {
+    if (!is_webview2_available()) {
+      return;
+    }
     if (!m_com_init.is_initialized()) {
       return;
     }
@@ -1249,6 +1252,15 @@ private:
     m_controller->put_Bounds(bounds);
   }
 
+  static bool is_webview2_available() noexcept {
+    LPWSTR version_info = nullptr;
+    auto res =
+        GetAvailableCoreWebView2BrowserVersionString(nullptr, &version_info);
+    // The result will be equal to HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+    // if the WebView2 runtime is not installed.
+    return SUCCEEDED(res) && version_info;
+  }
+
   virtual void on_message(const std::string &msg) = 0;
 
   class webview2_com_handler
@@ -1333,7 +1345,7 @@ private:
   // CreateCoreWebView2EnvironmentWithOptions.
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init{COINIT_APARTMENTTHREADED};
-  HWND m_window;
+  HWND m_window = NULL;
   POINT m_minsz = POINT{0, 0};
   POINT m_maxsz = POINT{0, 0};
   DWORD m_main_thread = GetCurrentThreadId();


### PR DESCRIPTION
This fixes an issue on Windows where webview construction would cause the program to crash when the WebView2 runtime was not installed. `webview_create` now returns null this case.

`CreateCoreWebView2EnvironmentWithOptions` would return `HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)` (`0x80070002`); the value returned by `embed()` (`false`) would not be checked in the constructor of `win32_edge_engine`; it would then crash when attempting to call `MoveFocus()` via `m_controller` which was `nullptr`.

This fix does not add a check for `embed()` but instead checks much earlier if the WebView2 runtime is available, avoiding creating the window just to destroy it again.

We should still check the return value of `embed()` but this simple fix requires less testing and can therefore be merged sooner.

Closes #799.