### PR TITLE
Return arg when unbinding

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1550,7 +1550,7 @@ WEBVIEW_API void webview_bind(webview_t w, const char *name,
 }
 
 WEBVIEW_API void *webview_unbind(webview_t w, const char *name) {
-  static_cast<webview::webview *>(w)->unbind(name);
+  return static_cast<webview::webview *>(w)->unbind(name);
 }
 
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,


### PR DESCRIPTION
This will resolve #730. Please see the discussion there.

To test, modify the bind.c example to malloc an argument, bind, unbind, and free.

> webview_t w = webview_create(0, NULL);
context_t *context = malloc (sizeof(context_t));
context->w = w;
context->count = 0;
webview_set_title(w, "Bind Example");
webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
webview_bind(w, "increment", increment, context);
void* arg = webview_unbind(w, "increment");
free(arg);