### PR TITLE
Fix macOS app bundle info

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Distribution of your app is outside the scope of this library but we can give so
 A minimalistic bundle typically has the following directory structure:
 
 ```
-example.app                 bundle (zip archive)
+example.app                 bundle
 └── Contents
     ├── Info.plist          information property list
     ├── MacOS


### PR DESCRIPTION
The bundles themselves are just directories, not zip archives.