### PR TITLE
Reorder macOS app initialization

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -777,6 +777,7 @@ private:
           app, "setActivationPolicy:"_sel,
           NSApplicationActivationPolicyRegular);
       // Activate the app regardless of other active apps.
+      // This can be obtrusive so we only do it when necessary.
       ((void (*)(id, SEL, BOOL))objc_msgSend)(
           app, "activateIgnoringOtherApps:"_sel, 1);
     }


### PR DESCRIPTION
Notable changes:

* Set the activation policy only if the app is not bundled.
* Activate the app only if the app is not bundled.
* Whether the app is bundled is determined by checking whether the bundle path has the `.app` suffix.
  * Note: Launching the executable directly within the bundle will cause `is_app_bundled()` to return `true` and therefore the app will not attempt to activate itself, but I do not really see it as a problem.
* `run()` no longer calls `dispatch` in order to invoke of `activateIgnoringOtherApps:` after the main run loop has started. Instead `applicationDidFinishLaunching:` is handled and the app is activated there.
* The constructor of `cocoa_wkwebview_engine` no longer creates the window. It is now done in `applicationDidFinishLaunching:`.
* The constructor of `cocoa_wkwebview_engine` temporarily starts the main run loop in order to handle `applicationDidFinishLaunching:`. The main run loop is then stopped again when handling `applicationDidFinishLaunching:` in order to return from the constructor and let the user call `run()` to resume the run loop.

With the exception of restarting the run loop, I believe this is a more natural flow for macOS apps given that Objective-C projects created with Xcode are set up to call [`NSApplicationMain`](https://developer.apple.com/documentation/appkit/1428499-nsapplicationmain) which creates the app, loads the main nib file from the bundle and starts the main run loop.

[`applicationDidFinishLaunching:`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428385-applicationdidfinishlaunching?language=objc) is meant for performing further initialization and will be called after the main run loop has started but before it has processed any events.