### PR TITLE
Avoid copy-constructor of std::atomic

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1196,7 +1196,7 @@ private:
   HWND m_window;
   msg_cb_t m_msgCb;
   webview2_com_handler_cb_t m_cb;
-  std::atomic<ULONG> m_ref_count = 1;
+  std::atomic<ULONG> m_ref_count{1};
 };
 
 class win32_edge_engine {


### PR DESCRIPTION
When compiling the library on Windows in C++14 mode using clang 14 from WinLibs' version of MinGW-w64, existing code would fail to compile due to `atomic(const atomic&)` being explicitly deleted.

The error is in the `atomic` header from Visual Studio 2022.

Using the normal constructor instead fixes the problem.