### PR TITLE
Add library version

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -44,6 +44,16 @@
 #define WEBVIEW_VERSION_PATCH 0
 #endif
 
+#ifndef WEBVIEW_VERSION_PRE_RELEASE
+// SemVer 2.0.0 pre-release labels prefixed with "-".
+#define WEBVIEW_VERSION_PRE_RELEASE ""
+#endif
+
+#ifndef WEBVIEW_VERSION_BUILD_METADATA
+// SemVer 2.0.0 build metadata prefixed with "+".
+#define WEBVIEW_VERSION_BUILD_METADATA ""
+#endif
+
 // Utility macro for stringifying a macro argument.
 #define WEBVIEW_STRINGIFY(x) #x
 
@@ -54,16 +64,6 @@
   WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_MAJOR)                          \
   "." WEBVIEW_EXPAND_AND_STRINGIFY(                                            \
       WEBVIEW_VERSION_MINOR) "." WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_PATCH)
-
-#ifndef WEBVIEW_VERSION_PRE_RELEASE
-// SemVer 2.0.0 pre-release labels prefixed with "-".
-#define WEBVIEW_VERSION_PRE_RELEASE ""
-#endif
-
-#ifndef WEBVIEW_VERSION_BUILD_METADATA
-// SemVer 2.0.0 build metadata prefixed with "+".
-#define WEBVIEW_VERSION_BUILD_METADATA ""
-#endif
 
 #define WEBVIEW_FULL_VERSION_STRING                                            \
   WEBVIEW_VERSION_STRING WEBVIEW_VERSION_PRE_RELEASE                           \

--- a/webview.h
+++ b/webview.h
@@ -66,7 +66,7 @@
   "." WEBVIEW_EXPAND_AND_STRINGIFY(                                            \
       WEBVIEW_VERSION_MINOR) "." WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_PATCH)
 
-// Holds the library's version information.
+// Holds the elements of a MAJOR.MINOR.PATCH version number.
 typedef struct {
   // Major version.
   unsigned int major;
@@ -74,6 +74,12 @@ typedef struct {
   unsigned int minor;
   // Patch version.
   unsigned int patch;
+} webview_version_t;
+
+// Holds the library's version information.
+typedef struct {
+  // The elements of the version number.
+  webview_version_t elements;
   // SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
   const char *version;
   // SemVer 2.0.0 pre-release labels prefixed with "-" if specified, otherwise
@@ -453,9 +459,10 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 
 inline const webview_version_info_t *get_version() {
   static constexpr webview_version_info_t version_info{
-      WEBVIEW_VERSION_MAJOR,       WEBVIEW_VERSION_MINOR,
-      WEBVIEW_VERSION_PATCH,       WEBVIEW_VERSION_STRING,
-      WEBVIEW_VERSION_PRE_RELEASE, WEBVIEW_VERSION_BUILD_METADATA};
+      {WEBVIEW_VERSION_MAJOR, WEBVIEW_VERSION_MINOR, WEBVIEW_VERSION_PATCH},
+      WEBVIEW_VERSION_STRING,
+      WEBVIEW_VERSION_PRE_RELEASE,
+      WEBVIEW_VERSION_BUILD_METADATA};
   return &version_info;
 }
 

--- a/webview.h
+++ b/webview.h
@@ -69,12 +69,6 @@
   WEBVIEW_VERSION_STRING WEBVIEW_VERSION_PRE_RELEASE                           \
       WEBVIEW_VERSION_BUILD_METADATA
 
-// Checks whether the MAJOR.MINOR version number in the library's header
-// is greater or equal to the specified MAJOR.MINOR version number.
-#define WEBVIEW_VERSION_AT_LEAST(major, minor)                                 \
-  ((WEBVIEW_VERSION_MAJOR == (major)) ? (WEBVIEW_VERSION_MINOR >= (minor))     \
-                                      : (WEBVIEW_VERSION_MAJOR > (major)))
-
 // Holds the library's version information.
 typedef struct {
   // Major version.

--- a/webview.h
+++ b/webview.h
@@ -451,6 +451,14 @@ inline std::string json_parse(const std::string &s, const std::string &key,
   return "";
 }
 
+inline const webview_version_info_t *get_version() {
+  static constexpr webview_version_info_t version_info{
+      WEBVIEW_VERSION_MAJOR,       WEBVIEW_VERSION_MINOR,
+      WEBVIEW_VERSION_PATCH,       WEBVIEW_VERSION_STRING,
+      WEBVIEW_VERSION_PRE_RELEASE, WEBVIEW_VERSION_BUILD_METADATA};
+  return &version_info;
+}
+
 } // namespace detail
 
 WEBVIEW_DEPRECATED_PRIVATE
@@ -1749,11 +1757,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 }
 
 WEBVIEW_API const webview_version_info_t *webview_version() {
-  static constexpr webview_version_info_t version_info{
-      WEBVIEW_VERSION_MAJOR,       WEBVIEW_VERSION_MINOR,
-      WEBVIEW_VERSION_PATCH,       WEBVIEW_VERSION_STRING,
-      WEBVIEW_VERSION_PRE_RELEASE, WEBVIEW_VERSION_BUILD_METADATA};
-  return &version_info;
+  return webview::detail::get_version();
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview.h
+++ b/webview.h
@@ -60,6 +60,7 @@
 // Utility macro for stringifying the result of a macro argument expansion.
 #define WEBVIEW_EXPAND_AND_STRINGIFY(x) WEBVIEW_STRINGIFY(x)
 
+// SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
 #define WEBVIEW_VERSION_STRING                                                 \
   WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_MAJOR)                          \
   "." WEBVIEW_EXPAND_AND_STRINGIFY(                                            \
@@ -177,6 +178,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result);
 
 // Get the library's version information.
+// @since 0.10
 WEBVIEW_API const webview_version_info_t *webview_version();
 
 #ifdef __cplusplus

--- a/webview.h
+++ b/webview.h
@@ -69,14 +69,11 @@
   WEBVIEW_VERSION_STRING WEBVIEW_VERSION_PRE_RELEASE                           \
       WEBVIEW_VERSION_BUILD_METADATA
 
-// Checks whether the MAJOR.MINOR.PATCH version number in the library's header
-// is greater or equal to the specified MAJOR.MINOR.PATCH version number.
-#define WEBVIEW_VERSION_AT_LEAST(major, minor, patch)                          \
-  ((WEBVIEW_VERSION_MAJOR == (major))                                          \
-       ? ((WEBVIEW_VERSION_MINOR == (minor))                                   \
-              ? (WEBVIEW_VERSION_PATCH >= (patch))                             \
-              : (WEBVIEW_VERSION_MINOR > (minor)))                             \
-       : (WEBVIEW_VERSION_MAJOR > (major)))
+// Checks whether the MAJOR.MINOR version number in the library's header
+// is greater or equal to the specified MAJOR.MINOR version number.
+#define WEBVIEW_VERSION_AT_LEAST(major, minor)                                 \
+  ((WEBVIEW_VERSION_MAJOR == (major)) ? (WEBVIEW_VERSION_MINOR >= (minor))     \
+                                      : (WEBVIEW_VERSION_MAJOR > (major)))
 
 // Holds the library's version information.
 typedef struct {

--- a/webview.h
+++ b/webview.h
@@ -88,9 +88,10 @@ typedef struct {
   unsigned int patch;
   // SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
   const char *version;
-  // SemVer 2.0.0 pre-release labels prefixed with "-".
+  // SemVer 2.0.0 pre-release labels prefixed with "-" if specified, otherwise
+  // an empty string.
   const char *pre_release;
-  // SemVer 2.0.0 build metadata prefixed with "+".
+  // SemVer 2.0.0 build metadata prefixed with "+", otherwise an empty string.
   const char *build_metadata;
 } webview_version_info_t;
 
@@ -182,7 +183,7 @@ WEBVIEW_API void webview_unbind(webview_t w, const char *name);
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result);
 
-// Get the version information of the library.
+// Get the library's version information.
 WEBVIEW_API const webview_version_info_t *webview_version();
 
 #ifdef __cplusplus

--- a/webview.h
+++ b/webview.h
@@ -61,7 +61,7 @@
 #define WEBVIEW_EXPAND_AND_STRINGIFY(x) WEBVIEW_STRINGIFY(x)
 
 // SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
-#define WEBVIEW_VERSION_STRING                                                 \
+#define WEBVIEW_VERSION_NUMBER                                                 \
   WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_MAJOR)                          \
   "." WEBVIEW_EXPAND_AND_STRINGIFY(                                            \
       WEBVIEW_VERSION_MINOR) "." WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_PATCH)
@@ -79,9 +79,9 @@ typedef struct {
 // Holds the library's version information.
 typedef struct {
   // The elements of the version number.
-  webview_version_t elements;
+  webview_version_t version;
   // SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
-  const char version[32];
+  const char version_number[32];
   // SemVer 2.0.0 pre-release labels prefixed with "-" if specified, otherwise
   // an empty string.
   const char pre_release[48];
@@ -235,7 +235,7 @@ namespace detail {
 // The library's version information.
 constexpr const webview_version_info_t library_version_info{
     {WEBVIEW_VERSION_MAJOR, WEBVIEW_VERSION_MINOR, WEBVIEW_VERSION_PATCH},
-    WEBVIEW_VERSION_STRING,
+    WEBVIEW_VERSION_NUMBER,
     WEBVIEW_VERSION_PRE_RELEASE,
     WEBVIEW_VERSION_BUILD_METADATA};
 

--- a/webview.h
+++ b/webview.h
@@ -36,7 +36,7 @@
 
 #ifndef WEBVIEW_VERSION_MINOR
 // The current library minor version.
-#define WEBVIEW_VERSION_MINOR 11
+#define WEBVIEW_VERSION_MINOR 10
 #endif
 
 #ifndef WEBVIEW_VERSION_PATCH

--- a/webview.h
+++ b/webview.h
@@ -29,6 +29,40 @@
 #define WEBVIEW_API extern
 #endif
 
+// The current library major version.
+#define WEBVIEW_MAJOR_VERSION 0
+// The current library minor version.
+#define WEBVIEW_MINOR_VERSION 11
+// The current library patch version.
+#define WEBVIEW_PATCH_VERSION 0
+
+// Represents a MAJOR.MINOR.PATCH version number packed as a 30-bit number.
+// The least significant component of the version number (PATCH) starts with
+// the 10 least significant bits. The last two bits are unused for now and
+// must be zero.
+// @see WEBVIEW_PACK_VERSION
+// @see WEBVIEW_UNPACK_MAJOR_VERSION
+// @see WEBVIEW_UNPACK_MINOR_VERSION
+// @see WEBVIEW_UNPACK_PATCH_VERSION
+typedef unsigned int webview_packed_version_t;
+
+// Packs a MAJOR.MINOR.PATCH version number format into a 30-bit number.
+#define WEBVIEW_PACK_VERSION(major, minor, patch)                              \
+  (webview_packed_version_t)((((major)&1023) << 20) | (((minor)&1023) << 10) | \
+                             ((patch)&1023))
+
+// The current library version in packed form.
+#define WEBVIEW_VERSION                                                        \
+  WEBVIEW_PACK_VERSION(WEBVIEW_MAJOR_VERSION, WEBVIEW_MINOR_VERSION,           \
+                       WEBVIEW_PATCH_VERSION)
+
+// Extracts the major version component of a packed version number.
+#define WEBVIEW_UNPACK_MAJOR_VERSION(version) (((version) >> 20) & 1023)
+// Extracts the minor version component of a packed version number.
+#define WEBVIEW_UNPACK_MINOR_VERSION(version) (((version) >> 10) & 1023)
+// Extracts the patch version component of a packed version number.
+#define WEBVIEW_UNPACK_PATCH_VERSION(version) ((version)&1023)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,6 +150,10 @@ WEBVIEW_API void webview_unbind(webview_t w, const char *name);
 // If status is not zero - result is an error JSON object.
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result);
+
+// Get the version of the library.
+// @since 0.11
+WEBVIEW_API webview_packed_version_t webview_version();
 
 #ifdef __cplusplus
 }
@@ -1657,6 +1695,10 @@ WEBVIEW_API void webview_unbind(webview_t w, const char *name) {
 WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
                                 const char *result) {
   static_cast<webview::webview *>(w)->resolve(seq, status, result);
+}
+
+WEBVIEW_API webview_packed_version_t webview_version() {
+  return WEBVIEW_VERSION;
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview.h
+++ b/webview.h
@@ -66,10 +66,6 @@
   "." WEBVIEW_EXPAND_AND_STRINGIFY(                                            \
       WEBVIEW_VERSION_MINOR) "." WEBVIEW_EXPAND_AND_STRINGIFY(WEBVIEW_VERSION_PATCH)
 
-#define WEBVIEW_FULL_VERSION_STRING                                            \
-  WEBVIEW_VERSION_STRING WEBVIEW_VERSION_PRE_RELEASE                           \
-      WEBVIEW_VERSION_BUILD_METADATA
-
 // Holds the library's version information.
 typedef struct {
   // Major version.

--- a/webview.h
+++ b/webview.h
@@ -463,6 +463,7 @@ inline std::string json_parse(const std::string &s, const std::string &key,
   }
   return "";
 }
+
 } // namespace detail
 
 WEBVIEW_DEPRECATED_PRIVATE

--- a/webview.h
+++ b/webview.h
@@ -81,12 +81,12 @@ typedef struct {
   // The elements of the version number.
   webview_version_t elements;
   // SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
-  const char *version;
+  const char version[32];
   // SemVer 2.0.0 pre-release labels prefixed with "-" if specified, otherwise
   // an empty string.
-  const char *pre_release;
+  const char pre_release[48];
   // SemVer 2.0.0 build metadata prefixed with "+", otherwise an empty string.
-  const char *build_metadata;
+  const char build_metadata[48];
 } webview_version_info_t;
 
 #ifdef __cplusplus
@@ -457,15 +457,15 @@ inline std::string json_parse(const std::string &s, const std::string &key,
   return "";
 }
 
-inline const webview_version_info_t *get_version() {
+// Get the library's version information.
+inline const webview_version_info_t &get_version() {
   static constexpr webview_version_info_t version_info{
       {WEBVIEW_VERSION_MAJOR, WEBVIEW_VERSION_MINOR, WEBVIEW_VERSION_PATCH},
       WEBVIEW_VERSION_STRING,
       WEBVIEW_VERSION_PRE_RELEASE,
       WEBVIEW_VERSION_BUILD_METADATA};
-  return &version_info;
+  return version_info;
 }
-
 } // namespace detail
 
 WEBVIEW_DEPRECATED_PRIVATE
@@ -1764,7 +1764,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 }
 
 WEBVIEW_API const webview_version_info_t *webview_version() {
-  return webview::detail::get_version();
+  return &webview::detail::get_version();
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview.h
+++ b/webview.h
@@ -232,6 +232,13 @@ using dispatch_fn_t = std::function<void()>;
 
 namespace detail {
 
+// The library's version information.
+constexpr const webview_version_info_t library_version_info{
+    {WEBVIEW_VERSION_MAJOR, WEBVIEW_VERSION_MINOR, WEBVIEW_VERSION_PATCH},
+    WEBVIEW_VERSION_STRING,
+    WEBVIEW_VERSION_PRE_RELEASE,
+    WEBVIEW_VERSION_BUILD_METADATA};
+
 inline int json_parse_c(const char *s, size_t sz, const char *key, size_t keysz,
                         const char **value, size_t *valuesz) {
   enum {
@@ -455,16 +462,6 @@ inline std::string json_parse(const std::string &s, const std::string &key,
     }
   }
   return "";
-}
-
-// Get the library's version information.
-inline const webview_version_info_t &get_version() {
-  static constexpr webview_version_info_t version_info{
-      {WEBVIEW_VERSION_MAJOR, WEBVIEW_VERSION_MINOR, WEBVIEW_VERSION_PATCH},
-      WEBVIEW_VERSION_STRING,
-      WEBVIEW_VERSION_PRE_RELEASE,
-      WEBVIEW_VERSION_BUILD_METADATA};
-  return version_info;
 }
 } // namespace detail
 
@@ -1764,7 +1761,7 @@ WEBVIEW_API void webview_return(webview_t w, const char *seq, int status,
 }
 
 WEBVIEW_API const webview_version_info_t *webview_version() {
-  return &webview::detail::get_version();
+  return &webview::detail::library_version_info;
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -54,10 +54,10 @@ static void test_c_api() {
 static void test_c_api_version() {
   auto vi = webview_version();
   assert(vi);
-  assert(vi->elements.major == 1);
-  assert(vi->elements.minor == 2);
-  assert(vi->elements.patch == 3);
-  assert(std::string(vi->version) == "1.2.3");
+  assert(vi->version.major == 1);
+  assert(vi->version.minor == 2);
+  assert(vi->version.patch == 3);
+  assert(std::string(vi->version_number) == "1.2.3");
   assert(std::string(vi->pre_release) == "-test");
   assert(std::string(vi->build_metadata) == "+gaabbccd");
   // The function should return the same pointer when called again.

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -60,6 +60,8 @@ static void test_c_api_version() {
   assert(std::string(vi->version) == "1.2.3");
   assert(std::string(vi->pre_release) == "-test");
   assert(std::string(vi->build_metadata) == "+gaabbccd");
+  // The function should return the same pointer when called again.
+  assert(webview_version() == vi);
 }
 
 // =================================================================

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -54,9 +54,9 @@ static void test_c_api() {
 static void test_c_api_version() {
   auto vi = webview_version();
   assert(vi);
-  assert(vi->major == 1);
-  assert(vi->minor == 2);
-  assert(vi->patch == 3);
+  assert(vi->elements.major == 1);
+  assert(vi->elements.minor == 2);
+  assert(vi->elements.patch == 3);
   assert(std::string(vi->version) == "1.2.3");
   assert(std::string(vi->pre_release) == "-test");
   assert(std::string(vi->build_metadata) == "+gaabbccd");

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -137,19 +137,6 @@ static void test_json() {
   assert(J("bad", "foo", -1) == "");
 }
 
-// =================================================================
-// TEST: ensure that the WEBVIEW_VERSION_AT_LEAST macro works.
-// =================================================================
-static void test_version_at_least_macro() {
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 1));
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 2));
-  assert(!WEBVIEW_VERSION_AT_LEAST(1, 3));
-
-  assert(WEBVIEW_VERSION_AT_LEAST(0, 2));
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 2));
-  assert(!WEBVIEW_VERSION_AT_LEAST(2, 2));
-}
-
 static void run_with_timeout(std::function<void()> fn, int timeout_ms) {
   std::atomic_flag flag_running = ATOMIC_FLAG_INIT;
   flag_running.test_and_set();
@@ -213,8 +200,7 @@ int main(int argc, char *argv[]) {
       {"c_api", test_c_api},
       {"c_api_version", test_c_api_version},
       {"bidir_comms", test_bidir_comms},
-      {"json", test_json},
-      {"version_at_least_macro", test_version_at_least_macro}};
+      {"json", test_json}};
 #if _WIN32
   all_tests.emplace("win32_narrow_wide_string_conversion",
                     test_win32_narrow_wide_string_conversion);

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -57,9 +57,9 @@ static void test_c_api_version() {
   assert(vi->major == 1);
   assert(vi->minor == 2);
   assert(vi->patch == 3);
-  assert(std::string{vi->version} == "1.2.3");
-  assert(std::string{vi->pre_release} == "-test");
-  assert(std::string{vi->build_metadata} == "+gaabbccd");
+  assert(std::string(vi->version) == "1.2.3");
+  assert(std::string(vi->pre_release) == "-test");
+  assert(std::string(vi->build_metadata) == "+gaabbccd");
 }
 
 // =================================================================

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -141,17 +141,13 @@ static void test_json() {
 // TEST: ensure that the WEBVIEW_VERSION_AT_LEAST macro works.
 // =================================================================
 static void test_version_at_least_macro() {
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 2));
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 3));
-  assert(!WEBVIEW_VERSION_AT_LEAST(1, 2, 4));
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 1));
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 2));
+  assert(!WEBVIEW_VERSION_AT_LEAST(1, 3));
 
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 1, 3));
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 3));
-  assert(!WEBVIEW_VERSION_AT_LEAST(1, 3, 3));
-
-  assert(WEBVIEW_VERSION_AT_LEAST(0, 2, 3));
-  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 3));
-  assert(!WEBVIEW_VERSION_AT_LEAST(2, 2, 3));
+  assert(WEBVIEW_VERSION_AT_LEAST(0, 2));
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 2));
+  assert(!WEBVIEW_VERSION_AT_LEAST(2, 2));
 }
 
 static void run_with_timeout(std::function<void()> fn, int timeout_ms) {

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -1,6 +1,12 @@
 //bin/echo; [ $(uname) = "Darwin" ] && FLAGS="-framework Webkit" || FLAGS="$(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0)" ; c++ "$0" $FLAGS -std=c++11 -Wall -Wextra -pedantic -g -o webview_test && ./webview_test ; exit
 // +build ignore
 
+#define WEBVIEW_VERSION_MAJOR 1
+#define WEBVIEW_VERSION_MINOR 2
+#define WEBVIEW_VERSION_PATCH 3
+#define WEBVIEW_VERSION_PRE_RELEASE "-test"
+#define WEBVIEW_VERSION_BUILD_METADATA "+gaabbccd"
+
 #include "webview.h"
 
 #include <cassert>
@@ -46,7 +52,14 @@ static void test_c_api() {
 // TEST: webview_version().
 // =================================================================
 static void test_c_api_version() {
-  assert(webview_version() == WEBVIEW_VERSION);
+  auto vi = webview_version();
+  assert(vi);
+  assert(vi->major == 1);
+  assert(vi->minor == 2);
+  assert(vi->patch == 3);
+  assert(std::string{vi->version} == "1.2.3");
+  assert(std::string{vi->pre_release} == "-test");
+  assert(std::string{vi->build_metadata} == "+gaabbccd");
 }
 
 // =================================================================
@@ -125,45 +138,20 @@ static void test_json() {
 }
 
 // =================================================================
-// TEST: ensure that version packing and unpacking works.
+// TEST: ensure that the WEBVIEW_VERSION_AT_LEAST macro works.
 // =================================================================
-static void test_packed_version() {
-  auto max_uint32 = 4294967295U;
-  {
-    // Packing numbers exceeding 10 bits should truncate.
-    // Unused bits should not be set.
-    auto version = WEBVIEW_PACK_VERSION(max_uint32, max_uint32, max_uint32);
-    assert(version == 1073741823);
-  }
-  {
-    // Unpacking numbers exceeding 10 bits should truncate.
-    // All bits except unused bits should be set.
-    assert(WEBVIEW_UNPACK_MAJOR_VERSION(max_uint32) == 1023);
-    assert(WEBVIEW_UNPACK_MINOR_VERSION(max_uint32) == 1023);
-    assert(WEBVIEW_UNPACK_PATCH_VERSION(max_uint32) == 1023);
-  }
-  {
-    auto version = WEBVIEW_PACK_VERSION(1, 1, 1);
-    // The first bit of each version component should be set.
-    assert(version == 1049601);
-    assert(WEBVIEW_UNPACK_MAJOR_VERSION(version) == 1);
-    assert(WEBVIEW_UNPACK_MINOR_VERSION(version) == 1);
-    assert(WEBVIEW_UNPACK_PATCH_VERSION(version) == 1);
-  }
-  {
-    auto version = WEBVIEW_PACK_VERSION(0, 0, 0);
-    assert(version == 0);
-    assert(WEBVIEW_UNPACK_MAJOR_VERSION(version) == 0);
-    assert(WEBVIEW_UNPACK_MINOR_VERSION(version) == 0);
-    assert(WEBVIEW_UNPACK_PATCH_VERSION(version) == 0);
-  }
-  {
-    auto version = WEBVIEW_PACK_VERSION(3, 7, 15);
-    assert(version == 3152911);
-    assert(WEBVIEW_UNPACK_MAJOR_VERSION(version) == 3);
-    assert(WEBVIEW_UNPACK_MINOR_VERSION(version) == 7);
-    assert(WEBVIEW_UNPACK_PATCH_VERSION(version) == 15);
-  }
+static void test_version_at_least_macro() {
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 2));
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 3));
+  assert(!WEBVIEW_VERSION_AT_LEAST(1, 2, 4));
+
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 1, 3));
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 3));
+  assert(!WEBVIEW_VERSION_AT_LEAST(1, 3, 3));
+
+  assert(WEBVIEW_VERSION_AT_LEAST(0, 2, 3));
+  assert(WEBVIEW_VERSION_AT_LEAST(1, 2, 3));
+  assert(!WEBVIEW_VERSION_AT_LEAST(2, 2, 3));
 }
 
 static void run_with_timeout(std::function<void()> fn, int timeout_ms) {
@@ -230,7 +218,7 @@ int main(int argc, char *argv[]) {
       {"c_api_version", test_c_api_version},
       {"bidir_comms", test_bidir_comms},
       {"json", test_json},
-      {"packed_version", test_packed_version}};
+      {"version_at_least_macro", test_version_at_least_macro}};
 #if _WIN32
   all_tests.emplace("win32_narrow_wide_string_conversion",
                     test_win32_narrow_wide_string_conversion);


### PR DESCRIPTION
I am submitting this PR with #707 in mind. The initial work was ripped out of #766 but I decided to rewrite it.

Feedback would be most welcome so that we do this properly the first time.

Which version would you prefer to set in this PR? It is currently set to 0.11.0 but 0.10.0 could also be a candidate.

Would you prefer a default value for `WEBVIEW_VERSION_PRE_RELEASE`?

Closes #442.

## Example 1

Program:

```cpp
// These preprocessor definitions are merely for demonstration purposes.
#define WEBVIEW_VERSION_MAJOR 1
#define WEBVIEW_VERSION_MINOR 2
#define WEBVIEW_VERSION_PATCH 3
#define WEBVIEW_VERSION_PRE_RELEASE "-dev"
#define WEBVIEW_VERSION_BUILD_METADATA "+gdd38be8"

#include "webview.h"
#include <iostream>

int main() {
  auto vi = webview_version();
  std::cout << "major: " << vi->major << "\n"
            << "minor: " << vi->minor << "\n"
            << "patch: " << vi->patch << "\n"
            << "version: " << vi->version << vi->pre_release
            << vi->build_metadata << "\n"
            << std::flush;
  return 0;
}
```

Output:

```
major: 1
minor: 2
patch: 3
version: 1.2.3-dev+gdd38be8
```

## Example 2

Program:

```cpp
#include "webview.h"
#include <iostream>

int main() {
  auto vi = webview_version();
  std::cout << "major: " << vi->major << "\n"
            << "minor: " << vi->minor << "\n"
            << "patch: " << vi->patch << "\n"
            << "version: " << vi->version << vi->pre_release
            << vi->build_metadata << "\n"
            << std::flush;
  return 0;
}
```

Output:

```
major: 0
minor: 11
patch: 0
version: 0.11.0
```