### PR TITLE
Returns nil in Go/NewWindow when C.webview_create returns NULL

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -139,11 +139,14 @@ func New(debug bool) WebView { return NewWindow(debug, nil) }
 // a pointer to the native window handle. If it's non-null - then child WebView is
 // embedded into the given parent window. Otherwise a new window is created.
 // Depending on the platform, a GtkWindow, NSWindow or HWND pointer can be passed
-// here.
+// here. Returns nil on failure. Creation can fail for various reasons such as when
+// required runtime dependencies are missing or when window creation fails.
 func NewWindow(debug bool, window unsafe.Pointer) WebView {
-	w := &webview{}
-	w.w = C.webview_create(boolToInt(debug), window)
-	return w
+	res := C.webview_create(boolToInt(debug), window)
+	if res == nil {
+		return nil
+	}
+	return &webview{w: res}
 }
 
 func (w *webview) Destroy() {


### PR DESCRIPTION
This lets Go-developers utilize the recent fix in [PR 807](https://github.com/webview/webview/pull/807). webview.New will return nil when users don't have WebView2 Runtime installed. Currently when users lack the Runtime, it returns an interface with no way (at least that I was able to figure out) to check if initialization was a success, and calling Window() on it causes a crash.