### PR TITLE
Expect applicationDidFinishLaunching only when window was not passed

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -645,12 +645,17 @@ public:
                              OBJC_ASSOCIATION_ASSIGN);
     objc::msg_send<void>(app, "setDelegate:"_sel, delegate);
 
-    // Start the main run loop so that the app delegate gets the
-    // NSApplicationDidFinishLaunchingNotification notification after the run
-    // loop has started in order to perform further initialization.
-    // We need to return from this constructor so this run loop is only
-    // temporary.
-    objc::msg_send<void>(app, "run"_sel);
+    // See comments related to application lifecycle in create_app_delegate().
+    if (window) {
+      on_application_did_finish_launching(delegate, app);
+    } else {
+      // Start the main run loop so that the app delegate gets the
+      // NSApplicationDidFinishLaunchingNotification notification after the run
+      // loop has started in order to perform further initialization.
+      // We need to return from this constructor so this run loop is only
+      // temporary.
+      objc::msg_send<void>(app, "run"_sel);
+    }
   }
   virtual ~cocoa_wkwebview_engine() = default;
   void *window() { return (void *)m_window; }
@@ -737,7 +742,7 @@ public:
 
 private:
   virtual void on_message(const std::string &msg) = 0;
-  static id create_app_delegate() {
+  id create_app_delegate() {
     auto cls =
         objc_allocateClassPair((Class) "NSResponder"_cls, "AppDelegate", 0);
     class_addProtocol(cls, objc_getProtocol("NSTouchBarProvider"));
@@ -751,13 +756,20 @@ private:
               objc::msg_send<id>(msg, "body"_sel), "UTF8String"_sel));
         }),
         "v@:@@");
-    class_addMethod(cls, "applicationDidFinishLaunching:"_sel,
-                    (IMP)(+[](id self, SEL, id notification) {
-                      auto app = objc::msg_send<id>(notification, "object"_sel);
-                      auto w = get_associated_webview(self);
-                      w->on_application_did_finish_launching(self, app);
-                    }),
-                    "v@:@");
+    // If the library was not initialized with an existing window then the user
+    // is likely managing the application lifecycle and we would not get the
+    // "applicationDidFinishLaunching:" message and therefore do not need to
+    // add this method.
+    if (!m_parent_window) {
+      class_addMethod(cls, "applicationDidFinishLaunching:"_sel,
+                      (IMP)(+[](id self, SEL, id notification) {
+                        auto app =
+                            objc::msg_send<id>(notification, "object"_sel);
+                        auto w = get_associated_webview(self);
+                        w->on_application_did_finish_launching(self, app);
+                      }),
+                      "v@:@");
+    }
     objc_registerClassPair(cls);
     return objc::msg_send<id>((id)cls, "new"_sel);
   }
@@ -829,9 +841,12 @@ private:
     return !!bundled;
   }
   void on_application_did_finish_launching(id delegate, id app) {
-    // Stop the main run loop so that we can return
-    // from the constructor.
-    objc::msg_send<void>(app, "stop:"_sel, nullptr);
+    // See comments related to application lifecycle in create_app_delegate().
+    if (!m_parent_window) {
+      // Stop the main run loop so that we can return
+      // from the constructor.
+      objc::msg_send<void>(app, "stop:"_sel, nullptr);
+    }
 
     // Activate the app if it is not bundled.
     // Bundled apps launched from Finder are activated automatically but


### PR DESCRIPTION
On macOS, initializing the library with an existing window likely means that the user wants to be responsible for setting up the application, and likely means that the user intends to manage the application lifecycle. If the library waits for the "applicationDidFinishLaunching:" message in this case then it may never receive the it.

Since the library still replaces any existing app delegate with its own, this change is consistent with behavior that existed in the library before it began expecting the "applicationDidFinishLaunching:" message.