### PR TITLE
Allow linking WebView2Loader.dll explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Build a shared library with WebView2 linked statically:
 ```bat
 cl libs\webview\webview.cc /std:c++17 /EHsc /Fobuild\ ^
     /D "WEBVIEW_API=__declspec(dllexport)" ^
+    /D WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK ^
     /I libs\webview ^
     /I libs\webview2\build\native\include ^
     libs\webview2\build\native\x64\WebView2LoaderStatic.lib ^
@@ -130,6 +131,7 @@ Build the example with WebView2 linked statically:
 
 ```bat
 cl basic.cc /std:c++17 /EHsc /Fobuild\ ^
+    /D WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK ^
     /I libs\webview ^
     /I libs\webview2\build\native\include ^
     libs\webview2\build\native\x64\WebView2LoaderStatic.lib ^

--- a/README.md
+++ b/README.md
@@ -110,8 +110,10 @@ g++ basic.cc -std=c++11 -Ilibs/webview $(pkg-config --cflags --libs gtk+-3.0 web
 # macOS
 g++ basic.cc -std=c++11 -Ilibs/webview -framework WebKit -o build/basic && ./build/basic
 # Windows/MinGW
-g++ basic.cc -std=c++17 -mwindows -Ilibs/webview -Ilibs/webview2/build/native/include -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
+g++ basic.cc -std=c++17 -mwindows -Ilibs/webview -Ilibs/webview2/build/native/include -Llibs/webview2/build/native/x64 -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
 ```
+
+> Windows Tip: The library supports linking `WebView2Loader.dll` explicitly when `WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK` is defined and avoids the need for `WebView2Loader.dll.lib`.
 
 #### Bonus for Visual C++
 
@@ -120,7 +122,6 @@ Build a shared library with WebView2 linked statically:
 ```bat
 cl libs\webview\webview.cc /std:c++17 /EHsc /Fobuild\ ^
     /D "WEBVIEW_API=__declspec(dllexport)" ^
-    /D WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK ^
     /I libs\webview ^
     /I libs\webview2\build\native\include ^
     libs\webview2\build\native\x64\WebView2LoaderStatic.lib ^
@@ -131,7 +132,6 @@ Build the example with WebView2 linked statically:
 
 ```bat
 cl basic.cc /std:c++17 /EHsc /Fobuild\ ^
-    /D WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK ^
     /I libs\webview ^
     /I libs\webview2\build\native\include ^
     libs\webview2\build\native\x64\WebView2LoaderStatic.lib ^
@@ -160,7 +160,7 @@ g++ build/basic.o build/webview.o -framework WebKit -o build/basic && build/basi
 # Windows/MinGW
 g++ -c libs/webview/webview.cc -std=c++17 -Ilibs/webview2/build/native/include -o build/webview.o
 gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o
-g++ build/basic.o build/webview.o -mwindows -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
+g++ build/basic.o build/webview.o -mwindows -Llibs/webview2/build/native/x64 -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
 ```
 
 ### Getting Started with Go

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ g++ basic.cc -std=c++11 -Ilibs/webview $(pkg-config --cflags --libs gtk+-3.0 web
 # macOS
 g++ basic.cc -std=c++11 -Ilibs/webview -framework WebKit -o build/basic && ./build/basic
 # Windows/MinGW
-g++ basic.cc -std=c++17 -mwindows -Ilibs/webview -Ilibs/webview2/build/native/include -Llibs/webview2/build/native/x64 -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
+g++ basic.cc -std=c++17 -mwindows -Ilibs/webview -Ilibs/webview2/build/native/include -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
 ```
 
 #### Bonus for Visual C++
@@ -158,7 +158,7 @@ g++ build/basic.o build/webview.o -framework WebKit -o build/basic && build/basi
 # Windows/MinGW
 g++ -c libs/webview/webview.cc -std=c++17 -Ilibs/webview2/build/native/include -o build/webview.o
 gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o
-g++ build/basic.o build/webview.o -mwindows -Llibs/webview2/build/native/x64 -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
+g++ build/basic.o build/webview.o -mwindows -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
 ```
 
 ### Getting Started with Go

--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ On Windows you will need to make the WebView2 loader discoverable by cgo (see [W
 
 ```bat
 set CGO_CXXFLAGS="-I%cd%\libs\webview2\build\native\include"
-set CGO_LDFLAGS="-L%cd%\libs\webview2\build\native\x64"
 ```
 
 > **Note:** Argument quoting works for Go 1.18 and later. Quotes can be removed if paths have no spaces.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ g++ basic.cc -std=c++11 -Ilibs/webview -framework WebKit -o build/basic && ./bui
 g++ basic.cc -std=c++17 -mwindows -Ilibs/webview -Ilibs/webview2/build/native/include -Llibs/webview2/build/native/x64 -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32 -o build/basic.exe && "build/basic.exe"
 ```
 
-> Windows Tip: The library supports linking `WebView2Loader.dll` explicitly when `WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK` is defined and avoids the need for `WebView2Loader.dll.lib`.
+> Windows Tip: The library supports linking `WebView2Loader.dll` explicitly when `WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK` is defined, avoiding the need for `WebView2Loader.dll.lib`.
 
 #### Bonus for Visual C++
 

--- a/script/build.bat
+++ b/script/build.bat
@@ -127,7 +127,6 @@ rem Argument quoting works for Go 1.18 and later but as of 2022-06-26 GitHub Act
 rem See https://go-review.googlesource.com/c/go/+/334732/
 rem TODO: Use proper quoting when GHA has Go 1.18 or later.
 set "CGO_CXXFLAGS=-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
-set "CGO_LDFLAGS=-L%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64"
 set CGO_ENABLED=1
 
 rem Go needs go.mod to be in the working directory.

--- a/script/build.bat
+++ b/script/build.bat
@@ -54,8 +54,8 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 	echo Building webview.dll ^(x86^)
 	cl %warning_params% ^
 		/D "WEBVIEW_API=__declspec(dllexport)" ^
-		/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+		"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x86\WebView2Loader.dll.lib" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x86\webview.dll" || exit /b
 
@@ -63,8 +63,8 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 	echo Building webview.dll ^(x64^)
 	cl %warning_params% ^
 		/D "WEBVIEW_API=__declspec(dllexport)" ^
-		/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+		"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x64\webview.dll" || exit /b
 )
@@ -80,16 +80,16 @@ call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
 echo Building C++ examples (x64)
 mkdir "%build_dir%\examples\cpp"
 cl %warning_params% ^
-	/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
 	"%src_dir%\examples\basic.cc" /link "/OUT:%build_dir%\examples\cpp\basic.exe" || exit /b
 cl %warning_params% ^
-	/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
 	"%src_dir%\examples\bind.cc" /link "/OUT:%build_dir%\examples\cpp\bind.exe" || exit /b
@@ -99,6 +99,7 @@ mkdir "%build_dir%\examples\c"
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
 	"%src_dir%\dll\x64\webview.lib" ^
@@ -106,6 +107,7 @@ cl %warning_params% ^
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
 	"%src_dir%\dll\x64\webview.lib" ^
@@ -114,9 +116,9 @@ cl %warning_params% ^
 echo Building webview_test.exe (x64)
 cl %warning_params% ^
 	/utf-8 ^
-	/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
+	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit /b
 

--- a/script/build.bat
+++ b/script/build.bat
@@ -55,7 +55,6 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 	cl %warning_params% ^
 		/D "WEBVIEW_API=__declspec(dllexport)" ^
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-		"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x86\WebView2Loader.dll.lib" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x86\webview.dll" || exit /b
 
@@ -64,7 +63,6 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 	cl %warning_params% ^
 		/D "WEBVIEW_API=__declspec(dllexport)" ^
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-		"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x64\webview.dll" || exit /b
 )
@@ -82,14 +80,12 @@ mkdir "%build_dir%\examples\cpp"
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
 	"%src_dir%\examples\basic.cc" /link "/OUT:%build_dir%\examples\cpp\basic.exe" || exit /b
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
 	"%src_dir%\examples\bind.cc" /link "/OUT:%build_dir%\examples\cpp\bind.exe" || exit /b
@@ -99,7 +95,6 @@ mkdir "%build_dir%\examples\c"
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
 	"%src_dir%\dll\x64\webview.lib" ^
@@ -107,7 +102,6 @@ cl %warning_params% ^
 cl %warning_params% ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
 	"%src_dir%\dll\x64\webview.lib" ^
@@ -118,7 +112,6 @@ cl %warning_params% ^
 	/utf-8 ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit /b
 

--- a/script/build.bat
+++ b/script/build.bat
@@ -54,6 +54,7 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 	echo Building webview.dll ^(x86^)
 	cl %warning_params% ^
 		/D "WEBVIEW_API=__declspec(dllexport)" ^
+		/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x86\webview.dll" || exit /b
@@ -62,6 +63,7 @@ if not exist "%src_dir%\dll\x64\webview.dll" (
 	echo Building webview.dll ^(x64^)
 	cl %warning_params% ^
 		/D "WEBVIEW_API=__declspec(dllexport)" ^
+		/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
 		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x64\webview.dll" || exit /b
@@ -78,12 +80,14 @@ call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
 echo Building C++ examples (x64)
 mkdir "%build_dir%\examples\cpp"
 cl %warning_params% ^
+	/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 	"%src_dir%\dll\x64\webview.lib" ^
 	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
 	"%src_dir%\examples\basic.cc" /link "/OUT:%build_dir%\examples\cpp\basic.exe" || exit /b
 cl %warning_params% ^
+	/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 	"%src_dir%\dll\x64\webview.lib" ^
@@ -110,6 +114,7 @@ cl %warning_params% ^
 echo Building webview_test.exe (x64)
 cl %warning_params% ^
 	/utf-8 ^
+	/D WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK ^
 	/I "%src_dir%" ^
 	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
 	/std:c++17 /EHsc "/Fo%build_dir%"\ ^

--- a/webview.go
+++ b/webview.go
@@ -7,7 +7,7 @@ package webview
 #cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
 #cgo darwin LDFLAGS: -framework WebKit
 
-#cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++17
+#cgo windows CXXFLAGS: -DWEBVIEW_EDGE -DWEBVIEW_MSWEBVIEW2_EXPLICIT_LINK -std=c++17
 #cgo windows LDFLAGS: -static -lole32 -lshell32 -lshlwapi -luser32
 
 #include "webview.h"

--- a/webview.go
+++ b/webview.go
@@ -8,7 +8,7 @@ package webview
 #cgo darwin LDFLAGS: -framework WebKit
 
 #cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++17
-#cgo windows LDFLAGS: -static -lWebView2Loader.dll -lole32 -lshell32 -lshlwapi -luser32
+#cgo windows LDFLAGS: -static -lole32 -lshell32 -lshlwapi -luser32
 
 #include "webview.h"
 

--- a/webview.h
+++ b/webview.h
@@ -1353,19 +1353,11 @@ public:
   HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                    ICoreWebView2Controller *controller) {
     if (FAILED(res)) {
-      m_cb(controller, nullptr);
       return S_OK;
     }
-
     ICoreWebView2 *webview;
-    res = controller->get_CoreWebView2(&webview);
-
-    if (FAILED(res)) {
-      m_cb(controller, nullptr);
-      return S_OK;
-    }
-
     ::EventRegistrationToken token;
+    controller->get_CoreWebView2(&webview);
     webview->add_WebMessageReceived(this, &token);
     webview->add_PermissionRequested(this, &token);
 

--- a/webview.h
+++ b/webview.h
@@ -1244,12 +1244,10 @@ struct webview2_symbols {
       HRESULT(STDMETHODCALLTYPE *)(PCWSTR, LPWSTR *);
 
   static constexpr auto CreateCoreWebView2EnvironmentWithOptions =
-      webview::detail::library_symbol<
-          CreateCoreWebView2EnvironmentWithOptions_t>(
+      library_symbol<CreateCoreWebView2EnvironmentWithOptions_t>(
           "CreateCoreWebView2EnvironmentWithOptions");
   static constexpr auto GetAvailableCoreWebView2BrowserVersionString =
-      webview::detail::library_symbol<
-          GetAvailableCoreWebView2BrowserVersionString_t>(
+      library_symbol<GetAvailableCoreWebView2BrowserVersionString_t>(
           "GetAvailableCoreWebView2BrowserVersionString");
 };
 #endif

--- a/webview.h
+++ b/webview.h
@@ -1582,7 +1582,6 @@ private:
         });
     auto res = m_webview2_loader.create_environment_with_options(
         nullptr, userDataFolder, nullptr, m_com_handler);
-    });
     if (FAILED(res)) {
       return false;
     }

--- a/webview.h
+++ b/webview.h
@@ -1237,11 +1237,6 @@ struct webview2_symbols {
       HRESULT(STDMETHODCALLTYPE *)(
           PCWSTR, PCWSTR, ICoreWebView2EnvironmentOptions *,
           ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *);
-  using CreateWebViewEnvironmentWithOptionsInternal_t =
-      HRESULT(STDMETHODCALLTYPE *)(
-          bool, webview2_runtime_type, PCWSTR, IUnknown *,
-          ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *);
-  using DllCanUnloadNow_t = HRESULT(STDMETHODCALLTYPE *)();
   using GetAvailableCoreWebView2BrowserVersionString_t =
       HRESULT(STDMETHODCALLTYPE *)(PCWSTR, LPWSTR *);
 
@@ -1249,12 +1244,6 @@ struct webview2_symbols {
       webview::detail::library_symbol<
           CreateCoreWebView2EnvironmentWithOptions_t>(
           "CreateCoreWebView2EnvironmentWithOptions");
-  static constexpr auto CreateWebViewEnvironmentWithOptionsInternal =
-      webview::detail::library_symbol<
-          CreateWebViewEnvironmentWithOptionsInternal_t>(
-          "CreateWebViewEnvironmentWithOptionsInternal");
-  static constexpr auto DllCanUnloadNow =
-      webview::detail::library_symbol<DllCanUnloadNow_t>("DllCanUnloadNow");
   static constexpr auto GetAvailableCoreWebView2BrowserVersionString =
       webview::detail::library_symbol<
           GetAvailableCoreWebView2BrowserVersionString_t>(

--- a/webview.h
+++ b/webview.h
@@ -1345,16 +1345,11 @@ public:
     return E_NOINTERFACE;
   }
   HRESULT STDMETHODCALLTYPE Invoke(HRESULT res, ICoreWebView2Environment *env) {
-    if (SUCCEEDED(res)) {
-      env->CreateCoreWebView2Controller(m_window, this);
-    }
+    env->CreateCoreWebView2Controller(m_window, this);
     return S_OK;
   }
   HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                    ICoreWebView2Controller *controller) {
-    if (FAILED(res)) {
-      return S_OK;
-    }
     ICoreWebView2 *webview;
     ::EventRegistrationToken token;
     controller->get_CoreWebView2(&webview);
@@ -1583,10 +1578,6 @@ private:
     m_com_handler = new webview2_com_handler(
         wnd, cb,
         [&](ICoreWebView2Controller *controller, ICoreWebView2 *webview) {
-          if (!controller || !webview) {
-            flag.clear();
-            return;
-          }
           controller->AddRef();
           webview->AddRef();
           m_controller = controller;
@@ -1595,7 +1586,7 @@ private:
         });
     auto res = m_webview2_loader.create_environment_with_options(
         nullptr, userDataFolder, nullptr, m_com_handler);
-    if (FAILED(res)) {
+    if (res != S_OK) {
       return false;
     }
     MSG msg = {};
@@ -1603,16 +1594,13 @@ private:
       TranslateMessage(&msg);
       DispatchMessage(&msg);
     }
-    if (!m_controller || !m_webview) {
-      return false;
-    }
     ICoreWebView2Settings *settings = nullptr;
     res = m_webview->get_Settings(&settings);
-    if (FAILED(res)) {
+    if (res != S_OK) {
       return false;
     }
     res = settings->put_AreDevToolsEnabled(debug ? TRUE : FALSE);
-    if (FAILED(res)) {
+    if (res != S_OK) {
       return false;
     }
     init("window.external={invoke:s=>window.chrome.webview.postMessage(s)}");

--- a/webview.h
+++ b/webview.h
@@ -1234,6 +1234,7 @@ inline bool enable_dpi_awareness() {
 
 namespace mswebview2 {
 
+#ifndef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
 struct webview2_symbols {
   using CreateCoreWebView2EnvironmentWithOptions_t =
       HRESULT(STDMETHODCALLTYPE *)(
@@ -1251,6 +1252,7 @@ struct webview2_symbols {
           GetAvailableCoreWebView2BrowserVersionString_t>(
           "GetAvailableCoreWebView2BrowserVersionString");
 };
+#endif
 
 class loader {
 public:
@@ -1259,6 +1261,10 @@ public:
       ICoreWebView2EnvironmentOptions *env_options,
       ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
           *created_handler) const {
+#ifdef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
+    return ::CreateCoreWebView2EnvironmentWithOptions(
+        browser_dir, user_data_dir, env_options, created_handler);
+#else
     if (m_lib.is_loaded()) {
       if (auto fn = m_lib.get(
               webview2_symbols::CreateCoreWebView2EnvironmentWithOptions)) {
@@ -1266,11 +1272,15 @@ public:
       }
     }
     return S_FALSE;
+#endif
   }
 
   HRESULT
   get_available_browser_version_string(PCWSTR browser_dir,
                                        LPWSTR *version) const {
+#ifdef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
+    return ::GetAvailableCoreWebView2BrowserVersionString(browser_dir, version);
+#else
     if (m_lib.is_loaded()) {
       if (auto fn = m_lib.get(
               webview2_symbols::GetAvailableCoreWebView2BrowserVersionString)) {
@@ -1278,6 +1288,7 @@ public:
       }
     }
     return S_FALSE;
+#endif
   }
 
   bool is_browser_available() const {
@@ -1293,7 +1304,9 @@ public:
   }
 
 private:
+#ifndef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
   native_library m_lib{L"WebView2Loader.dll"};
+#endif
 };
 
 } // namespace mswebview2

--- a/webview.h
+++ b/webview.h
@@ -1353,11 +1353,19 @@ public:
   HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                    ICoreWebView2Controller *controller) {
     if (FAILED(res)) {
+      m_cb(controller, nullptr);
       return S_OK;
     }
+
     ICoreWebView2 *webview;
+    res = controller->get_CoreWebView2(&webview);
+
+    if (FAILED(res)) {
+      m_cb(controller, nullptr);
+      return S_OK;
+    }
+
     ::EventRegistrationToken token;
-    controller->get_CoreWebView2(&webview);
     webview->add_WebMessageReceived(this, &token);
     webview->add_PermissionRequested(this, &token);
 

--- a/webview.h
+++ b/webview.h
@@ -1232,6 +1232,8 @@ inline bool enable_dpi_awareness() {
   return true;
 }
 
+namespace mswebview2 {
+
 struct webview2_symbols {
   using CreateCoreWebView2EnvironmentWithOptions_t =
       HRESULT(STDMETHODCALLTYPE *)(

--- a/webview.h
+++ b/webview.h
@@ -1234,7 +1234,7 @@ inline bool enable_dpi_awareness() {
 
 namespace mswebview2 {
 
-#ifndef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
+#ifdef WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK
 struct webview2_symbols {
   using CreateCoreWebView2EnvironmentWithOptions_t =
       HRESULT(STDMETHODCALLTYPE *)(
@@ -1261,10 +1261,7 @@ public:
       ICoreWebView2EnvironmentOptions *env_options,
       ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler
           *created_handler) const {
-#ifdef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
-    return ::CreateCoreWebView2EnvironmentWithOptions(
-        browser_dir, user_data_dir, env_options, created_handler);
-#else
+#ifdef WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK
     if (m_lib.is_loaded()) {
       if (auto fn = m_lib.get(
               webview2_symbols::CreateCoreWebView2EnvironmentWithOptions)) {
@@ -1272,15 +1269,16 @@ public:
       }
     }
     return S_FALSE;
+#else
+    return ::CreateCoreWebView2EnvironmentWithOptions(
+        browser_dir, user_data_dir, env_options, created_handler);
 #endif
   }
 
   HRESULT
   get_available_browser_version_string(PCWSTR browser_dir,
                                        LPWSTR *version) const {
-#ifdef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
-    return ::GetAvailableCoreWebView2BrowserVersionString(browser_dir, version);
-#else
+#ifdef WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK
     if (m_lib.is_loaded()) {
       if (auto fn = m_lib.get(
               webview2_symbols::GetAvailableCoreWebView2BrowserVersionString)) {
@@ -1288,6 +1286,8 @@ public:
       }
     }
     return S_FALSE;
+#else
+    return ::GetAvailableCoreWebView2BrowserVersionString(browser_dir, version);
 #endif
   }
 
@@ -1304,7 +1304,7 @@ public:
   }
 
 private:
-#ifndef WEBVIEW_MSWEBVIEW2_IMPLICIT_LINK
+#ifdef WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK
   native_library m_lib{L"WebView2Loader.dll"};
 #endif
 };


### PR DESCRIPTION
According to #888, LLVM-based MinGW-w64 has a problem with linking `WebView2Loader.dll.lib` when the `-static` flag is used, which is the case when using the Go bindings.

This PR takes some bits from #783 in order to allow linking `WebView2Loader.dll` explicitly so that one can eliminate the need for the `WebView2Loader.dll.lib` file.

Note that when linking `WebView2Loader.dll` explicitly and the file isn't present then the user will no longer be presented with a message box stating that the DLL was not found. Instead of recreating such a message box, I would prefer to return an error code from the library (#766). The new behavior is acceptable to me because the readme explicitly states that one should bundle the DLL.

For now this is an opt-in feature of the core library that can be enabled by defining `WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK`.

Go bindings opt into this feature in order to improve toolchain compatibility.

Closes #888.