### PR TITLE
SWIG info and CI config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,21 @@ jobs:
         run: ./script/build.bat
         shell: cmd
 
+  swig:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [csharp, java, python, ruby]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Generate bindings with SWIG
+        run: |
+          mkdir -p "build/bindings/${{ matrix.language }}" \
+            && swig -Wall -Werror -c++ "-${{ matrix.language }}" \
+              -outdir "build/bindings/${{ matrix.language }}" \
+              -o build/bindings/${{ matrix.language }}/${{ matrix.language }}_wrap.cpp \
+              webview.i
+
   clang-format:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -318,10 +318,10 @@ Here are some examples to get you started. Unix-style command lines are used for
 
 ```sh
 mkdir -p build/bindings/{python,csharp,java,ruby}
-swig -Wall -Werror -c++ -python -outdir build/bindings/python -o build/bindings/python/python_wrap.cpp webview.i
-swig -Wall -Werror -c++ -csharp -outdir build/bindings/csharp -o build/bindings/csharp/csharp_wrap.cpp webview.i
-swig -Wall -Werror -c++ -java -outdir build/bindings/java -o build/bindings/java/java_wrap.cpp webview.i
-swig -Wall -Werror -c++ -ruby -outdir build/bindings/ruby -o build/bindings/ruby/ruby_wrap.cpp webview.i
+swig -c++ -python -outdir build/bindings/python -o build/bindings/python/python_wrap.cpp webview.i
+swig -c++ -csharp -outdir build/bindings/csharp -o build/bindings/csharp/csharp_wrap.cpp webview.i
+swig -c++ -java -outdir build/bindings/java -o build/bindings/java/java_wrap.cpp webview.i
+swig -c++ -ruby -outdir build/bindings/ruby -o build/bindings/ruby/ruby_wrap.cpp webview.i
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -310,18 +310,19 @@ V           | [malisipi/mui](https://github.com/malisipi/mui/tree/main/webview)
 
 If you wish to add bindings to the list, feel free to submit a pull request or [open an issue][issues-new].
 
-## SWIG
+## Generating Bindings
 
-Swig bindings are included if you wish to generate bindings yourself.  Examples of how to generate bindings are below.
+You can generate bindings for the library by yourself using the included SWIG interface (`webview.i`).
 
+Here are some examples to get you started. Unix-style command lines are used for conciseness.
+
+```sh
+mkdir -p build/bindings/{python,csharp,java,ruby}
+swig -Wall -Werror -c++ -python -outdir build/bindings/python -o build/bindings/python/python_wrap.cpp webview.i
+swig -Wall -Werror -c++ -csharp -outdir build/bindings/csharp -o build/bindings/csharp/csharp_wrap.cpp webview.i
+swig -Wall -Werror -c++ -java -outdir build/bindings/java -o build/bindings/java/java_wrap.cpp webview.i
+swig -Wall -Werror -c++ -ruby -outdir build/bindings/ruby -o build/bindings/ruby/ruby_wrap.cpp webview.i
 ```
-swig -c++ -python -outdir bindings/python -o bindings/python/python_wrap.cpp webview.i
-swig -c++ -csharp -outdir bindings/csharp -o bindings/csharp/csharp_wrap.cpp webview.i
-swig -c++ -java -outdir bindings/java -o bindings/java/java_wrap.cpp webview.i
-swig -c++ -ruby -outdir bindings/ruby -o bindings/ruby/ruby_wrap.cpp webview.i
-```
-
-This generates bindings in the `bindings/<lang>` folders (must be made first with `mkdir`) using the provided swig interface `webview.i`
 
 ## License
 


### PR DESCRIPTION
Changes:

* Rewrote the SWIG section the readme.
* Output to `build/bindings` directory.
* Added CI configuration for SWIG based on examples in readme.
* Added `-Wall -Werror` flags to `swig` command in CI config.