### PR TITLE
Fix parsing negative version number elements

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1120,7 +1120,8 @@ std::array<unsigned int, 4>
 parse_version(const std::basic_string<T> &version) noexcept {
   auto parse_component = [](auto sb, auto se) -> unsigned int {
     try {
-      return std::stoul(std::basic_string<T>(sb, se));
+      auto n = std::stol(std::basic_string<T>(sb, se));
+      return n < 0 ? 0 : n;
     } catch (std::exception &) {
       return 0;
     }

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -300,7 +300,7 @@ static void test_parse_version() {
   v = parse_version("0.0.0.0");
   assert(v[0] == 0 && v[1] == 0 && v[2] == 0 && v[3] == 0);
   v = parse_version("-1.-2.-3.-4");
-  assert(v[0] == -1 && v[1] == -2 && v[2] == -3 && v[3] == -4);
+  assert(v[0] == 0 && v[1] == 0 && v[2] == 0 && v[3] == 0);
   v = parse_version("a.b.c.d");
   assert(v[0] == 0 && v[1] == 0 && v[2] == 0 && v[3] == 0);
   v = parse_version("...");


### PR DESCRIPTION
When a negative version number element is parsed, set it to 0 instead.

Also avoids a sign conversion warning in the version parsing test by not comparing signed/unsigned numbers anymore.