### PR TITLE
add Move

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -80,6 +80,9 @@ type WebView interface {
 	// SetSize updates native window size. See Hint constants.
 	SetSize(w int, h int, hint Hint)
 
+	// Move update native window potision
+	Move(x int, y int)
+
 	// Navigate navigates webview to the given URL. URL may be a properly encoded data.
 	// URI. Examples:
 	// w.Navigate("https://github.com/webview/webview")
@@ -185,6 +188,10 @@ func (w *webview) SetTitle(title string) {
 
 func (w *webview) SetSize(width int, height int, hint Hint) {
 	C.webview_set_size(w.w, C.int(width), C.int(height), C.int(hint))
+}
+
+func (w *webview) Move(x int, y int) {
+	C.webview_move(w.w, C.int(x), C.int(y))
 }
 
 func (w *webview) Init(js string) {

--- a/webview.h
+++ b/webview.h
@@ -138,6 +138,9 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_size(webview_t w, int width, int height,
                                   int hints);
 
+// Move webview to the given point.
+WEBVIEW_API void webview_move(webview_t w, int x, int y);
+
 // Navigates webview to the given URL. URL may be a properly encoded data URI.
 // Examples:
 // webview_navigate(w, "https://github.com/webview/webview");
@@ -591,6 +594,10 @@ public:
       // This defines either MIN_SIZE, or MAX_SIZE, but not both:
       gtk_window_set_geometry_hints(GTK_WINDOW(m_window), nullptr, &g, h);
     }
+  }
+
+  void move(int x, int y){
+    gtk_window_move(GTK_WINDOW(m_window), x, y);
   }
 
   void navigate(const std::string &url) {
@@ -2247,6 +2254,10 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title) {
 WEBVIEW_API void webview_set_size(webview_t w, int width, int height,
                                   int hints) {
   static_cast<webview::webview *>(w)->set_size(width, height, hints);
+}
+
+WEBVIEW_API void webview_move(webview_t w, int x, int y) {
+  static_cast<webview::webview *>(w)->move(x, y);
 }
 
 WEBVIEW_API void webview_navigate(webview_t w, const char *url) {


### PR DESCRIPTION
Dear webviewers, thank you for providing an excellent project!

This PR is added to **Move** feature with **gtk_window_move** to both C and golang.
With this PR, the window can be moved to the given x, y position.
I was necessary for this feature in my project https://github.com/UedaTakeyuki/weathermap and https://github.com/UedaTakeyuki/tokyu, and confirmed working fine.

If there is any no good coding or lack of consideration, I welcome any points or suggestions. Thank you.