### PR TITLE
Make WKWebView inspectable via Safari

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1034,6 +1034,12 @@ private:
     objc::msg_send<void>(m_webview, "initWithFrame:configuration:"_sel,
                          CGRectMake(0, 0, 0, 0), config);
     objc::msg_send<void>(m_webview, "setUIDelegate:"_sel, ui_delegate);
+    if (m_debug) {
+      objc::msg_send<void>(
+          m_webview, "setInspectable:"_sel,
+          objc::msg_send<id>("NSNumber"_cls, "numberWithBool:"_sel, YES));
+    }
+
     auto script_message_handler = create_script_message_handler();
     objc::msg_send<void>(m_manager, "addScriptMessageHandler:name:"_sel,
                          script_message_handler, "external"_str);

--- a/webview.h
+++ b/webview.h
@@ -1034,10 +1034,27 @@ private:
     objc::msg_send<void>(m_webview, "initWithFrame:configuration:"_sel,
                          CGRectMake(0, 0, 0, 0), config);
     objc::msg_send<void>(m_webview, "setUIDelegate:"_sel, ui_delegate);
+
     if (m_debug) {
-      objc::msg_send<void>(
-          m_webview, "setInspectable:"_sel,
-          objc::msg_send<id>("NSNumber"_cls, "numberWithBool:"_sel, YES));
+      // Explicitly make WKWebView inspectable via Safari on OS versions that
+      // disable the feature by default (macOS 13.3 and later) and support
+      // enabling it. According to Apple, the behavior on older OS versions is
+      // for content to always be inspectable in "debug builds".
+      // Testing shows that this is true for macOS 12.6 but somehow not 10.15.
+      // https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+      if (__builtin_available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+        objc::msg_send<void>(
+            m_webview, "setInspectable:"_sel,
+            objc::msg_send<id>("NSNumber"_cls, "numberWithBool:"_sel, YES));
+      }
+#else
+#error __builtin_available not supported by compiler
+#endif
+#else
+#error __has_builtin not supported by compiler
+#endif
     }
 
     auto script_message_handler = create_script_message_handler();


### PR DESCRIPTION
This PR replaces the following PR:

* #940

This combined work makes `WKWebView` inspectable via Safari on OS versions that disable the feature by default (macOS 13.3 and later) and support enabling it.

According to Apple, the behavior on older OS versions is for content to always be inspectable in "debug builds".

Testing shows that this is true for macOS 12.6 but not macOS 10.15.

A runtime check avoids crashing the program on OS versions that do not support the `setInspectable:` selector.

## API availability

macOS | Safari | `setInspectable:`
| - | - | - |
10.15.7 | 15.6.1 | no
12.6.6 | 16.5 | no
13.4.1 | 16.5.1 | yes

## Inspectable?

macOS | Safari | default | w/devtools | w/inspectable
| - | - | - | - | - |
10.15.7 | 15.6.1 | no | no | n/a
12.6.6 | 16.5 | yes | yes | n/a
13.4.1 | 16.5.1 | no | no | yes