### PR TITLE
Rewrite build.sh script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TARGET_OS: windows
-      CC: x86_64-w64-mingw32-gcc
-      CXX: x86_64-w64-mingw32-g++
+      CC: x86_64-w64-mingw32-gcc-posix
+      CXX: x86_64-w64-mingw32-g++-posix
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       CC: gcc
       CXX: g++
+      PATCH_MSWEBVIEW2: 1
     steps:
       - uses: actions/checkout@v1
       - name: Add MinGW-w64 to PATH
@@ -52,12 +53,13 @@ jobs:
       TARGET_OS: windows
       CC: x86_64-w64-mingw32-gcc-posix
       CXX: x86_64-w64-mingw32-g++-posix
+      PATCH_MSWEBVIEW2: 1
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install mingw-w64 -y
       - name: Build
-        run: ./script/build.sh info clean deps cross_patch_mswebview2 build
+        run: ./script/build.sh info clean deps build
 
   swig:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,10 @@ jobs:
         shell: cmd
 
   build-cross-windows-on-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.image }}
     env:
       TARGET_OS: windows
       CC: x86_64-w64-mingw32-gcc-posix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,16 +31,20 @@ jobs:
 
   build-cross-windows-on-linux:
     runs-on: ubuntu-latest
+    env:
+      TARGET_OS: windows
+      CC: x86_64-w64-mingw32-gcc
+      CXX: x86_64-w64-mingw32-g++
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install mingw-w64 -y
+      - name: Fetch library dependencies
+        run: ./script/build.sh deps
+      - name: Patch MS WebView2
+        run: ./script/build.sh cross_patch_mswebview2
       - name: Build
-        run: ./script/build.sh clean deps build
-        env:
-          TARGET_OS: windows
-          CC: x86_64-w64-mingw32-gcc
-          CXX: x86_64-w64-mingw32-g++
+        run: ./script/build.sh build
 
   swig:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,19 @@ jobs:
         run: ./script/build.bat
         shell: cmd
 
+  build-cross-windows-on-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install mingw-w64 -y
+      - name: Build
+        run: ./script/build.sh clean deps build
+        env:
+          TARGET_OS: windows
+          CC: x86_64-w64-mingw32-gcc
+          CXX: x86_64-w64-mingw32-g++
+
   swig:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,12 +56,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install mingw-w64 -y
-      - name: Fetch library dependencies
-        run: ./script/build.sh deps
-      - name: Patch MS WebView2
-        run: ./script/build.sh cross_patch_mswebview2
       - name: Build
-        run: ./script/build.sh build
+        run: ./script/build.sh info clean deps cross_patch_mswebview2 build
 
   swig:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Build and run tests
         run: ./script/build.sh
 
-  build-windows:
+  build-windows-msvc:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
@@ -28,6 +28,20 @@ jobs:
       - name: Build and run tests
         run: ./script/build.bat
         shell: cmd
+
+  build-windows-mingw:
+    runs-on: windows-latest
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - uses: actions/checkout@v1
+      - name: Add MinGW-w64 to PATH
+        run: echo PATH=%ProgramData%\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%>>%GITHUB_ENV%
+        shell: cmd
+      - name: Build and run tests
+        run: ./script/build.sh
+        shell: bash
 
   build-cross-windows-on-linux:
     strategy:

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -2,7 +2,7 @@
 #include <stddef.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifdef _WIN32

--- a/examples/bind.c
+++ b/examples/bind.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <pthread.h>
 #include <unistd.h>

--- a/script/build.sh
+++ b/script/build.sh
@@ -36,9 +36,9 @@ windows_fetch_mswebview2() {
 go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
-        cgo_cxxflags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
+        cgo_cxxflags+=("'-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include'")
     fi
-    export CGO_CXXFLAGS=("${cgo_cxxflags[@]}")
+    export CGO_CXXFLAGS="${cgo_cxxflags[@]}"
     export CGO_ENABLED=1
 }
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -106,8 +106,8 @@ task_build() {
     mkdir -p build/examples/c build/examples/cc build/examples/go || true
 
     echo "Building C++ examples"
-    "${cxx_compiler}" "${project_dir}/examples/basic.cc" "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || exit 1
-    "${cxx_compiler}" "${project_dir}/examples/bind.cc" "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || exit 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || exit 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || exit 1
 
     echo "Building C examples"
     "${cxx_compiler}" -c "${cxx_compile_flags[@]}" "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || exit 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,63 +1,228 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+unix_realpath_wrapper() {
+    if [[ "${host_os}" == "macos" ]]; then
+        readlink -f "${1}" || return 1
+    else
+        realpath "${1}" || return 1
+    fi
+}
 
-DIR="$(cd "$(dirname "$0")/../" && pwd)"
-FLAGS="-Wall -Wextra -pedantic -I$DIR"
-CFLAGS="-std=c99 $FLAGS"
+windows_fetch_mswebview2() {
+    if [[ "${host_os}" == "windows" ]]; then
+        local nuget_exe=${tools_dir}/nuget/nuget.exe
+        if [[ ! -f "${nuget_exe}" ]]; then
+            mkdir -p "$(dirname "${nuget_exe}")" || return 1
+            echo "Fetching NuGet..."
+            curl -sSLo "${nuget_exe}" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe || return 1
+        fi
+    fi
+    local mswebview2_dir=${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}
+    if [[ ! -d "${mswebview2_dir}" ]]; then
+        mkdir -p "${mswebview2_dir}" || return 1
+        echo "Fetching mswebview2 ${mswebview2_version}..."
+        if [[ "${host_os}" == "windows" ]]; then
+            "${nuget_exe}" install Microsoft.Web.Webview2 -Version "${mswebview2_version}" -OutputDirectory "${libs_dir}" || return 1
+        else
+            local mswebview2_zip=${mswebview2_dir}.zip
+            if [[ ! -f "${mswebview2_zip}" ]]; then
+                curl -sSLo "${mswebview2_zip}" "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${mswebview2_version}" || return 1
+                unzip -q "${mswebview2_zip}" -d "${mswebview2_dir}" || return 1
+            fi
+        fi
+    fi
+}
 
-if [ "$(uname)" = "Darwin" ]; then
-	CXXFLAGS="-DWEBVIEW_COCOA -std=c++11 $FLAGS -framework WebKit"
+go_setup_env() {
+    # Argument quoting works for Go 1.18 and later but as of 2022-06-26 GitHub Actions has Go 1.17.11.
+    # See https://go-review.googlesource.com/c/go/+/334732/
+    # TODO: Use proper quoting when GHA has Go 1.18 or later.
+    export "CGO_CXXFLAGS=-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include"
+    export CGO_ENABLED=1
+}
+
+task_clean() {
+    if [[ -d "${build_dir}" ]]; then
+        rm -rd "${build_dir}" || return 1
+    fi
+}
+
+task_format() {
+    if command -v clang-format >/dev/null 2>&1 ; then
+        echo "Formatting..."
+        clang-format -i \
+                "${project_dir}/webview.h" \
+                "${project_dir}/webview_test.cc" \
+                "${project_dir}/examples/"*.c \
+                "${project_dir}/examples/"*.cc || return 1
+    else
+        echo "SKIP: Formatting (clang-format not installed)"
+    fi
+}
+
+task_deps() {
+    if [[ "${target_os}" == "windows" ]]; then
+        windows_fetch_mswebview2 || return 1
+    fi
+}
+
+task_check() {
+    if command -v clang-tidy >/dev/null 2>&1 ; then
+        echo "Linting..."
+        clang-tidy "${project_dir}/examples/basic.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
+        clang-tidy "${project_dir}/examples/bind.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
+        clang-tidy "${project_dir}/webview_test.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
+    else
+        echo "SKIP: Linting (clang-tidy not installed)"
+    fi
+}
+
+task_build() {
+    mkdir -p build/examples/c build/examples/cc build/examples/go || true
+
+    echo "Building C++ examples"
+    "${cxx_compiler}" "${project_dir}/examples/basic.cc" "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || exit 1
+    "${cxx_compiler}" "${project_dir}/examples/bind.cc" "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || exit 1
+
+    echo "Building C examples"
+    "${cxx_compiler}" -c "${cxx_compile_flags[@]}" "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || exit 1
+    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || exit 1
+    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || exit 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || exit 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || exit 1
+
+    echo "Building test app"
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || exit 1
+}
+
+task_test() {
+    echo "Running tests..."
+    "${build_dir}/webview_test${exe_suffix}" || return 1
+}
+
+task_go_build() {
+    if command -v go >/dev/null 2>&1 ; then
+        go_setup_env || return 1
+        echo "Building Go examples..."
+        (cd "${project_dir}" && (
+            go build -ldflags "-H windowsgui" -o "build/examples/go/basic${exe_suffix}" examples/basic.go || exit 1
+            go build -ldflags "-H windowsgui" -o "build/examples/go/bind${exe_suffix}" examples/bind.go || exit 1
+        )) || return 1
+    else
+        echo "SKIP: Go build (go not installed)"
+    fi
+}
+
+task_go_test() {
+    if command -v go >/dev/null 2>&1 ; then
+        go_setup_env || return 1
+        echo "Running Go tests..."
+        CGO_ENABLED=1 go test
+    else
+        echo "SKIP: Go tests (go not installed)"
+    fi
+}
+
+run_task() {
+    local name=${1/:/_}
+    shift
+    eval "task_${name}" "${@}" || return 1
+}
+
+# Host operating system
+if [[ -z "${HOST_OS}" ]]; then
+    if [[ "${OSTYPE}" == "msys" || "${OSTYPE}" == "cygwin" ]]; then
+        host_os=windows
+    elif [[ "$(uname)" == "Darwin" ]]; then
+        host_os=macos
+    else
+        host_os=linux
+    fi
 else
-	CXXFLAGS="-DWEBVIEW_GTK -std=c++11 $FLAGS $(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0)"
+    host_os=${HOST_OS}
 fi
 
-if command -v clang-format >/dev/null 2>&1 ; then
-	echo "Formatting..."
-	clang-format -i \
-		"$DIR/webview.h" \
-		"$DIR/webview_test.cc" \
-		"$DIR/examples/"*.c \
-		"$DIR/examples/"*.cc
+# Target operating system for cross-compilation
+if [[ -z "${TARGET_OS}" ]]; then
+    # Target OS is by default the same as the host OS
+    target_os=${host_os}
 else
-	echo "SKIP: Formatting (clang-format not installed)"
+    target_os=${TARGET_OS}
 fi
 
-if command -v clang-tidy >/dev/null 2>&1 ; then
-	echo "Linting..."
-	clang-tidy "$DIR/examples/basic.cc" -- $CXXFLAGS
-	clang-tidy "$DIR/examples/bind.cc" -- $CXXFLAGS
-	clang-tidy "$DIR/webview_test.cc" -- $CXXFLAGS
-else
-	echo "SKIP: Linting (clang-tidy not installed)"
+# Versions of dependencies
+mswebview2_version=1.0.1150.38
+
+# Default C standard
+c_std=c99
+# Default C++ standard
+cxx_std=c++11
+# Default C compiler
+c_compiler=cc
+# Default C++ compiler
+cxx_compiler=c++
+
+# C compiler override
+if [[ ! -z "${CC}" ]]; then
+    c_compiler=${CC}
 fi
 
-mkdir -p build/examples/c build/examples/cc build/examples/go || true
-
-echo "Building C++ examples"
-c++ examples/basic.cc $CXXFLAGS -o build/examples/cc/basic
-c++ examples/bind.cc $CXXFLAGS -o build/examples/cc/bind
-
-echo "Building C examples"
-c++ -c $CXXFLAGS webview.cc -o build/webview.o
-cc -c examples/basic.c $CFLAGS -o build/examples/c/basic.o
-cc -c examples/bind.c $CFLAGS -o build/examples/c/bind.o
-c++ build/examples/c/basic.o build/webview.o $CXXFLAGS -o build/examples/c/basic
-c++ build/examples/c/bind.o build/webview.o $CXXFLAGS -o build/examples/c/bind
-
-echo "Building Go examples"
-go build -o build/examples/go/basic examples/basic.go
-go build -o build/examples/go/bind examples/bind.go
-
-echo "Building test app"
-c++ webview_test.cc $CXXFLAGS -o webview_test
-
-echo "Running tests"
-./webview_test
-
-if command -v go >/dev/null 2>&1 ; then
-	echo "Running Go tests"
-	CGO_ENABLED=1 go test
-else
-	echo "SKIP: Go tests"
+# C++ compiler override
+if [[ ! -z "${CXX}" ]]; then
+    cxx_compiler=${CXX}
 fi
+
+project_dir=$(dirname "$(dirname "$(unix_realpath_wrapper "${BASH_SOURCE[0]}")")") || exit 1
+build_dir=${project_dir}/build
+external_dir=${build_dir}/external
+libs_dir=${external_dir}/libs
+tools_dir=${external_dir}/tools
+warning_flags=(-Wall -Wextra -pedantic)
+common_compile_flags=("${warning_flags[@]}" "-I${project_dir}")
+common_link_flags=("${warning_flags[@]}")
+c_compile_flags=("${common_compile_flags[@]}")
+c_link_flags=("${common_link_flags[@]}")
+cxx_compile_flags=("${common_compile_flags[@]}")
+cxx_link_flags=("${common_link_flags[@]}")
+exe_suffix=
+
+if [[ "${target_os}" == "windows" ]]; then
+    cxx_std=c++17
+fi
+
+c_compile_flags+=("-std=${c_std}")
+cxx_compile_flags+=("-std=${cxx_std}")
+
+if [[ "${target_os}" == "linux" ]]; then
+    pkgconfig_libs=(gtk+-3.0 webkit2gtk-4.0)
+    cxx_compile_flags+=($(pkg-config --cflags "${pkgconfig_libs[@]}")) || exit 1
+    cxx_link_flags+=($(pkg-config --libs "${pkgconfig_libs[@]}")) || exit 1
+elif [[ "${target_os}" == "macos" ]]; then
+    cxx_link_flags+=(-framework WebKit)
+    macos_target_version=10.9
+    c_compile_flags+=("-mmacosx-version-min=${macos_target_version}")
+    cxx_compile_flags+=("-mmacosx-version-min=${macos_target_version}")
+elif [[ "${target_os}" == "windows" ]]; then
+    exe_suffix=.exe
+    cxx_compile_flags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
+    cxx_link_flags+=(-mwindows -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion)
+fi
+
+# Default tasks
+tasks=(clean format deps check build test go:build go:test)
+
+# Task override from command line
+if [[ ${#@} -gt 0 ]]; then
+    tasks=("${@}")
+fi
+
+echo "-- C compiler: ${c_compiler}"
+echo "-- C compiler flags: ${c_compile_flags[@]}"
+echo "-- C linker flags: ${c_link_flags[@]}"
+echo "-- C++ compiler: ${cxx_compiler}"
+echo "-- C++ compiler flags: ${cxx_compile_flags[@]}"
+echo "-- C++ linker flags: ${cxx_link_flags[@]}"
+
+for task in "${tasks[@]}"; do
+    run_task "${task}" || exit 1
+done

--- a/script/build.sh
+++ b/script/build.sh
@@ -41,9 +41,9 @@ go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
         # Path must somehow be Windows-style (forward slashes are OK)
-        mswebview_include_path=$(cygpath --mixed "${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
+        mswebview_include_path=$(cygpath --mixed "${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include") || return 1
         cgo_cxxflags+=("\"-I${mswebview_include_path}\"")
-        mingw_header_path=$(cygpath --mixed "${project_dir}/webview_mingw_support.h")
+        mingw_header_path=$(cygpath --mixed "${project_dir}/webview_mingw_support.h") || return 1
         cgo_cxxflags+=("\"--include=${mingw_header_path}\"")
     fi
     export CGO_CXXFLAGS="${cgo_cxxflags[@]}"

--- a/script/build.sh
+++ b/script/build.sh
@@ -174,6 +174,16 @@ task_go_test() {
     CGO_ENABLED=1 go test
 }
 
+task_info() {
+    echo "-- Target OS: ${target_os}"
+    echo "-- C compiler: ${c_compiler}"
+    echo "-- C compiler flags: ${c_compile_flags[@]}"
+    echo "-- C linker flags: ${c_link_flags[@]}"
+    echo "-- C++ compiler: ${cxx_compiler}"
+    echo "-- C++ compiler flags: ${cxx_compile_flags[@]}"
+    echo "-- C++ linker flags: ${cxx_link_flags[@]}"
+}
+
 run_task() {
     local name=${1/:/_}
     shift
@@ -261,20 +271,12 @@ elif [[ "${target_os}" == "windows" ]]; then
 fi
 
 # Default tasks
-tasks=(clean format deps check build test go:build go:test)
+tasks=(info clean format deps check build test go:build go:test)
 
 # Task override from command line
 if [[ ${#@} -gt 0 ]]; then
     tasks=("${@}")
 fi
-
-echo "-- Target OS: ${target_os}"
-echo "-- C compiler: ${c_compiler}"
-echo "-- C compiler flags: ${c_compile_flags[@]}"
-echo "-- C linker flags: ${c_link_flags[@]}"
-echo "-- C++ compiler: ${cxx_compiler}"
-echo "-- C++ compiler flags: ${cxx_compile_flags[@]}"
-echo "-- C++ linker flags: ${cxx_link_flags[@]}"
 
 for task in "${tasks[@]}"; do
     run_task "${task}" || exit 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -57,6 +57,16 @@ is_ci() {
     return 0
 }
 
+invoke_go_build() {
+    local output=${1}
+    local input=${2}
+    local ldflags=()
+    if [[ ! -z "${3}" ]]; then
+        ldflags=("${3}")
+    fi
+    (cd "${project_dir}" && go build "${ldflags[@]}" -o "${output}" "${input}") || return 1
+}
+
 task_clean() {
     if [[ -d "${build_dir}" ]]; then
         rm -rd "${build_dir}" || return 1
@@ -126,16 +136,6 @@ task_build() {
 task_test() {
     echo "Running tests..."
     "${build_dir}/webview_test${exe_suffix}" || return 1
-}
-
-invoke_go_build() {
-    local output=${1}
-    local input=${2}
-    local ldflags=()
-    if [[ ! -z "${3}" ]]; then
-        ldflags=("${3}")
-    fi
-    (cd "${project_dir}" && go build "${ldflags[@]}" -o "${output}" "${input}") || return 1
 }
 
 task_go_build() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -37,6 +37,24 @@ windows_fetch_mswebview2() {
     fi
 }
 
+get_go_os_from_os() {
+    case "${1}" in
+        linux)
+            echo linux
+            ;;
+        macos)
+            echo darwin
+            ;;
+        windows)
+            echo windows
+            ;;
+        *)
+            echo "WARNING: Unsupported OS (${1}), assuming linux" >&2
+            echo linux
+            ;;
+    esac
+}
+
 go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
@@ -53,6 +71,10 @@ go_setup_env() {
     fi
     export CGO_CXXFLAGS="${cgo_cxxflags[@]}"
     export CGO_ENABLED=1
+    # Export GOOS only when cross-compiling
+    if [[ "${target_os}" != "${host_os}" ]]; then
+        export GOOS=$(get_go_os_from_os "${target_os}")
+    fi
 }
 
 is_ci() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -83,7 +83,8 @@ task_deps() {
 task_check() {
     if ! command -v clang-tidy >/dev/null 2>&1 ; then
         local message="Linting (clang-tidy not installed)"
-        if is_ci; then
+        # Allow skipping this task on macOS because GHA doesn't have clang-tidy installed.
+        if is_ci && [[ "${host_os}" != "macos" ]]; then
             echo "FAIL: ${message}"
             return 1
         fi

--- a/script/build.sh
+++ b/script/build.sh
@@ -30,6 +30,10 @@ windows_fetch_mswebview2() {
                 unzip -q "${mswebview2_zip}" -d "${mswebview2_dir}" || return 1
             fi
         fi
+        if [[ "${PATCH_MSWEBVIEW2}" == 1 ]]; then
+            echo "Patching mswebview2 ${mswebview2_version}..."
+            sed -i 's/#include "EventToken.h"/\/\/#include "EventToken.h"/' ${mswebview2_dir}/build/native/include/WebView2.h || return 1
+        fi
     fi
 }
 
@@ -82,11 +86,6 @@ task_deps() {
     if [[ "${target_os}" == "windows" ]]; then
         windows_fetch_mswebview2 || return 1
     fi
-}
-
-task_cross_patch_mswebview2() {
-    local mswebview2_dir=${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}
-    sed -i 's/#include "EventToken.h"/\/\/#include "EventToken.h"/' ${mswebview2_dir}/build/native/include/WebView2.h || return 1
 }
 
 task_check() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -161,6 +161,16 @@ task_build() {
 }
 
 task_test() {
+    if [[ "${target_os}" != "${host_os}" ]]; then
+        local message="Tests (target OS (${target_os}) is different from host OS (${host_os}))"
+        # Allow skipping this task on .
+        if is_ci && [[ "${host_os}" != "macos" ]]; then
+            echo "FAIL: ${message}"
+            return 1
+        fi
+        echo "SKIP: ${message}"
+        return 0
+    fi
     echo "Running tests..."
     "${build_dir}/webview_test${exe_suffix}" || return 1
 }
@@ -189,6 +199,16 @@ task_go_build() {
 }
 
 task_go_test() {
+    if [[ "${target_os}" != "${host_os}" ]]; then
+        local message="Go tests (target OS (${target_os}) is different from host OS (${host_os}))"
+        # Allow skipping this task on .
+        if is_ci && [[ "${host_os}" != "macos" ]]; then
+            echo "FAIL: ${message}"
+            return 1
+        fi
+        echo "SKIP: ${message}"
+        return 0
+    fi
     if ! command -v go >/dev/null 2>&1 ; then
         local message="Go tests (go not installed)"
         if is_ci; then

--- a/script/build.sh
+++ b/script/build.sh
@@ -40,10 +40,15 @@ windows_fetch_mswebview2() {
 go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
-        # Path must somehow be Windows-style (forward slashes are OK)
-        mswebview_include_path=$(cygpath --mixed "${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include") || return 1
+        mswebview_include_path=${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include
+        mingw_header_path=${project_dir}/webview_mingw_support.h
+        # Path must somehow be Windows-style (forward slashes are OK) if the host OS is Windows.
+        # cygpath isn't available on Ubuntu so only convert the path while on Windows.
+        if [[ "${host_os}" == "windows" ]]; then
+            mswebview_include_path=$(cygpath --mixed "${mswebview_include_path}") || return 1
+            mingw_header_path=$(cygpath --mixed "${mingw_header_path}") || return 1
+        fi
         cgo_cxxflags+=("\"-I${mswebview_include_path}\"")
-        mingw_header_path=$(cygpath --mixed "${project_dir}/webview_mingw_support.h") || return 1
         cgo_cxxflags+=("\"--include=${mingw_header_path}\"")
     fi
     export CGO_CXXFLAGS="${cgo_cxxflags[@]}"

--- a/script/build.sh
+++ b/script/build.sh
@@ -22,7 +22,7 @@ windows_fetch_mswebview2() {
         mkdir -p "${mswebview2_dir}" || return 1
         echo "Fetching mswebview2 ${mswebview2_version}..."
         if [[ "${host_os}" == "windows" ]]; then
-            "${nuget_exe}" install Microsoft.Web.Webview2 -Version "${mswebview2_version}" -OutputDirectory "${libs_dir}" || return 1
+            "${nuget_exe}" install Microsoft.Web.Webview2 -Verbosity quiet -Version "${mswebview2_version}" -OutputDirectory "${libs_dir}" || return 1
         else
             local mswebview2_zip=${mswebview2_dir}.zip
             if [[ ! -f "${mswebview2_zip}" ]]; then

--- a/script/build.sh
+++ b/script/build.sh
@@ -32,7 +32,7 @@ windows_fetch_mswebview2() {
         fi
         if [[ "${PATCH_MSWEBVIEW2}" == 1 ]]; then
             echo "Patching mswebview2 ${mswebview2_version}..."
-            sed -i 's/#include "EventToken.h"/\/\/#include "EventToken.h"/' ${mswebview2_dir}/build/native/include/WebView2.h || return 1
+            sed -i 's/#include "EventToken.h"/\/\/#include "EventToken.h"/' "${mswebview2_dir}/build/native/include/WebView2.h" || return 1
         fi
     fi
 }

--- a/script/build.sh
+++ b/script/build.sh
@@ -58,7 +58,8 @@ task_clean() {
 task_format() {
     if ! command -v clang-format >/dev/null 2>&1 ; then
         local message="Formatting (clang-format not installed)"
-        if is_ci; then
+        # Allow skipping this task on macOS because GHA doesn't have clang-format installed.
+        if is_ci && [[ "${host_os}" != "macos" ]]; then
             echo "FAIL: ${message}"
             return 1
         fi

--- a/script/build.sh
+++ b/script/build.sh
@@ -216,6 +216,7 @@ if [[ ${#@} -gt 0 ]]; then
     tasks=("${@}")
 fi
 
+echo "-- Target OS: ${target_os}"
 echo "-- C compiler: ${c_compiler}"
 echo "-- C compiler flags: ${c_compile_flags[@]}"
 echo "-- C linker flags: ${c_link_flags[@]}"

--- a/script/build.sh
+++ b/script/build.sh
@@ -37,6 +37,7 @@ go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
         cgo_cxxflags+=("'-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include'")
+        cgo_cxxflags+=(-include "'${project_dir}/webview_mingw_support.h'")
     fi
     export CGO_CXXFLAGS="${cgo_cxxflags[@]}"
     export CGO_ENABLED=1
@@ -255,11 +256,8 @@ elif [[ "${target_os}" == "macos" ]]; then
 elif [[ "${target_os}" == "windows" ]]; then
     exe_suffix=.exe
     cxx_compile_flags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
+    cxx_compile_flags+=(-include "${project_dir}/webview_mingw_support.h")
     cxx_link_flags+=(-mwindows -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion)
-    # Cross-compiling
-    if [[ "${target_os}" != "${host_os}" ]]; then
-        cxx_compile_flags+=(-include "${project_dir}/webview_mingw_support.h")
-    fi
 fi
 
 # Default tasks

--- a/script/build.sh
+++ b/script/build.sh
@@ -40,11 +40,11 @@ windows_fetch_mswebview2() {
 go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
-        cgo_cxxflags+=("'-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include'")
-        header_path=${project_dir}/webview_mingw_support.h
-        # This must somehow be a Windows-style path (forward slashes are OK)
-        header_path=$(cygpath --mixed "${header_path}")
-        cgo_cxxflags+=("'--include=${header_path}'")
+        # Path must somehow be Windows-style (forward slashes are OK)
+        mswebview_include_path=$(cygpath --mixed "${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
+        cgo_cxxflags+=("\"-I${mswebview_include_path}\"")
+        mingw_header_path=$(cygpath --mixed "${project_dir}/webview_mingw_support.h")
+        cgo_cxxflags+=("\"--include=${mingw_header_path}\"")
     fi
     export CGO_CXXFLAGS="${cgo_cxxflags[@]}"
     export CGO_ENABLED=1

--- a/script/build.sh
+++ b/script/build.sh
@@ -80,6 +80,11 @@ task_deps() {
     fi
 }
 
+task_cross_patch_mswebview2() {
+    local mswebview2_dir=${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}
+    sed -i 's/#include "EventToken.h"/\/\/#include "EventToken.h"/' ${mswebview2_dir}/build/native/include/WebView2.h || return 1
+}
+
 task_check() {
     if ! command -v clang-tidy >/dev/null 2>&1 ; then
         local message="Linting (clang-tidy not installed)"
@@ -251,6 +256,10 @@ elif [[ "${target_os}" == "windows" ]]; then
     exe_suffix=.exe
     cxx_compile_flags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
     cxx_link_flags+=(-mwindows -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion)
+    # Cross-compiling
+    if [[ "${target_os}" != "${host_os}" ]]; then
+        cxx_compile_flags+=(-include "${project_dir}/webview_mingw_support.h")
+    fi
 fi
 
 # Default tasks

--- a/script/build.sh
+++ b/script/build.sh
@@ -118,6 +118,16 @@ task_test() {
     "${build_dir}/webview_test${exe_suffix}" || return 1
 }
 
+invoke_go_build() {
+    local output=${1}
+    local input=${2}
+    local ldflags=()
+    if [[ ! -z "${3}" ]]; then
+        ldflags=("${3}")
+    fi
+    (cd "${project_dir}" && go build "${ldflags[@]}" -o "${output}" "${input}") || return 1
+}
+
 task_go_build() {
     if ! command -v go >/dev/null 2>&1 ; then
         local message="Go build (go not installed)"
@@ -130,17 +140,15 @@ task_go_build() {
     fi
     go_setup_env || return 1
     echo "Building Go examples..."
-    local go_ldflags=
+    local go_ldflags=()
     if [[ "${target_os}" == "windows" ]]; then
-        go_ldflags="-H windowsgui"
+        go_ldflags=(-H windowsgui)
     fi
-    if [[ ! -z "${go_ldflags}" ]]; then
-        go_ldflags="-ldflags \"${go_ldflags}\""
+    if [[ "${#go_ldflags}" -gt 0 ]]; then
+        go_ldflags="-ldflags=${go_ldflags[@]}"
     fi
-    (cd "${project_dir}" && (
-        go build ${go_ldflags} -o "build/examples/go/basic${exe_suffix}" examples/basic.go || exit 1
-        go build ${go_ldflags} -o "build/examples/go/bind${exe_suffix}" examples/bind.go || exit 1
-    )) || return 1
+    invoke_go_build "build/examples/go/basic${exe_suffix}" examples/basic.go "${go_ldflags}" || return 1
+    invoke_go_build "build/examples/go/bind${exe_suffix}" examples/bind.go "${go_ldflags}" || return 1
 }
 
 task_go_test() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -37,7 +37,10 @@ go_setup_env() {
     local cgo_cxxflags=()
     if [[ "${target_os}" == "windows" ]]; then
         cgo_cxxflags+=("'-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include'")
-        cgo_cxxflags+=(-include "'${project_dir}/webview_mingw_support.h'")
+        header_path=${project_dir}/webview_mingw_support.h
+        # This must somehow be a Windows-style path (forward slashes are OK)
+        header_path=$(cygpath --mixed "${header_path}")
+        cgo_cxxflags+=("'--include=${header_path}'")
     fi
     export CGO_CXXFLAGS="${cgo_cxxflags[@]}"
     export CGO_ENABLED=1
@@ -266,7 +269,7 @@ elif [[ "${target_os}" == "macos" ]]; then
 elif [[ "${target_os}" == "windows" ]]; then
     exe_suffix=.exe
     cxx_compile_flags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
-    cxx_compile_flags+=(-include "${project_dir}/webview_mingw_support.h")
+    cxx_compile_flags+=("--include=${project_dir}/webview_mingw_support.h")
     cxx_link_flags+=(-mwindows -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion)
 fi
 

--- a/webview.h
+++ b/webview.h
@@ -1119,14 +1119,17 @@ inline std::wstring widen_string(const std::string &input) {
 
 // Converts a wide (UTF-16-encoded) string into a narrow (UTF-8-encoded) string.
 inline std::string narrow_string(const std::wstring &input) {
-#ifndef WC_ERR_INVALID_CHARS
-  static constexpr const auto WC_ERR_INVALID_CHARS = 0x00000080U;
-#endif
+  struct wc_flags {
+    enum TYPE : unsigned int {
+      // WC_ERR_INVALID_CHARS
+      err_invalid_chars = 0x00000080U
+    };
+  };
   if (input.empty()) {
     return std::string();
   }
   UINT cp = CP_UTF8;
-  DWORD flags = WC_ERR_INVALID_CHARS;
+  DWORD flags = wc_flags::err_invalid_chars;
   auto input_c = input.c_str();
   auto input_length = static_cast<int>(input.size());
   auto required_length = WideCharToMultiByte(cp, flags, input_c, input_length,

--- a/webview.h
+++ b/webview.h
@@ -217,6 +217,7 @@ WEBVIEW_API const webview_version_info_t *webview_version();
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <future>
 #include <map>
@@ -1295,7 +1296,9 @@ struct user32_symbols {
   using DPI_AWARENESS_CONTEXT = HANDLE;
   using SetProcessDpiAwarenessContext_t = BOOL(WINAPI *)(DPI_AWARENESS_CONTEXT);
   using SetProcessDPIAware_t = BOOL(WINAPI *)();
-  enum class dpi_awareness { per_monitor_aware = -3 };
+  // Use intptr_t as the underlying type because we need to
+  // reinterpret_cast<DPI_AWARENESS_CONTEXT> which is a pointer.
+  enum class dpi_awareness : intptr_t { per_monitor_aware = -3 };
 
   static constexpr auto SetProcessDpiAwarenessContext =
       library_symbol<SetProcessDpiAwarenessContext_t>(

--- a/webview_mingw_support.h
+++ b/webview_mingw_support.h
@@ -10,13 +10,5 @@ typedef struct EventRegistrationToken {
 } EventRegistrationToken;
 #endif
 
-#ifndef WC_ERR_INVALID_CHARS
-#define WC_ERR_INVALID_CHARS 0
-#endif
-
-#ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
-#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE ((DPI_AWARENESS_CONTEXT)-3)
-#endif
-
 #endif /* _WIN32 */
 #endif /* WEBVIEW_MINGW_SUPPORT_H */

--- a/webview_mingw_support.h
+++ b/webview_mingw_support.h
@@ -1,0 +1,18 @@
+#ifndef WEBVIEW_MINGW_SUPPORT_H
+#define WEBVIEW_MINGW_SUPPORT_H
+#ifdef _WIN32
+
+#ifndef __eventtoken_h__
+#include <cstdint>
+
+typedef struct EventRegistrationToken {
+  int64_t value;
+} EventRegistrationToken;
+#endif
+
+#ifndef WC_ERR_INVALID_CHARS
+#define WC_ERR_INVALID_CHARS 0
+#endif
+
+#endif /* _WIN32 */
+#endif /* WEBVIEW_MINGW_SUPPORT_H */

--- a/webview_mingw_support.h
+++ b/webview_mingw_support.h
@@ -6,6 +6,7 @@
 // Define the things used by WebView2 from the EventToken.h header if needed.
 #if defined(__has_include)
 #if !defined(WEBVIEW_HAVE_EVENTTOKEN_H) && __has_include(<EventToken.h>)
+#include <EventToken.h>
 #define WEBVIEW_HAVE_EVENTTOKEN_H
 #endif
 #if !defined(WEBVIEW_HAVE_EVENTTOKEN_H) && defined(__eventtoken_h__)

--- a/webview_mingw_support.h
+++ b/webview_mingw_support.h
@@ -14,5 +14,9 @@ typedef struct EventRegistrationToken {
 #define WC_ERR_INVALID_CHARS 0
 #endif
 
+#ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE
+#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE ((DPI_AWARENESS_CONTEXT)-3)
+#endif
+
 #endif /* _WIN32 */
 #endif /* WEBVIEW_MINGW_SUPPORT_H */

--- a/webview_mingw_support.h
+++ b/webview_mingw_support.h
@@ -2,12 +2,19 @@
 #define WEBVIEW_MINGW_SUPPORT_H
 #ifdef _WIN32
 
-#ifndef __eventtoken_h__
+// Some MinGW distributions do not have the EventToken.h header (used by WebView2).
+// Define the things used by WebView2 from the EventToken.h header if needed.
+#if defined(__has_include)
+#if !defined(WEBVIEW_HAVE_EVENTTOKEN_H) && __has_include(<EventToken.h>)
+#define WEBVIEW_HAVE_EVENTTOKEN_H
+#endif
+#if !defined(WEBVIEW_HAVE_EVENTTOKEN_H) && defined(__eventtoken_h__)
+#define WEBVIEW_HAVE_EVENTTOKEN_H
+#endif
+#if !defined(WEBVIEW_HAVE_EVENTTOKEN_H)
 #include <cstdint>
-
-typedef struct EventRegistrationToken {
-  int64_t value;
-} EventRegistrationToken;
+typedef struct EventRegistrationToken { int64_t value; } EventRegistrationToken;
+#endif
 #endif
 
 #endif /* _WIN32 */

--- a/webview_mingw_support.h
+++ b/webview_mingw_support.h
@@ -14,7 +14,9 @@
 #endif
 #if !defined(WEBVIEW_HAVE_EVENTTOKEN_H)
 #include <cstdint>
-typedef struct EventRegistrationToken { int64_t value; } EventRegistrationToken;
+typedef struct EventRegistrationToken {
+  int64_t value;
+} EventRegistrationToken;
 #endif
 #endif
 


### PR DESCRIPTION
This is an attempt at a minimalistic rewrite of the build.sh script that aims to improve compatibility with MinGW-w64 and cross-compilation from Linux to Windows (C,  C++ and Go), with some quality of life improvements. It isn't meant to be a permanent solution but rather something that takes some pain away while developing and testing the library.

Code has been split into smaller tasks that can be run individually by specifying them on the command line. Specifying no tasks runs the default set of tasks, while specifying one or more tasks runs only those tasks.

Example usage: `build.sh clean deps build test`

The default C and C++ compiler executables remain the same (cc/c++) but can now be overridden using the `CC` and `CXX` environment variables.

Example of cross-compilation from Linux to Windows:

```
export TARGET_OS=windows
export CC=x86_64-w64-mingw32-gcc-posix
export CXX=x86_64-w64-mingw32-g++-posix
./script/build.sh clean deps build
```

MS WebView2 `#include`s `EventToken.h` from the Windows SDK and uses a symbol (`EventRegistrationToken`) that isn't available in all MinGW-w64 distributions, and can't be redefined within the library itself without polluting the global namespace. A new optional support header named `webview_mingw_support.h` conditionally redefines the symbol.

The build script patches away the inclusion of `EventToken.h` in the `WebView2.h` header file if the `PATCH_MSWEBVIEW2` environment variable is set to `1`, and the script decides includes the `webview_mingw_support.h` header (before other headers) on Windows. Users of the library will still need to figure out how they want to deal with this because it's really outside the scope of the library.

A few other symbols (`WC_ERR_INVALID_CHARS`, `DPI_AWARENESS_CONTEXT_*`) from the Windows SDK have been redefined within the library without introducing conflicts or pollution.

The script will now by default require tools such as `clang-format`, `clang-tidy` and `go` when run in a CI environment (`CI` environment variable defined) and will otherwise skip the task.

As for the change from `sh` to `bash` in the shebang line, this is because I used Bash-specific syntax such as arrays.

New CI jobs have been added for compiling on Windows using MinGW-w64, and for cross-compilation from Linux to Windows using MinGW-w64.