### PR TITLE
Build shared library in build.sh

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -146,11 +146,13 @@ task_build() {
     mkdir -p "${build_dir}/library" || true
 
     echo "Building shared library..."
-    local shared_lib_args=(-fPIC)
+    local shared_lib_args=(-fPIC -fvisibility=hidden -fvisibility-inlines-hidden)
     if [[ "${target_os}" == "macos" ]]; then
-        shared_lib_args+=(-dynamiclib "-Wl,-install_name,@rpath/${lib_prefix}webview${shared_lib_suffix}")
+        shared_lib_args+=(-dynamiclib "-Wl,-install_name,@rpath/${lib_prefix}webview${shared_lib_suffix}" '-DWEBVIEW_API=__attribute__ ((visibility ("default")))')
+    elif [[ "${target_os}" == "windows" ]]; then
+        shared_lib_args+=(-shared '-DWEBVIEW_API=__declspec(dllexport)')
     else
-        shared_lib_args+=(-shared)
+        shared_lib_args+=(-shared '-DWEBVIEW_API=__attribute__ ((visibility ("default")))')
     fi
     "${cxx_compiler}" "${cxx_compile_flags[@]}" "${shared_lib_args[@]}" "${project_dir}/webview.cc" "${cxx_link_flags[@]}" -o "${build_dir}/library/${lib_prefix}webview${shared_lib_suffix}" || return 1
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -283,6 +283,8 @@ cxx_std=c++11
 c_compiler=cc
 # Default C++ compiler
 cxx_compiler=c++
+# Default library name prefix
+lib_prefix=lib
 
 # C compiler override
 if [[ ! -z "${CC+x}" ]]; then
@@ -292,6 +294,11 @@ fi
 # C++ compiler override
 if [[ ! -z "${CXX+x}" ]]; then
     cxx_compiler=${CXX}
+fi
+
+# Library name prefix override
+if [[ ! -z "${LIB_PREFIX+x}" ]]; then
+    lib_prefix=${LIB_PREFIX}
 fi
 
 project_dir=$(dirname "$(dirname "$(unix_realpath_wrapper "${BASH_SOURCE[0]}")")") || exit 1
@@ -307,7 +314,6 @@ c_link_flags=("${common_link_flags[@]}")
 cxx_compile_flags=("${common_compile_flags[@]}")
 cxx_link_flags=("${common_link_flags[@]}")
 exe_suffix=
-lib_prefix=lib
 shared_lib_suffix=
 
 if [[ "${target_os}" == "windows" ]]; then
@@ -330,7 +336,6 @@ elif [[ "${target_os}" == "macos" ]]; then
     cxx_compile_flags+=("-mmacosx-version-min=${macos_target_version}")
 elif [[ "${target_os}" == "windows" ]]; then
     exe_suffix=.exe
-    lib_prefix=
     shared_lib_suffix=.dll
     cxx_compile_flags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
     cxx_compile_flags+=("--include=${project_dir}/webview_mingw_support.h")


### PR DESCRIPTION
Builds the library as a shared library on each platform:

* `*.so` on Linux.
* `*.dylib` on macOS.
* `*.dll` on Windows.

Doesn't build examples with shared linking of the library but I'll provide examples for that below.

## Examples

### Linux

```
mkdir -p dist
./script/build.sh clean build
cp build/library/libwebview.so dist/
cc -c examples/basic.c -std=c99 -I. -o build/basic.o
c++ build/basic.o '-Wl,-rpath,$ORIGIN' -Lbuild/library -lwebview -o dist/basic
./dist/basic
```

### macOS

```
mkdir -p dist
./script/build.sh clean build
cp build/library/libwebview.dylib dist/
cc -c examples/basic.c -std=c99 -I. -o build/basic.o
c++ build/basic.o -rpath @executable_path -Lbuild/library -lwebview -framework WebKit -o dist/basic
./dist/basic
```

### Windows

```
mkdir -p dist
./script/build.sh clean deps build
cp build/library/libwebview.dll dist/
cc -c examples/basic.c -std=c99 -I. -o build/basic.o
c++ build/basic.o -Lbuild/library -lwebview -mwindows -o dist/basic
./dist/basic
```

If you want a different library name prefix than `lib` on Windows then you can configure it with the `LIB_PREFIX` environment variable.

You'll need to distribute the runtime libraries you use from MinGW, e.g. `libgcc_s_seh-1.dll`, `libstdc++-6.dll` and `libwinpthread-1.dll` unless you link them statically (no option for that at the moment).
