### PR TITLE
Rewrite build.bat script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,14 +19,23 @@ jobs:
         run: ./script/build.sh
 
   build-windows-msvc:
+    strategy:
+      matrix:
+        arch: [x64, x86]
     runs-on: windows-latest
+    env:
+      TARGET_ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v3
+      - name: Build and run tests
+        run: ./script/build.bat info clean format deps check build test
+        shell: cmd
       - name: Add MinGW-w64 to PATH
         run: echo PATH=%ProgramData%\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%>>%GITHUB_ENV%
         shell: cmd
-      - name: Build and run tests
-        run: ./script/build.bat
+      - name: 'Go: Build and run tests'
+        if: matrix.arch == 'x64'
+        run: ./script/build.bat go:build go:test
         shell: cmd
 
   build-windows-mingw:

--- a/script/build.bat
+++ b/script/build.bat
@@ -144,7 +144,7 @@ goto :main
     goto :eof
 
 :task_check
-    echo SKIP: Linting ^(disabled^)
+    echo SKIP: Linting ^(not implemented^)
     goto :eof
 
 :task_build

--- a/script/build.bat
+++ b/script/build.bat
@@ -1,143 +1,299 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
+goto :main
 
-echo Prepare directories...
-set script_dir=%~dp0
-set script_dir=%script_dir:~0,-1%
-set src_dir=%script_dir%\..
-set build_dir=%script_dir%\..\build
-mkdir "%build_dir%"
+:dirname
+    setlocal
+    set "out_var=%~1"
+    set "in_path=%~dp2"
+    if "%in_path:~-1%" == "\" (
+        set "in_path=%in_path:~0,-1%"
+    )
+    endlocal & set "%out_var%=%in_path%"
+    goto :eof
 
-echo Webview directory: %src_dir%
-echo Build directory: %build_dir%
+:get_host_arch
+    setlocal
+    set out_var=%~1
+    if defined PROCESSOR_ARCHITEW6432 (
+        set "host_arch=%PROCESSOR_ARCHITEW6432%"
+    ) else (
+        set "host_arch=%PROCESSOR_ARCHITECTURE%"
+    )
+    if "%host_arch%" == "AMD64" (
+        set result=x64
+    ) else if "%host_arch%" == "x86" (
+        set result=x86
+    ) else (
+        echo ERROR: Unsupported host machine architecture.
+        endlocal
+        exit /b 1
+    )
+    endlocal & set %out_var%=%result%
+    goto :eof
 
-:: If you update the nuget package, change its version here
-set nuget_version=1.0.1150.38
-echo Using Nuget Package microsoft.web.webview2.%nuget_version%
-if not exist "%script_dir%\microsoft.web.webview2.%nuget_version%" (
-	curl -sSLO https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-	nuget.exe install Microsoft.Web.Webview2 -Version %nuget_version% -OutputDirectory %script_dir%
-	echo Nuget package installed
+:fetch_mswebview2
+    set nuget_exe=%tools_dir%\nuget\nuget.exe
+    if not exist "%nuget_exe%" (
+        call :dirname nuget_dir "%nuget_exe%" || exit /b 1
+        if not exist "!nuget_dir!" mkdir "!nuget_dir!" || exit /b 1
+        echo Fetching NuGet...
+        curl -sSLo "%nuget_exe%" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe || exit /b 1
+    )
+    set mswebview2_dir=%libs_dir%\Microsoft.Web.WebView2.%mswebview2_version%
+    if not exist "%mswebview2_dir%" (
+        mkdir "%mswebview2_dir%" || exit /b 1
+        echo Fetching mswebview2 %mswebview2_version%...
+        "%nuget_exe%" install Microsoft.Web.Webview2 -Verbosity quiet -Version "%mswebview2_version%" -OutputDirectory "%libs_dir%" || exit /b 1
+    )
+    goto :eof
+
+:get_go_arch_from_arch
+    setlocal
+    set out_var=%~1
+    if "%~2" == "x64" (
+        set result=amd64
+    ) else if "%~2" == "x86" (
+        set result=386
+    ) else (
+        echo ERROR: Unsupported architecture ^(%~2^)
+        endlocal & exit /b 1
+    )
+    endlocal & set "%out_var%=%result%"
+    goto :eof
+
+:go_setup_env
+    set CGO_CXXFLAGS=%cgo_cxxflags% "-I%libs_dir%\Microsoft.Web.WebView2.%mswebview2_version%\build\native\include"
+    set CGO_ENABLED=1
+    call :get_go_arch_from_arch GOARCH "%target_arch%"
+    goto :eof
+
+:is_ci
+    if "%CI%" == "" exit /b 1
+    goto :eof
+
+:invoke_go_build
+    setlocal
+    set output=%~1
+    set input=%~2
+    set ldflags=%~3
+    pushd "%project_dir%" || (popd & exit /b 1 & endlocal)
+    go build "%ldflags%" -o "%output%" "%input%" || (popd & exit /b 1 & endlocal)
+    popd
+    endlocal
+    goto :eof
+
+:find_msvc
+    setlocal
+    set out_var=%~1
+    rem Find vswhere.exe
+    set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    if not exist "%vswhere%" set "vswhere=!ProgramFiles!\Microsoft Visual Studio\Installer\vswhere.exe"
+    if not exist "%vswhere%" (
+        echo ERROR: Failed to find vswhere.exe>&2
+        endlocal & exit /b 1
+    )
+    rem Find VC tools
+    for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+        set vc_dir=%%i
+    )
+    if not exist "%vc_dir%\Common7\Tools\vsdevcmd.bat" (
+        echo ERROR: Failed to find MSVC.>&2
+        endlocal & exit /b 1
+    )
+    endlocal & set "%out_var%=%vc_dir%"
+    goto :eof
+
+:activate_msvc
+    where cl.exe > nul 2>&1 && goto :eof || cmd /c exit 0
+    call :find_msvc vc_dir || goto :eof
+    call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -no_logo -arch=%~1 || goto :eof
+    goto :eof
+
+:task_clean
+    if exist "%build_dir%" rmdir /q /s "%build_dir%" || exit /b 1
+    goto :eof
+
+:task_format
+    where clang-format > nul 2>&1
+    if not "%errorlevel%" == "0" (
+        setlocal
+        set message=Formatting ^(clang-format not installed^)
+        call :is_ci && (
+            echo FAIL: !message!
+            endlocal
+            exit /b 1
+        )
+        echo SKIP: !message!
+        endlocal
+        exit /b 0
+    )
+    echo Formatting...
+    clang-format -i ^
+        "%project_dir%\webview.h" ^
+        "%project_dir%\webview_test.cc" ^
+        "%project_dir%\examples/basic.c" ^
+        "%project_dir%\examples/bind.c" ^
+        "%project_dir%\examples/basic.cc" ^
+        "%project_dir%\examples/bind.cc" ^
+        || exit /b 1
+    goto :eof
+
+:task_deps
+    call :fetch_mswebview2 || exit /b 1
+    goto :eof
+
+:task_check
+    echo SKIP: Linting ^(disabled^)
+    goto :eof
+
+:task_build
+    call :activate_msvc "%target_arch%" || goto :eof
+
+    if not exist "%build_dir%\library" mkdir "%build_dir%\library"
+
+    echo Building shared library...
+    set shared_lib_args=/D "WEBVIEW_API=__declspec(dllexport)"
+    "%cxx_compiler%" %cxx_compile_flags% %shared_lib_args% "%project_dir%\webview.cc" "/Fo%build_dir%\library"\ %cxx_link_flags% /link /DLL "/out:%build_dir%\library\webview%shared_lib_suffix%" || exit /b 1
+
+    if not exist "%build_dir%\examples\c" mkdir "%build_dir%\examples\c"
+    if not exist "%build_dir%\examples\cc" mkdir "%build_dir%\examples\cc"
+
+    echo Building C++ examples...
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\basic.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\basic%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\bind.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\bind%exe_suffix%" || exit /b 1
+
+    echo Building C examples...
+    "%cxx_compiler%" /c %cxx_compile_flags% "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %cxx_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %cxx_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
+
+    echo Building test app...
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1
+    goto :eof
+
+:task_test
+    echo Running tests...
+    "%build_dir%\webview_test%exe_suffix%" || exit /b 1
+    goto :eof
+
+:task_go_build
+    where go > nul 2>&1
+    if not "%errorlevel%" == "0" (
+        setlocal
+        set message=Go build ^(go not installed^)
+        call :is_ci && (
+            echo FAIL: !message!
+            endlocal
+            exit /b 1
+        )
+        echo SKIP: !message!
+        endlocal
+        exit /b 0
+    )
+    setlocal
+    call :go_setup_env || (exit /b 1 & endlocal)
+    echo Building Go examples...
+    set go_ldflags=-ldflags=-H windowsgui
+    if not exist "%build_dir%\examples\go" (
+        mkdir "%build_dir%\examples\go" || (exit /b 1 & endlocal)
+    )
+    call :invoke_go_build "build\examples\go\basic%exe_suffix%" examples\basic.go "%go_ldflags%" || (exit /b 1 & endlocal)
+    call :invoke_go_build "build\examples\go\bind%exe_suffix%" examples\bind.go "%go_ldflags%" || (exit /b 1 & endlocal)
+    endlocal
+    goto :eof
+
+:task_go_test
+    where go > nul 2>&1
+    if not "%errorlevel%" == "0" (
+        setlocal
+        set message=Go tests ^(go not installed^)
+        call :is_ci && (
+            echo FAIL: !message!
+            endlocal
+            exit /b 1
+        )
+        echo SKIP: !message!
+        endlocal
+        exit /b 0
+    )
+    setlocal
+    call :go_setup_env || (exit /b 1 & endlocal)
+    echo Running Go tests...
+    set CGO_ENABLED=1
+    pushd "%project_dir%" || (popd & exit /b 1 & endlocal)
+    go test || (popd & exit /b 1 & endlocal)
+    popd
+    endlocal
+    goto :eof
+
+:task_info
+    echo -- Target architecture: %target_arch%
+    echo -- C compiler: %c_compiler%
+    echo -- C compiler flags: %c_compile_flags%
+    echo -- C linker flags: %c_link_flags%
+    echo -- C++ compiler: %cxx_compiler%
+    echo -- C++ compiler flags: %cxx_compile_flags%
+    echo -- C++ linker flags: %cxx_link_flags%
+    goto :eof
+
+:run_task
+    setlocal
+    set name=%~1
+    set name=%name::=_%
+    call :task_%name% || exit /b 1
+    goto :eof
+
+:main
+rem Versions of dependencies
+set mswebview2_version=1.0.1150.38
+
+rem Target architecture for cross-compilation
+call :get_host_arch host_arch || exit /b
+if not defined TARGET_ARCH (
+    rem Target architecture is by default the same as the host architecture
+    set target_arch=%host_arch%
 )
 
-echo Looking for vswhere.exe...
-set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
-if not exist "%vswhere%" (
-	echo ERROR: Failed to find vswhere.exe
-	exit /b 1
-)
-echo Found %vswhere%
+rem Default C standard
+set c_std=c11
+rem Default C++ standard
+set cxx_std=c++17
+rem Default C compiler
+set c_compiler=cl
+rem Default C++ compiler
+set cxx_compiler=cl
 
-echo Looking for VC...
-for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-  set vc_dir=%%i
-)
-if not exist "%vc_dir%\Common7\Tools\vsdevcmd.bat" (
-	echo ERROR: Failed to find VC tools x86/x64
-	exit /b 1
-)
-echo Found %vc_dir%
+call :dirname project_dir "%~dpf0" || exit /b
+call :dirname project_dir "%project_dir%" || exit /b
+set build_dir=%project_dir%\build
+set external_dir=%build_dir%\external
+set libs_dir=%external_dir%\libs
+set tools_dir=%external_dir%\tools
+rem 4100: unreferenced formal parameter
+set warning_flags=/W4 /wd4100
+set common_compile_flags=%warning_flags% /utf-8 /I "%project_dir%"
+set common_link_flags=%warning_flags%
+set c_compile_flags=%common_compile_flags%
+set c_link_flags=%common_link_flags%
+set cxx_compile_flags=%common_compile_flags% /EHsc
+set cxx_link_flags=%common_link_flags%
+set exe_suffix=.exe
+set shared_lib_suffix=.dll
 
-:: 4100: unreferenced formal parameter
-set warning_params=/W4 /wd4100
+set c_compile_flags=%c_compile_flags% "/std:%c_std%"
+set cxx_compile_flags=%cxx_compile_flags% "/std:%cxx_std%"
 
-:: build dlls if not found
-if not exist "%src_dir%\dll\x64\webview.dll" (
-	mkdir "%src_dir%\dll\x86"
-	mkdir "%src_dir%\dll\x64"
-	copy  "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll" "%src_dir%\dll\x64"
-	copy  "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x86\WebView2Loader.dll" "%src_dir%\dll\x86"
+set cxx_compile_flags=%cxx_compile_flags% /I "%libs_dir%\Microsoft.Web.WebView2.%mswebview2_version%\build\native\include"
 
-	call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x86 -host_arch=x64
+rem Default tasks
+set tasks=info clean format deps check build test go:build go:test
 
-	echo Building webview.dll ^(x86^)
-	cl %warning_params% ^
-		/D "WEBVIEW_API=__declspec(dllexport)" ^
-		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
-		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x86\webview.dll" || exit /b
-
-	call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
-	echo Building webview.dll ^(x64^)
-	cl %warning_params% ^
-		/D "WEBVIEW_API=__declspec(dllexport)" ^
-		/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-		/std:c++17 /EHsc "/Fo%build_dir%"\ ^
-		"%src_dir%\webview.cc" /link /DLL "/OUT:%src_dir%\dll\x64\webview.dll" || exit /b
-)
-if not exist "%build_dir%\webview.dll" (
-	copy "%src_dir%\dll\x64\webview.dll" %build_dir%
-)
-if not exist "%build_dir%\WebView2Loader.dll" (
-	copy "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\x64\WebView2Loader.dll" "%build_dir%"
+rem Task override from command line
+if not "%~1" == "" (
+    set tasks=%*
 )
 
-call "%vc_dir%\Common7\Tools\vsdevcmd.bat" -arch=x64 -host_arch=x64
-
-echo Building C++ examples (x64)
-mkdir "%build_dir%\examples\cpp"
-cl %warning_params% ^
-	/I "%src_dir%" ^
-	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%src_dir%\dll\x64\webview.lib" ^
-	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
-	"%src_dir%\examples\basic.cc" /link "/OUT:%build_dir%\examples\cpp\basic.exe" || exit /b
-cl %warning_params% ^
-	/I "%src_dir%" ^
-	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%src_dir%\dll\x64\webview.lib" ^
-	/std:c++17 /EHsc "/Fo%build_dir%\examples\cpp"\ ^
-	"%src_dir%\examples\bind.cc" /link "/OUT:%build_dir%\examples\cpp\bind.exe" || exit /b
-
-echo Building C examples (x64)
-mkdir "%build_dir%\examples\c"
-cl %warning_params% ^
-	/I "%src_dir%" ^
-	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%src_dir%\dll\x64\webview.lib" ^
-	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
-	"%src_dir%\dll\x64\webview.lib" ^
-	"%src_dir%\examples\basic.c" /link "/OUT:%build_dir%\examples\c\basic.exe" || exit /b
-cl %warning_params% ^
-	/I "%src_dir%" ^
-	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	"%src_dir%\dll\x64\webview.lib" ^
-	/std:c++17 /EHsc "/Fo%build_dir%\examples\c"\ ^
-	"%src_dir%\dll\x64\webview.lib" ^
-	"%src_dir%\examples\bind.c" /link "/OUT:%build_dir%\examples\c\bind.exe" || exit /b
-
-echo Building webview_test.exe (x64)
-cl %warning_params% ^
-	/utf-8 ^
-	/I "%src_dir%" ^
-	/I "%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include" ^
-	/std:c++17 /EHsc "/Fo%build_dir%"\ ^
-	"%src_dir%\webview_test.cc" /link "/OUT:%build_dir%\webview_test.exe" || exit /b
-
-echo Setting up environment for Go...
-rem Argument quoting works for Go 1.18 and later but as of 2022-06-26 GitHub Actions has Go 1.17.11.
-rem See https://go-review.googlesource.com/c/go/+/334732/
-rem TODO: Use proper quoting when GHA has Go 1.18 or later.
-set "CGO_CXXFLAGS=-I%script_dir%\microsoft.web.webview2.%nuget_version%\build\native\include"
-set CGO_ENABLED=1
-
-rem Go needs go.mod to be in the working directory.
-pushd "%src_dir%" || exit /b
-
-echo Building Go examples
-mkdir "%build_dir%\examples\go"
-go build -ldflags="-H windowsgui" -o "%build_dir%\examples\go\basic.exe" examples\basic.go || goto :go_end
-go build -ldflags="-H windowsgui" -o "%build_dir%\examples\go\bind.exe" examples\bind.go || goto :go_end
-
-echo Running tests
-"%build_dir%\webview_test.exe" || goto :go_end
-
-echo Running Go tests
-set "PATH=%PATH%;%src_dir%\dll\x64;%src_dir%\dll\x86"
-go test || goto :go_end
-
-:go_end
-set go_error=%errorlevel%
-popd
-if not "%go_error%" == "0" exit /b "%go_error%"
+for %%t in (%tasks%) do (
+    call :run_task "%%t" || exit /b 1
+)


### PR DESCRIPTION
Similarly to PR # #957 for `build.sh`, this PR overhauls `build.bat`.

`build.bat` is still MSVC-specific but retains support for Go. Linting isn't implemented here both because it wasn't originally implemented, and because it would have needed different compiler and linker flags for `clang-tidy`.

The only cross-compilation support implemented is for MSVC by setting the `TARGET_ARCH` environment variable to `x86` or `x64`

 The script no longer builds the library for both `x86` and `x64` in a single invocation—instead it should be controlled with `TARGET_ARCH`.

`CC` and `CXX` can be set for Go but isn't used for C/C++ unlike `build.sh`—instead `cl` is always used for C/C++.

Example:

```bat
set TARGET_ARCH=x86
set CC=i686-w64-mingw32-gcc
set CXX=i686-w64-mingw32-g++
script\build.bat
```

The CI configuration has been adjusted to build for x86 and x64 separately.

For consistency, examples no longer link the shared library.