### PR TITLE
Allow build directory override

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Variable     | Description
 ------------ | ---------------------------------------------------------
 `CI`         | Changes behavior in CI environments (more strict).
 `TARGET_ARCH`| Target architecture for cross-compilation (`x64`, `x86`).
+`BUILD_DIR`  | Overrides the path of the build directory.
 
 Only `build.sh`:
 

--- a/script/build.bat
+++ b/script/build.bat
@@ -205,8 +205,8 @@ goto :main
     if not exist "%build_dir%\examples\go" (
         mkdir "%build_dir%\examples\go" || (exit /b 1 & endlocal)
     )
-    call :invoke_go_build "build\examples\go\basic%exe_suffix%" examples\basic.go "%go_ldflags%" || (exit /b 1 & endlocal)
-    call :invoke_go_build "build\examples\go\bind%exe_suffix%" examples\bind.go "%go_ldflags%" || (exit /b 1 & endlocal)
+    call :invoke_go_build "%build_dir%\examples\go\basic%exe_suffix%" examples\basic.go "%go_ldflags%" || (exit /b 1 & endlocal)
+    call :invoke_go_build "%build_dir%\examples\go\bind%exe_suffix%" examples\bind.go "%go_ldflags%" || (exit /b 1 & endlocal)
     endlocal
     goto :eof
 

--- a/script/build.bat
+++ b/script/build.bat
@@ -2,6 +2,13 @@
 setlocal enabledelayedexpansion
 goto :main
 
+:realpath
+    setlocal
+    set "out_var=%~1"
+    set "in_path=%~dpf2"
+    endlocal & set "%out_var%=%in_path%"
+    goto :eof
+
 :dirname
     setlocal
     set "out_var=%~1"
@@ -229,6 +236,7 @@ goto :main
 
 :task_info
     echo -- Target architecture: %target_arch%
+    echo -- Build directory: %build_dir%
     echo -- C compiler: %c_compiler%
     echo -- C compiler flags: %c_compile_flags%
     echo -- C linker flags: %c_link_flags%
@@ -266,7 +274,14 @@ set cxx_compiler=cl
 
 call :dirname project_dir "%~dpf0" || exit /b
 call :dirname project_dir "%project_dir%" || exit /b
-set build_dir=%project_dir%\build
+
+rem Default build directory unless overridden
+if defined BUILD_DIR (
+    call :realpath build_dir "%BUILD_DIR%" || exit /b
+) else (
+    set build_dir=%project_dir%\build
+)
+
 set external_dir=%build_dir%\external
 set libs_dir=%external_dir%\libs
 set tools_dir=%external_dir%\tools

--- a/script/build.sh
+++ b/script/build.sh
@@ -242,8 +242,8 @@ task_go_build() {
         go_ldflags="-ldflags=${go_ldflags[@]}"
     fi
     mkdir -p "${build_dir}/examples/go" || true
-    invoke_go_build "build/examples/go/basic${exe_suffix}" examples/basic.go "${go_ldflags}" || return 1
-    invoke_go_build "build/examples/go/bind${exe_suffix}" examples/bind.go "${go_ldflags}" || return 1
+    invoke_go_build "${build_dir}/examples/go/basic${exe_suffix}" examples/basic.go "${go_ldflags}" || return 1
+    invoke_go_build "${build_dir}/examples/go/bind${exe_suffix}" examples/bind.go "${go_ldflags}" || return 1
 }
 
 task_go_test() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -274,6 +274,7 @@ task_go_test() {
 task_info() {
     echo "-- Target OS: ${target_os}"
     echo "-- Target architecture: ${target_arch}"
+    echo "-- Build directory: ${build_dir}"
     echo "-- C compiler: ${c_compiler}"
     echo "-- C compiler flags: ${c_compile_flags[@]}"
     echo "-- C linker flags: ${c_link_flags[@]}"
@@ -356,7 +357,14 @@ if [[ ! -z "${PKGCONFIG+x}" ]]; then
 fi
 
 project_dir=$(dirname "$(dirname "$(unix_realpath_wrapper "${BASH_SOURCE[0]}")")") || exit 1
-build_dir=${project_dir}/build
+
+# Default build directory unless overridden
+if [[ -z "${BUILD_DIR+x}" ]]; then
+    build_dir=${project_dir}/build
+else
+    build_dir=$(unix_realpath_wrapper "${BUILD_DIR}") || exit 1
+fi
+
 external_dir=${build_dir}/external
 libs_dir=${external_dir}/libs
 tools_dir=${external_dir}/tools


### PR DESCRIPTION
Allows overriding the path of the build directory using the `BUILD_DIR` environment variable in order to produce build artifacts in an alternative location.

Useful for out-of-source builds or multiple configurations with separate build directories