### PR TITLE
fix Windows scaling issue

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -2027,6 +2027,10 @@ public:
     }
     SetWindowLong(m_window, GWL_STYLE, style);
 
+    UINT dpi = GetDpiForWindow(m_window);
+    width = (width * dpi) / USER_DEFAULT_SCREEN_DPI;
+    height = (height * dpi) / USER_DEFAULT_SCREEN_DPI;
+
     if (hints == WEBVIEW_HINT_MAX) {
       m_maxsz.x = width;
       m_maxsz.y = height;

--- a/webview.h
+++ b/webview.h
@@ -2027,9 +2027,13 @@ public:
     }
     SetWindowLong(m_window, GWL_STYLE, style);
 
-    UINT dpi = GetDpiForWindow(m_window);
-    width = (width * dpi) / USER_DEFAULT_SCREEN_DPI;
-    height = (height * dpi) / USER_DEFAULT_SCREEN_DPI;
+    if (GetProcAddress(GetModuleHandle("user32.dll"),
+                       "GetDpiForWindow") != nullptr) {
+      // Windows 10 (version 1607) or above
+      UINT dpi = GetDpiForWindow(m_window);
+      width = (width * dpi) / USER_DEFAULT_SCREEN_DPI;
+      height = (height * dpi) / USER_DEFAULT_SCREEN_DPI;
+    }
 
     if (hints == WEBVIEW_HINT_MAX) {
       m_maxsz.x = width;

--- a/webview.h
+++ b/webview.h
@@ -2027,12 +2027,13 @@ public:
     }
     SetWindowLong(m_window, GWL_STYLE, style);
 
-    if (GetProcAddress(GetModuleHandle("user32.dll"),
-                       "GetDpiForWindow") != nullptr) {
-      // Windows 10 (version 1607) or above
-      UINT dpi = GetDpiForWindow(m_window);
-      width = (width * dpi) / USER_DEFAULT_SCREEN_DPI;
-      height = (height * dpi) / USER_DEFAULT_SCREEN_DPI;
+    typedef UINT (WINAPI *pGetDpiForWindow_t)(HWND);
+    pGetDpiForWindow_t pGetDpiForWindow = (pGetDpiForWindow_t)
+        GetProcAddress(GetModuleHandle("user32.dll"), "GetDpiForWindow");
+    if (pGetDpiForWindow != nullptr) {
+      int dpi = (int)pGetDpiForWindow(m_window);
+      width = (width * dpi) / 96; // USER_DEFAULT_SCREEN_DPI = 96
+      height = (height * dpi) / 96;
     }
 
     if (hints == WEBVIEW_HINT_MAX) {


### PR DESCRIPTION
The webview window did not respond to display 'scaling' on Windows. The window was ok at 100% scale, but at 125%, 150%, etc., it was too small. This PR fixes that issue.