### PR TITLE
DPI scaling for Windows 10 and later

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1557,7 +1557,7 @@ constexpr SIZE scale_size(int width, int height, int from_dpi, int to_dpi) {
   return {scaled_width, scaled_height};
 }
 
-SIZE make_window_frame_size(HWND window, int width, int height, int dpi) {
+inline SIZE make_window_frame_size(HWND window, int width, int height, int dpi) {
   auto style = GetWindowLong(window, GWL_STYLE);
   RECT r{0, 0, width, height};
   auto user32 = native_library(L"user32.dll");

--- a/webview.h
+++ b/webview.h
@@ -1557,7 +1557,8 @@ constexpr SIZE scale_size(int width, int height, int from_dpi, int to_dpi) {
   return {scaled_width, scaled_height};
 }
 
-inline SIZE make_window_frame_size(HWND window, int width, int height, int dpi) {
+inline SIZE make_window_frame_size(HWND window, int width, int height,
+                                   int dpi) {
   auto style = GetWindowLong(window, GWL_STYLE);
   RECT r{0, 0, width, height};
   auto user32 = native_library(L"user32.dll");

--- a/webview.h
+++ b/webview.h
@@ -1484,7 +1484,7 @@ inline bool is_os_version_at_least(unsigned int major, unsigned int minor,
 }
 
 inline bool is_per_monitor_v2_awareness_available() {
-  return is_os_version_at_least(10, 0, 1703);
+  return is_os_version_at_least(10, 0, 15063); // Windows 10, version 1703
 }
 
 inline bool enable_dpi_awareness() {

--- a/webview.h
+++ b/webview.h
@@ -2216,7 +2216,6 @@ private:
     const auto &r = suggested_bounds;
     SetWindowPos(m_window, nullptr, r.left, r.top, r.right - r.left,
                  r.bottom - r.top, SWP_NOZORDER | SWP_NOACTIVATE);
-    resize_widget();
   }
 
   virtual void on_message(const std::string &msg) = 0;

--- a/webview.h
+++ b/webview.h
@@ -1346,8 +1346,8 @@ private:
 };
 
 namespace ntdll_symbols {
-using RtlGetVersion_t = unsigned int /*NTSTATUS*/ (WINAPI *)(
-    OSVERSIONINFOW * /*PRTL_OSVERSIONINFOW*/);
+using RtlGetVersion_t =
+    unsigned int /*NTSTATUS*/ (WINAPI *)(RTL_OSVERSIONINFOW *);
 
 constexpr auto RtlGetVersion = library_symbol<RtlGetVersion_t>("RtlGetVersion");
 }; // namespace ntdll_symbols
@@ -1533,7 +1533,7 @@ inline bool enable_non_client_dpi_scaling_if_needed(HWND window) {
   return true;
 }
 
-constexpr inline int get_default_window_dpi() {
+constexpr int get_default_window_dpi() {
   constexpr const int default_dpi = 96; // USER_DEFAULT_SCREEN_DPI
   return default_dpi;
 }

--- a/webview.h
+++ b/webview.h
@@ -2152,17 +2152,20 @@ public:
       auto old_scale_factor = old_scale.get_factor();
       m_window_scale = new_scale;
 
+      // This is the 100% scale size.
       auto scaled_width = width;
       auto scaled_height = height;
 
       constexpr const auto epsilon = std::numeric_limits<double>::epsilon();
 
+      // Don't undo the old scale if it was 100%.
       if (std::abs(old_scale_factor - 1.0) > epsilon) {
         auto undo_scale = old_scale.swapped();
         scaled_width = undo_scale.apply_to(scaled_width);
         scaled_height = undo_scale.apply_to(scaled_height);
       }
 
+      // Don't apply the new scale if it's 100%.
       if (std::abs(new_scale_factor - 1.0) > epsilon) {
         scaled_width = new_scale.apply_to(scaled_width);
         scaled_height = new_scale.apply_to(scaled_height);

--- a/webview.h
+++ b/webview.h
@@ -1351,6 +1351,8 @@ using SetProcessDpiAwarenessContext_t = BOOL(WINAPI *)(DPI_AWARENESS_CONTEXT);
 using SetProcessDPIAware_t = BOOL(WINAPI *)();
 using GetDpiForWindow_t = UINT(WINAPI *)(HWND);
 using EnableNonClientDpiScaling_t = BOOL(WINAPI *)(HWND);
+using AdjustWindowRectExForDpi_t = BOOL(WINAPI *)(LPRECT, DWORD, BOOL, DWORD,
+                                                  UINT);
 // Use intptr_t as the underlying type because we need to
 // reinterpret_cast<DPI_AWARENESS_CONTEXT> which is a pointer.
 enum class dpi_awareness : intptr_t { per_monitor_aware = -3 };
@@ -1364,6 +1366,8 @@ constexpr auto GetDpiForWindow =
     library_symbol<GetDpiForWindow_t>("GetDpiForWindow");
 constexpr auto EnableNonClientDpiScaling =
     library_symbol<EnableNonClientDpiScaling_t>("EnableNonClientDpiScaling");
+constexpr auto AdjustWindowRectExForDpi =
+    library_symbol<AdjustWindowRectExForDpi_t>("AdjustWindowRectExForDpi");
 }; // namespace user32_symbols
 
 namespace shcore_symbols {
@@ -1468,16 +1472,30 @@ inline bool enable_non_client_dpi_scaling(HWND window) {
 
 template <typename T> class dpi_scale_t {
 public:
+  dpi_scale_t() {}
+
   dpi_scale_t(T numerator, T denominator)
       : m_numerator(numerator), m_denominator(denominator) {}
 
-  constexpr T apply_to(T value) {
+  constexpr T apply_to(T value) const {
     return ::MulDiv(value, m_numerator, m_denominator);
   }
 
+  constexpr T get_numerator() const { return m_numerator; }
+
+  constexpr T get_denominator() const { return m_denominator; }
+
+  constexpr double get_factor() const {
+    return m_numerator / static_cast<double>(m_denominator);
+  }
+
+  constexpr dpi_scale_t<T> swapped() const {
+    return {m_denominator, m_numerator};
+  }
+
 private:
-  T m_numerator{};
-  T m_denominator{};
+  T m_numerator{0};
+  T m_denominator{1};
 };
 
 inline dpi_scale_t<int> get_window_dpi_scale(HWND window) {
@@ -2042,11 +2060,14 @@ public:
         return;
       }
 
+      m_window_scale = get_window_dpi_scale(m_window);
+
       constexpr const int initial_width = 640;
       constexpr const int initial_height = 480;
       set_size(initial_width, initial_height, WEBVIEW_HINT_NONE);
     } else {
       m_window = *(static_cast<HWND *>(window));
+      m_window_scale = get_window_dpi_scale(m_window);
     }
 
     ShowWindow(m_window, SW_SHOW);
@@ -2118,10 +2139,6 @@ public:
     }
     SetWindowLong(m_window, GWL_STYLE, style);
 
-    auto scale = get_window_dpi_scale(m_window);
-    width = scale.apply_to(width);
-    height = scale.apply_to(height);
-
     if (hints == WEBVIEW_HINT_MAX) {
       m_maxsz.x = width;
       m_maxsz.y = height;
@@ -2129,13 +2146,42 @@ public:
       m_minsz.x = width;
       m_minsz.y = height;
     } else {
-      RECT r{};
-      r.right = width;
-      r.bottom = height;
-      AdjustWindowRect(&r, WS_OVERLAPPEDWINDOW, 0);
-      SetWindowPos(
-          m_window, nullptr, r.left, r.top, r.right - r.left, r.bottom - r.top,
-          SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_FRAMECHANGED);
+      auto new_scale = get_window_dpi_scale(m_window);
+      auto new_scale_factor = new_scale.get_factor();
+      auto old_scale = m_window_scale;
+      auto old_scale_factor = old_scale.get_factor();
+      m_window_scale = new_scale;
+
+      auto scaled_width = width;
+      auto scaled_height = height;
+
+      constexpr const auto epsilon = std::numeric_limits<double>::epsilon();
+
+      if (std::abs(old_scale_factor - 1.0) > epsilon) {
+        auto undo_scale = old_scale.swapped();
+        scaled_width = undo_scale.apply_to(scaled_width);
+        scaled_height = undo_scale.apply_to(scaled_height);
+      }
+
+      if (std::abs(new_scale_factor - 1.0) > epsilon) {
+        scaled_width = new_scale.apply_to(scaled_width);
+        scaled_height = new_scale.apply_to(scaled_height);
+      }
+
+      RECT r{0, 0, scaled_width, scaled_height};
+      auto user32 = native_library(L"user32.dll");
+      if (auto fn = user32.get(user32_symbols::AdjustWindowRectExForDpi)) {
+        fn(&r, style, FALSE, 0, static_cast<UINT>(new_scale.get_numerator()));
+      } else {
+        AdjustWindowRect(&r, style, 0);
+      }
+
+      auto frame_width = r.right - r.left;
+      auto frame_height = r.bottom - r.top;
+
+      SetWindowPos(m_window, nullptr, 0, 0, frame_width, frame_height,
+                   SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE |
+                       SWP_FRAMECHANGED);
     }
   }
 
@@ -2239,9 +2285,13 @@ private:
   }
 
   void on_dpi_changed(int x, int y, const RECT &suggested_bounds) {
-    const auto &r = suggested_bounds;
-    SetWindowPos(m_window, nullptr, r.left, r.top, r.right - r.left,
-                 r.bottom - r.top, SWP_NOZORDER | SWP_NOACTIVATE);
+    // x and y are the same in desktop apps.
+    // The suggested bounds diverge from the expected bounds so don't use them.
+    RECT bounds;
+    GetClientRect(m_window, &bounds);
+    auto width = bounds.right - bounds.left;
+    auto height = bounds.bottom - bounds.top;
+    set_size(width, height, WEBVIEW_HINT_NONE);
   }
 
   virtual void on_message(const std::string &msg) = 0;
@@ -2258,6 +2308,7 @@ private:
   ICoreWebView2Controller *m_controller = nullptr;
   webview2_com_handler *m_com_handler = nullptr;
   mswebview2::loader m_webview2_loader;
+  dpi_scale_t<int> m_window_scale;
 };
 
 } // namespace detail

--- a/webview.h
+++ b/webview.h
@@ -2320,22 +2320,9 @@ private:
     auto old_scale = m_window_scale;
     m_window_scale = new_scale;
 
-    // This is the 100% scale size.
-    auto scaled_width = width;
-    auto scaled_height = height;
-
-    // Undo the old scale if it wasn't 100%.
-    if (!old_scale.is_one()) {
-      auto undo_scale = old_scale.swapped();
-      scaled_width = undo_scale.apply_to(scaled_width);
-      scaled_height = undo_scale.apply_to(scaled_height);
-    }
-
-    // Apply the new scale if it isn't 100%.
-    if (!new_scale.is_one()) {
-      scaled_width = new_scale.apply_to(scaled_width);
-      scaled_height = new_scale.apply_to(scaled_height);
-    }
+    dpi_scale_t<int> diff{new_scale.get_numerator(), old_scale.get_numerator()};
+    auto scaled_width = diff.apply_to(width);
+    auto scaled_height = diff.apply_to(height);
 
     RECT r{0, 0, scaled_width, scaled_height};
     auto user32 = native_library(L"user32.dll");

--- a/webview.h
+++ b/webview.h
@@ -2147,9 +2147,7 @@ public:
       m_minsz.y = height;
     } else {
       auto new_scale = get_window_dpi_scale(m_window);
-      auto new_scale_factor = new_scale.get_factor();
       auto old_scale = m_window_scale;
-      auto old_scale_factor = old_scale.get_factor();
       m_window_scale = new_scale;
 
       // This is the 100% scale size.
@@ -2159,14 +2157,14 @@ public:
       constexpr const auto epsilon = std::numeric_limits<double>::epsilon();
 
       // Don't undo the old scale if it was 100%.
-      if (std::abs(old_scale_factor - 1.0) > epsilon) {
+      if (std::abs(old_scale.get_factor() - 1.0) > epsilon) {
         auto undo_scale = old_scale.swapped();
         scaled_width = undo_scale.apply_to(scaled_width);
         scaled_height = undo_scale.apply_to(scaled_height);
       }
 
       // Don't apply the new scale if it's 100%.
-      if (std::abs(new_scale_factor - 1.0) > epsilon) {
+      if (std::abs(new_scale.get_factor() - 1.0) > epsilon) {
         scaled_width = new_scale.apply_to(scaled_width);
         scaled_height = new_scale.apply_to(scaled_height);
       }

--- a/webview.h
+++ b/webview.h
@@ -2109,7 +2109,6 @@ public:
       SetWindowPos(
           m_window, nullptr, r.left, r.top, r.right - r.left, r.bottom - r.top,
           SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_FRAMECHANGED);
-      resize_widget();
     }
   }
 

--- a/webview.h
+++ b/webview.h
@@ -1445,7 +1445,7 @@ public:
       : m_numerator(numerator), m_denominator(denominator) {}
 
   constexpr T apply_to(T value) {
-    return (value * m_numerator) / m_denominator;
+    return ::MulDiv(value, m_numerator, m_denominator);
   }
 
 private:


### PR DESCRIPTION
Scales when the DPI setting changes on the window's display:

[change_dpi.webm](https://github.com/webview/webview/assets/1543854/adfe2186-9534-4548-898c-bd49d72ed233)

Scales when moving window to display with different DPI:

[move_between_displays.webm](https://github.com/webview/webview/assets/1543854/621544ad-b3c7-4a52-83c2-b1637d3bf30f)

## Test cases

| Case | Description                                                    | Expected                        |
| ---- | -------------------------------------------------------------- | ------------------------------- |
| 1    | Start on primary display with 100% DPI.                        | Window not scaled.              |
| 2    | Start on display with >100% DPI when primary display at 100%.  | Window scaled up.               |
| 3    | Start on primary display with >100% DPI.                       | Window scaled up.               |
| 4    | Move window to displays of varying DPI.                        | Window scaled with display DPI. |
| 5    | Start on display with >100% DPI without calling `*set_size()`. | Window scaled up.               |
| 6    | Change DPI for window's display.                               | Window scaled with new DPI.     |

## Result for 5defd8c794dae26a1aad801faead10e31bac99f0 (`master`)

| Case | OK? | Reason                                                             |
| ---- | --- | ------------------------------------------------------------------ |
| 1    | yes | Window not scaled.                                                 |
| 2    | no  | Window at 100% and only WebView2 scaled up.                        |
| 3    | no  | Window at 100% and only WebView2 scaled up.                        |
| 4    | no  | Window not scaled, WebView2 not scaled until manual window resize. |
| 5    | no  | Window at 100% and only WebView2 scaled up.                        |
| 6    | no  | Window not scaled and only WebView2 scaled.                        |

## Result for b7a05b52916a2e505f7c07416cb3cebbab2ddfd8

| Case | OK? | Reason                                                             |
| ---- | --- | ------------------------------------------------------------------ |
| 1    | yes | Window not scaled.                                                 |
| 2    | yes | Window scaled up.                                                  |
| 3    | yes | Window scaled up.                                                  |
| 4    | yes | Window scaled with display DPI.                                    |
| 5    | yes | Window scaled up.                                                  |
| 6    | yes | Window scaled with new DPI.                                        |
