### PR TITLE
Use c++17 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,10 @@ Build and run the example:
 
 ```sh
 # Linux
-g++ basic.cc -std=c++11 -Ilibs/webview $(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0) -o build/basic && ./build/basic
-# macOS
+g++ basic.cc -std=c++17 -Ilibs/webview $(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0) -o build/basic && ./build/basic
+# macOS arm
+g++ basic.cc -std=c++17 -Ilibs/webview -framework WebKit -o build/basic && ./build/basic
+# macOS intel
 g++ basic.cc -std=c++11 -Ilibs/webview -framework WebKit -o build/basic && ./build/basic
 # Windows/MinGW
 g++ basic.cc -std=c++17 -mwindows -Ilibs/webview -Ilibs/webview2/build/native/include -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion -o build/basic.exe && "build/basic.exe"
@@ -139,10 +141,14 @@ Build the library and example, then run it:
 
 ```sh
 # Linux
-g++ -c libs/webview/webview.cc -std=c++11 $(pkg-config --cflags gtk+-3.0 webkit2gtk-4.0) -o build/webview.o
+g++ -c libs/webview/webview.cc -std=c++17 $(pkg-config --cflags gtk+-3.0 webkit2gtk-4.0) -o build/webview.o
 gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o
 g++ build/basic.o build/webview.o $(pkg-config --libs gtk+-3.0 webkit2gtk-4.0) -o build/basic && build/basic
-# macOS
+# macOS arm
+g++ -c libs/webview/webview.cc -std=c++17 -o build/webview.o
+gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o
+g++ build/basic.o build/webview.o -framework WebKit -o build/basic && build/basic
+# macOS intel
 g++ -c libs/webview/webview.cc -std=c++11 -o build/webview.o
 gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o
 g++ build/basic.o build/webview.o -framework WebKit -o build/basic && build/basic

--- a/script/build.sh
+++ b/script/build.sh
@@ -325,7 +325,7 @@ mswebview2_version=1.0.1150.38
 # Default C standard
 c_std=c99
 # Default C++ standard
-cxx_std=c++11
+cxx_std=c++17
 # Default C compiler
 c_compiler=cc
 # Default C++ compiler
@@ -379,9 +379,10 @@ c_compile_flags+=("${common_compile_flags[@]}")
 c_link_flags+=("${common_link_flags[@]}")
 cxx_compile_flags+=("${common_compile_flags[@]}")
 cxx_link_flags+=("${common_link_flags[@]}")
+arch=$(uname -m)
 
-if [[ "${target_os}" == "windows" ]]; then
-    cxx_std=c++17
+if [[ "${target_os}" == "macos" ]] && [ "$arch" == "x86_64" ]; then
+    cxx_std=c++11
 fi
 
 c_compile_flags+=("-std=${c_std}")

--- a/script/build.sh
+++ b/script/build.sh
@@ -379,9 +379,8 @@ c_compile_flags+=("${common_compile_flags[@]}")
 c_link_flags+=("${common_link_flags[@]}")
 cxx_compile_flags+=("${common_compile_flags[@]}")
 cxx_link_flags+=("${common_link_flags[@]}")
-arch=$(uname -m)
 
-if [[ "${target_os}" == "macos" ]] && [ "$arch" == "x86_64" ]; then
+if [[ "${target_os}" == "macos" ]] && [[ -z "${target_arch}" ]] &&  [[ $(uname -m) == "x86_64" ]]; then
     cxx_std=c++11
 fi
 

--- a/webview.go
+++ b/webview.go
@@ -1,10 +1,11 @@
 package webview
 
 /*
-#cgo linux openbsd freebsd netbsd CXXFLAGS: -DWEBVIEW_GTK -std=c++11
+#cgo linux openbsd freebsd netbsd CXXFLAGS: -DWEBVIEW_GTK -std=c++17
 #cgo linux openbsd freebsd netbsd pkg-config: gtk+-3.0 webkit2gtk-4.0
 
-#cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
+#cgo darwin,amd64 CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
+#cgo darwin,arm64 CXXFLAGS: -DWEBVIEW_COCOA -std=c++17
 #cgo darwin LDFLAGS: -framework WebKit
 
 #cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++17


### PR DESCRIPTION
This proposal updates the default compiler version to C++17.
C++11 is only needed for macOS intel afaik so it could be handled separately to still allow for the benefits on other platforms.

Edit:
I unfortunately can't know yet how the build script is intertwined and all it's use cases. So the target architecture condition in the build script might be further improved. If this should be merged please check carefully.