### PR TITLE
Lower C++ standard requirement from C++17 to C++14 on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
   build-windows-msvc:
     strategy:
       matrix:
-        cxx_std: [c++17, c++20]
+        cxx_std: [c++14, c++17, c++20]
         arch: [x64, x86]
     runs-on: windows-latest
     env:
@@ -53,7 +53,7 @@ jobs:
   build-windows-mingw:
     strategy:
       matrix:
-        cxx_std: [c++17, c++20]
+        cxx_std: [c++14, c++17, c++20]
     runs-on: windows-latest
     env:
       CC: gcc
@@ -71,7 +71,7 @@ jobs:
   build-windows-msys2:
     strategy:
       matrix:
-        cxx_std: [c++17, c++20]
+        cxx_std: [c++14, c++17, c++20]
         include:
           - { sys: mingw64, cc: gcc  , cxx: g++ }
           - { sys: clang64, cc: clang, cxx: clang++ }
@@ -96,7 +96,7 @@ jobs:
   build-cross-windows-on-linux:
     strategy:
       matrix:
-        cxx_std: [c++17]
+        cxx_std: [c++14, c++17]
         image: [ubuntu-20.04, ubuntu-22.04]
         include:
           - cxx_std: c++20

--- a/script/build.bat
+++ b/script/build.bat
@@ -268,7 +268,7 @@ if not defined TARGET_ARCH (
 rem Default C standard unless overridden
 if not defined C_STD set c_std=c11
 rem Default C++ standard unless overridden
-if not defined CXX_STD set cxx_std=c++17
+if not defined CXX_STD set cxx_std=c++14
 rem Default C compiler
 set c_compiler=cl
 rem Default C++ compiler

--- a/script/build.sh
+++ b/script/build.sh
@@ -339,7 +339,7 @@ lib_prefix=lib
 pkgconfig_exe=pkg-config
 
 if [[ "${target_os}" == "windows" ]]; then
-    cxx_std=c++17
+    cxx_std=c++14
 fi
 
 # C standard override

--- a/webview.go
+++ b/webview.go
@@ -7,7 +7,7 @@ package webview
 #cgo darwin CXXFLAGS: -DWEBVIEW_COCOA -std=c++11
 #cgo darwin LDFLAGS: -framework WebKit
 
-#cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++17
+#cgo windows CXXFLAGS: -DWEBVIEW_EDGE -std=c++14
 #cgo windows LDFLAGS: -static -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion
 
 #include "webview.h"

--- a/webview.h
+++ b/webview.h
@@ -1318,28 +1318,28 @@ private:
   HMODULE m_handle = nullptr;
 };
 
-struct user32_symbols {
-  using DPI_AWARENESS_CONTEXT = HANDLE;
-  using SetProcessDpiAwarenessContext_t = BOOL(WINAPI *)(DPI_AWARENESS_CONTEXT);
-  using SetProcessDPIAware_t = BOOL(WINAPI *)();
-  // Use intptr_t as the underlying type because we need to
-  // reinterpret_cast<DPI_AWARENESS_CONTEXT> which is a pointer.
-  enum class dpi_awareness : intptr_t { per_monitor_aware = -3 };
+namespace user32_symbols {
+using DPI_AWARENESS_CONTEXT = HANDLE;
+using SetProcessDpiAwarenessContext_t = BOOL(WINAPI *)(DPI_AWARENESS_CONTEXT);
+using SetProcessDPIAware_t = BOOL(WINAPI *)();
+// Use intptr_t as the underlying type because we need to
+// reinterpret_cast<DPI_AWARENESS_CONTEXT> which is a pointer.
+enum class dpi_awareness : intptr_t { per_monitor_aware = -3 };
 
-  static constexpr auto SetProcessDpiAwarenessContext =
-      library_symbol<SetProcessDpiAwarenessContext_t>(
-          "SetProcessDpiAwarenessContext");
-  static constexpr auto SetProcessDPIAware =
-      library_symbol<SetProcessDPIAware_t>("SetProcessDPIAware");
-};
+constexpr auto SetProcessDpiAwarenessContext =
+    library_symbol<SetProcessDpiAwarenessContext_t>(
+        "SetProcessDpiAwarenessContext");
+constexpr auto SetProcessDPIAware =
+    library_symbol<SetProcessDPIAware_t>("SetProcessDPIAware");
+}; // namespace user32_symbols
 
-struct shcore_symbols {
-  typedef enum { PROCESS_PER_MONITOR_DPI_AWARE = 2 } PROCESS_DPI_AWARENESS;
-  using SetProcessDpiAwareness_t = HRESULT(WINAPI *)(PROCESS_DPI_AWARENESS);
+namespace shcore_symbols {
+typedef enum { PROCESS_PER_MONITOR_DPI_AWARE = 2 } PROCESS_DPI_AWARENESS;
+using SetProcessDpiAwareness_t = HRESULT(WINAPI *)(PROCESS_DPI_AWARENESS);
 
-  static constexpr auto SetProcessDpiAwareness =
-      library_symbol<SetProcessDpiAwareness_t>("SetProcessDpiAwareness");
-};
+constexpr auto SetProcessDpiAwareness =
+    library_symbol<SetProcessDpiAwareness_t>("SetProcessDpiAwareness");
+}; // namespace shcore_symbols
 
 class reg_key {
 public:
@@ -1450,8 +1450,8 @@ inline bool enable_dpi_awareness() {
 template <typename T>
 std::basic_string<T>
 get_last_native_path_component(const std::basic_string<T> &path) {
-  if (auto pos = path.find_last_of(static_cast<T>('\\'));
-      pos != std::basic_string<T>::npos) {
+  auto pos = path.find_last_of(static_cast<T>('\\'));
+  if (pos != std::basic_string<T>::npos) {
     return path.substr(pos + 1);
   }
   return std::basic_string<T>();


### PR DESCRIPTION
This should be a backward-compatible change because the library is statically linked into Go programs and the library's own dependencies such as the C++ runtime library are also statically linked using the `-static` flag.