### PR TITLE
Stop run loop instead of terminating app on macOS

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1079,13 +1079,9 @@ private:
     objc::msg_send<void>(m_window, "makeKeyAndOrderFront:"_sel, nullptr);
   }
   int on_application_should_terminate(id /*delegate*/, id app) {
-    dispatch([app] {
-      // Don't terminate the application.
-      objc::msg_send<void>(app, "replyToApplicationShouldTerminate:"_sel, NO);
-      // Instead stop the run loop.
-      objc::msg_send<void>(app, "stop:"_sel, nullptr);
-    });
-    return 2 /*NSTerminateLater*/;
+    // Stop the run loop instead of terminating the app.
+    objc::msg_send<void>(app, "stop:"_sel, nullptr);
+    return 0 /*NSTerminateCancel*/;
   }
   bool m_debug;
   void *m_parent_window;

--- a/webview.h
+++ b/webview.h
@@ -859,9 +859,10 @@ private:
                     (IMP)(+[](id, SEL, id) -> BOOL { return YES; }), "c@:@");
     class_addMethod(cls, "applicationShouldTerminate:"_sel,
                     (IMP)(+[](id self, SEL, id sender) -> int {
-                        auto w = get_associated_webview(self);
-                        return w->on_application_should_terminate(self, sender);
-                      }), "i@:@");
+                      auto w = get_associated_webview(self);
+                      return w->on_application_should_terminate(self, sender);
+                    }),
+                    "i@:@");
     // If the library was not initialized with an existing window then the user
     // is likely managing the application lifecycle and we would not get the
     // "applicationDidFinishLaunching:" message and therefore do not need to

--- a/webview.h
+++ b/webview.h
@@ -764,7 +764,8 @@ public:
   void *window() { return (void *)m_window; }
   void terminate() {
     auto app = get_shared_application();
-    objc::msg_send<void>(app, "terminate:"_sel, nullptr);
+    // Stop the run loop.
+    objc::msg_send<void>(app, "stop:"_sel, nullptr);
   }
   void run() {
     auto app = get_shared_application();

--- a/webview.h
+++ b/webview.h
@@ -762,9 +762,7 @@ public:
   }
   virtual ~cocoa_wkwebview_engine() = default;
   void *window() { return (void *)m_window; }
-  void terminate() {
-    stop_run_loop();
-  }
+  void terminate() { stop_run_loop(); }
   void run() {
     auto app = get_shared_application();
     objc::msg_send<void>(app, "run"_sel);

--- a/webview.h
+++ b/webview.h
@@ -1079,9 +1079,13 @@ private:
     objc::msg_send<void>(m_window, "makeKeyAndOrderFront:"_sel, nullptr);
   }
   int on_application_should_terminate(id /*delegate*/, id app) {
-    // Stop the run loop instead of terminating the app.
-    objc::msg_send<void>(app, "stop:"_sel, nullptr);
-    return 0 /*NSTerminateCancel*/;
+    dispatch([app] {
+      // Don't terminate the application.
+      objc::msg_send<void>(app, "replyToApplicationShouldTerminate:"_sel, NO);
+      // Instead stop the run loop.
+      objc::msg_send<void>(app, "stop:"_sel, nullptr);
+    });
+    return 2 /*NSTerminateLater*/;
   }
   bool m_debug;
   void *m_parent_window;


### PR DESCRIPTION
Stops the run loop after the last window is closed instead of terminating the app; otherwise user code would have no way of cleaning up.

Closes #989
Closes #372