### PR TITLE
Add support for dark title bar on Windows 10 and later

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1520,11 +1520,6 @@ inline int compare_os_version(unsigned int major, unsigned int minor,
   return false;
 }
 
-inline bool is_os_version_at_least(unsigned int major, unsigned int minor,
-                                   unsigned int build) {
-  return compare_os_version(major, minor, build) >= 0;
-}
-
 inline bool is_per_monitor_v2_awareness_available() {
   // Windows 10, version 1703
   return compare_os_version(10, 0, 15063) >= 0;

--- a/webview.h
+++ b/webview.h
@@ -1614,7 +1614,7 @@ inline SIZE make_window_frame_size(HWND window, int width, int height,
 inline bool is_dark_theme_enabled() {
   constexpr auto *sub_key =
       L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
-  reg_key key(HKEY_CURRENT_USER, sub_key, 0, KEY_READ | KEY_WOW64_32KEY);
+  reg_key key(HKEY_CURRENT_USER, sub_key, 0, KEY_READ);
   if (!key.is_open()) {
     // Default is light theme
     return false;

--- a/webview.h
+++ b/webview.h
@@ -1391,6 +1391,21 @@ constexpr auto AreDpiAwarenessContextsEqual =
         "AreDpiAwarenessContextsEqual");
 }; // namespace user32_symbols
 
+namespace dwmapi_symbols {
+typedef enum {
+  // This is used instead of DWMWA_USE_IMMERSIVE_DARK_MODE on old versions of
+  // Windows 10.
+  DWMWA_USE_IMMERSIVE_DARK_MODE_OLD = 19,
+  // Documented as being supported since Windows 11 build 22000, but it also
+  // works on Windows 10.
+  DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+} DWMWINDOWATTRIBUTE;
+using DwmSetWindowAttribute_t = HRESULT(WINAPI *)(HWND, DWORD, LPCVOID, DWORD);
+
+constexpr auto DwmSetWindowAttribute =
+    library_symbol<DwmSetWindowAttribute_t>("DwmSetWindowAttribute");
+}; // namespace dwmapi_symbols
+
 namespace shcore_symbols {
 typedef enum { PROCESS_PER_MONITOR_DPI_AWARE = 2 } PROCESS_DPI_AWARENESS;
 using SetProcessDpiAwareness_t = HRESULT(WINAPI *)(PROCESS_DPI_AWARENESS);
@@ -1430,22 +1445,30 @@ public:
   bool is_open() const { return !!m_handle; }
   bool get_handle() const { return m_handle; }
 
-  std::wstring query_string(const wchar_t *name) const {
+  template<typename Container>
+  void query_bytes(const wchar_t *name, Container& result) const {
     DWORD buf_length = 0;
     // Get the size of the data in bytes.
     auto status = RegQueryValueExW(m_handle, name, nullptr, nullptr, nullptr,
                                    &buf_length);
     if (status != ERROR_SUCCESS && status != ERROR_MORE_DATA) {
-      return std::wstring();
+      result.resize(0);
+      return;
     }
     // Read the data.
-    std::wstring result(buf_length / sizeof(wchar_t), 0);
-    auto buf = reinterpret_cast<LPBYTE>(&result[0]);
+    result.resize(buf_length / sizeof(typename Container::value_type));
+    auto *buf = reinterpret_cast<LPBYTE>(&result[0]);
     status =
         RegQueryValueExW(m_handle, name, nullptr, nullptr, buf, &buf_length);
     if (status != ERROR_SUCCESS) {
-      return std::wstring();
+      result.resize(0);
+      return;
     }
+  }
+
+  std::wstring query_string(const wchar_t *name) const {
+    std::wstring result;
+    query_bytes(name, result);
     // Remove trailing null-characters.
     for (std::size_t length = result.size(); length > 0; --length) {
       if (result[length - 1] != 0) {
@@ -1454,6 +1477,16 @@ public:
       }
     }
     return result;
+  }
+
+  unsigned int query_uint(const wchar_t *name,
+                          unsigned int default_value) const {
+    std::vector<char> data;
+    query_bytes(name, data);
+    if (data.size() < sizeof(DWORD)) {
+      return default_value;
+    }
+    return static_cast<unsigned int>(*reinterpret_cast<DWORD *>(data.data()));
   }
 
 private:
@@ -1576,6 +1609,34 @@ inline SIZE make_window_frame_size(HWND window, int width, int height,
   auto frame_width = r.right - r.left;
   auto frame_height = r.bottom - r.top;
   return {frame_width, frame_height};
+}
+
+inline bool is_dark_theme_enabled() {
+  constexpr auto *sub_key =
+      L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+  reg_key key(HKEY_CURRENT_USER, sub_key, 0, KEY_READ | KEY_WOW64_32KEY);
+  if (!key.is_open()) {
+    // Default is light theme
+    return false;
+  }
+  return key.query_uint(L"AppsUseLightTheme", 1) == 0;
+}
+
+inline void apply_window_theme(HWND window) {
+  auto dark_theme_enabled = is_dark_theme_enabled();
+
+  // Use "immersive dark mode" on systems that support it.
+  // Changes the color of the window's title bar (light or dark).
+  BOOL use_dark_mode{dark_theme_enabled ? TRUE : FALSE};
+  static native_library dwmapi{L"dwmapi.dll"};
+  if (auto fn = dwmapi.get(dwmapi_symbols::DwmSetWindowAttribute)) {
+    // Try the modern, documented attribute before the older, undocumented one.
+    if (fn(window, dwmapi_symbols::DWMWA_USE_IMMERSIVE_DARK_MODE,
+           &use_dark_mode, sizeof(use_dark_mode)) != S_OK) {
+      fn(window, dwmapi_symbols::DWMWA_USE_IMMERSIVE_DARK_MODE_OLD,
+         &use_dark_mode, sizeof(use_dark_mode));
+    }
+  }
 }
 
 // Enable built-in WebView2Loader implementation by default.
@@ -2079,6 +2140,7 @@ public:
           w->m_window = hwnd;
           SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(w));
           enable_non_client_dpi_scaling_if_needed(hwnd);
+          apply_window_theme(hwnd);
         } else {
           w = reinterpret_cast<win32_edge_engine *>(
               GetWindowLongPtrW(hwnd, GWLP_USERDATA));
@@ -2123,6 +2185,13 @@ public:
           // Due to this difference, don't use the suggested bounds.
           auto dpi = static_cast<int>(HIWORD(wp));
           w->on_dpi_changed(dpi);
+          break;
+        }
+        case WM_SETTINGCHANGE: {
+          auto *area = reinterpret_cast<const wchar_t *>(lp);
+          if (area) {
+            w->on_system_setting_change(area);
+          }
           break;
         }
         default:
@@ -2354,6 +2423,13 @@ private:
   SIZE get_scaled_size(int from_dpi, int to_dpi) const {
     auto size = get_size();
     return scale_size(size.cx, size.cy, from_dpi, to_dpi);
+  }
+
+  void on_system_setting_change(const wchar_t *area) {
+    // Detect light/dark mode change in system.
+    if (lstrcmpW(area, L"ImmersiveColorSet") == 0) {
+      apply_window_theme(m_window);
+    }
   }
 
   virtual void on_message(const std::string &msg) = 0;

--- a/webview.h
+++ b/webview.h
@@ -1445,8 +1445,8 @@ public:
   bool is_open() const { return !!m_handle; }
   bool get_handle() const { return m_handle; }
 
-  template<typename Container>
-  void query_bytes(const wchar_t *name, Container& result) const {
+  template <typename Container>
+  void query_bytes(const wchar_t *name, Container &result) const {
     DWORD buf_length = 0;
     // Get the size of the data in bytes.
     auto status = RegQueryValueExW(m_handle, name, nullptr, nullptr, nullptr,


### PR DESCRIPTION
## Test Procedure

1. Start app with light theme enabled for apps (system-wide setting). The titlebar color should be light.
2. Change the theme to dark and observe that the titlebar color changes to dark.
3. Start app with dark theme enabled. The titlebar color should be dark.
4. Change the theme to light and observe that the titlebar color changes to light.

## Test Results

### Old OS

Version | Supported
------- | ----------
7       | no/only light
8       | no/only light
8.1     | no/only light

### Windows 10

Version | Supported
------- | ----------
1607    | no/only light
1809    | yes\*
1909    | yes
2004    | yes
21H1    | yes
21H2    | yes
22H2    | yes

\* 1809: Doesn't update titlebar until activating the window. This behavior is consistent with File Explorer.

### Windows 11

Version | Supported
------- | ----------
22H2    | yes
