### PR TITLE
Refactor OS version comparison

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1460,8 +1460,12 @@ private:
   HKEY m_handle = nullptr;
 };
 
-inline bool is_os_version_at_least(unsigned int major, unsigned int minor,
-                                   unsigned int build) {
+// Compare the specified version against the OS version.
+// Returns less than 0 if the OS version is less.
+// Returns 0 if the versions are equal.
+// Returns greater than 0 if the specified version is greater.
+inline int compare_os_version(unsigned int major, unsigned int minor,
+                              unsigned int build) {
   // Use RtlGetVersion both to bypass potential issues related to
   // VerifyVersionInfo and manifests, and because both GetVersion and
   // GetVersionEx are deprecated.
@@ -1474,17 +1478,18 @@ inline bool is_os_version_at_least(unsigned int major, unsigned int minor,
     }
     if (vi.dwMajorVersion == major) {
       if (vi.dwMinorVersion == minor) {
-        return vi.dwBuildNumber >= build;
+        return static_cast<int>(vi.dwBuildNumber) - static_cast<int>(build);
       }
-      return vi.dwMinorVersion > minor;
+      return static_cast<int>(vi.dwMinorVersion) - static_cast<int>(minor);
     }
-    return vi.dwMajorVersion > major;
+    return static_cast<int>(vi.dwMajorVersion) - static_cast<int>(major);
   }
   return false;
 }
 
 inline bool is_per_monitor_v2_awareness_available() {
-  return is_os_version_at_least(10, 0, 15063); // Windows 10, version 1703
+  // Windows 10, version 1703
+  return compare_os_version(10, 0, 15063) >= 0;
 }
 
 inline bool enable_dpi_awareness() {


### PR DESCRIPTION
Replaces `is_os_version_at_least()` with `compare_os_version()` to allow for more flexible comparisons.