### PR TITLE
Remove unstable MinGW-w64 CI build job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,24 +50,6 @@ jobs:
         run: ./script/build.bat go:build go:test
         shell: cmd
 
-  build-windows-mingw:
-    strategy:
-      matrix:
-        cxx_std: [c++14, c++17, c++20]
-    runs-on: windows-latest
-    env:
-      CC: gcc
-      CXX: g++
-      CXX_STD: ${{ matrix.cxx_std }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Add MinGW-w64 to PATH
-        run: echo PATH=%ProgramData%\chocolatey\lib\mingw\tools\install\mingw64\bin;%PATH%>>%GITHUB_ENV%
-        shell: cmd
-      - name: Build and run tests
-        run: ./script/build.sh
-        shell: bash
-
   build-windows-msys2:
     strategy:
       matrix:


### PR DESCRIPTION
Compilation with MinGW-w64 appears to be broken in GHA runner image version 20230820. 20230804 is OK.

Error:

```
Error while processing D:\a\webview\webview\examples\basic.cc.
warning: argument unused during compilation: '-mwindows' [clang-diagnostic-unused-command-line-argument]
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.37.32822\include\yvals_core.h:847:1: error: static assertion failed: Error in C++ Standard Library usage. [clang-diagnostic-error]
_EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 16.0.0 or newer.");
^
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.37.32822\include\yvals_core.h:502:5: note: expanded from macro '_EMIT_STL_ERROR'
    static_assert(false, "Error in C++ Standard Library usage.")
    ^             ~~~~~
```

MinGW-w64 is still covered with MSYS2 so for now we can simply remove the unstable build job.