### PR TITLE
Fix WebKitGTK >= 2.22 check

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -623,7 +623,8 @@ private:
 
   static char *get_string_from_js_result(WebKitJavascriptResult *r) {
     char *s;
-#if WEBKIT_MAJOR_VERSION >= 2 && WEBKIT_MINOR_VERSION >= 22
+#if (WEBKIT_MAJOR_VERSION == 2 && WEBKIT_MINOR_VERSION >= 22) ||               \
+    WEBKIT_MAJOR_VERSION > 2
     JSCValue *value = webkit_javascript_result_get_js_value(r);
     s = jsc_value_to_string(value);
 #else


### PR DESCRIPTION
The existing compile-time condition for calling `webkit_javascript_result_get_js_value()` (WebKitGTK) isn't quite right.

If we consider an imaginary version 3.0, then the condition `WEBKIT_MAJOR_VERSION >= 2 && WEBKIT_MINOR_VERSION >= 22` will evaluate to false because 0 is less than 22. It would however evaluate to true for versions >= 3.22,  >= 4.22, etc.