### PR TITLE
Split migration guide from changelog and add release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,28 @@
 # Changelog
 
-### Migrating from v0.1.1 to v0.10.0
+All notable changes to this project will be documented in this file.
 
-1. Use opaque `webview_t` type instead of `struct webview`. Size, title and URL are controlled via API setter functions. Invoke callback has been replaced with `webview_bind()` and `webview_return()` to make native function bindings inter-operate with JS.
-2. If you have been using simplified `webview()` API to only open a single URL
-   in a webview window - this function has been removed. You now have to create
-   a new webview instance, configure and run it explicitly.
-3. `webview_init()` is replaced by `webview_create()` which creates a new webview instance.
-4. `webview_exit()` has been replaced with more meaningful `webview_destroy()`.
-5. Main UI loop with `webview_loop()` inside has been replaced with `webview_run()` runs infinitely until the webview window is closed.
-6. `webview_terminate()` remains the same.
-7. `webview_dispatch()` remains the same.
-8. `webview_set_title()` remains the same.
-9. `webview_set_color()` has been removed. Use `webview_get_window` and native
-   window APIs to control colors, transparency and other native window
-   properties. At some point these APIs might be brought back.
-10. `webview_set_fullscreen()` has been removed, see above.
-11. `webview_dialog()` has been removed. But I'd like to see it added back as a separate independent module or library.
-12. `webview_eval()` remains the same.
-13. `webview_inject_css()` has been removed. Use `webview_eval()` to create style tag manually.
-14. `webview_debug()` has been removed. Use whatever fits best to your programming language and environment to debug your GUI apps.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+Windows:
+
+- Custom WebView2Loader implementation ([#783](https://github.com/webview/webview/pull/783))
+- DPI scaling for Windows 10 and later ([#982](https://github.com/webview/webview/pull/982))
+- Add support for dark title bar on Windows 10 and later ([#996](https://github.com/webview/webview/pull/996))
+
+### Removed
+
+- Go binding ([#1009](https://github.com/webview/webview/pull/1009)) — moved to [webview/webview_go](https://github.com/webview/webview_go)
+
+## [0.1.1] - 2020-01-21
+
+## [0.1.0] - 2018-05-09
+
+[unreleased]: https://github.com/webview/webview/compare/0.1.1...HEAD
+[0.1.1]:      https://github.com/webview/webview/compare/0.1.0...0.1.1
+[0.1.0]:      https://github.com/webview/webview/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This is the first release since the library rewrite by [zserge](https://github.com/zserge) ([#315](https://github.com/webview/webview/pull/315)).
+
 ### Added
 
 Windows:
 
+- Microsoft Edge WebView2 backend ([#315](https://github.com/webview/webview/pull/315))
 - Custom WebView2Loader implementation ([#783](https://github.com/webview/webview/pull/783))
 - DPI scaling for Windows 10 and later ([#982](https://github.com/webview/webview/pull/982))
 - Add support for dark title bar on Windows 10 and later ([#996](https://github.com/webview/webview/pull/996))
 
 ### Removed
 
+- MSHTML backend ([#315](https://github.com/webview/webview/pull/315))
 - Go binding ([#1009](https://github.com/webview/webview/pull/1009)) — moved to [webview/webview_go](https://github.com/webview/webview_go)
 
 ## [0.1.1] - 2020-01-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-This is the first release since the library rewrite by [zserge](https://github.com/zserge) ([#315](https://github.com/webview/webview/pull/315)).
+This is the first release since the library rewrite by [zserge](https://github.com/zserge) ([#315](https://github.com/webview/webview/pull/315)), and is a necessary one that allows us to prepare for future changes in the library.
+
+Due to the vast amount of contributions that are in this release on top of the changes and removals introduced in the library rewrite, we've picked a few contributions aside from the rewrite that had a significant impact compared to the previous release.
 
 ### Added
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,22 @@
+# Migration
+
+## v0.1.1 to v0.10.0
+
+1. Use opaque `webview_t` type instead of `struct webview`. Size, title and URL are controlled via API setter functions. Invoke callback has been replaced with `webview_bind()` and `webview_return()` to make native function bindings inter-operate with JS.
+2. If you have been using simplified `webview()` API to only open a single URL
+   in a webview window - this function has been removed. You now have to create
+   a new webview instance, configure and run it explicitly.
+3. `webview_init()` is replaced by `webview_create()` which creates a new webview instance.
+4. `webview_exit()` has been replaced with more meaningful `webview_destroy()`.
+5. Main UI loop with `webview_loop()` inside has been replaced with `webview_run()` runs infinitely until the webview window is closed.
+6. `webview_terminate()` remains the same.
+7. `webview_dispatch()` remains the same.
+8. `webview_set_title()` remains the same.
+9. `webview_set_color()` has been removed. Use `webview_get_window` and native
+   window APIs to control colors, transparency and other native window
+   properties. At some point these APIs might be brought back.
+10. `webview_set_fullscreen()` has been removed, see above.
+11. `webview_dialog()` has been removed. But I'd like to see it added back as a separate independent module or library.
+12. `webview_eval()` remains the same.
+13. `webview_inject_css()` has been removed. Use `webview_eval()` to create style tag manually.
+14. `webview_debug()` has been removed. Use whatever fits best to your programming language and environment to debug your GUI apps.


### PR DESCRIPTION
This PR splits the migration guide from the changelog and instead adds some release notes into the changelog.

Release notes were not added for old releases because I couldn't find any notes associated with old releases.

After sifting through the PRs since the rewrite, I referenced a few in the changelog that I thought had a major impact on the library compared to the previous release, aside from the major rewrite.

Most of the PRs I picked are coincidentally my own, but the changelog can be amended upon request.