### PR TITLE
Fix various compile/lint warnings

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -411,7 +411,7 @@ inline std::string json_escape(const std::string &s, bool add_quotes = true) {
   // Add space for the double quotes.
   auto required_length = s.size() + (add_quotes ? 2 : 0);
   for (auto c : s) {
-    auto uc = static_cast<unsigned int>(c);
+    auto uc = static_cast<unsigned char>(c);
     if (is_json_special_char(uc)) {
       // '\' and a single following character
       required_length += 2;
@@ -442,8 +442,10 @@ inline std::string json_escape(const std::string &s, bool add_quotes = true) {
       auto h = (uc >> 4) & 0x0f;
       auto l = uc & 0x0f;
       result += "\\u00";
+      // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
       result += hex_alphabet[h];
       result += hex_alphabet[l];
+      // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
       continue;
     }
     result += c;

--- a/webview.h
+++ b/webview.h
@@ -2692,6 +2692,7 @@ public:
 
   // Asynchronous bind
   void bind(const std::string &name, binding_t fn, void *arg) {
+    // NOLINTNEXTLINE(readability-container-contains): contains() requires C++20
     if (bindings.count(name) > 0) {
       return;
     }

--- a/webview.h
+++ b/webview.h
@@ -2730,6 +2730,7 @@ public:
   }
 
   void resolve(const std::string &seq, int status, const std::string &result) {
+    // NOLINTNEXTLINE(modernize-avoid-bind): Lambda with move requires C++14
     dispatch(std::bind(
         [seq, status, this](std::string escaped_result) {
           std::string js;


### PR DESCRIPTION
The following GCC/Clang compile warnings were fixed/suppressed in the library.

Windows:
* `-Wmissing-braces`
* `-Wtype-limits`
* `-Wcast-function-type` (suppressed)
* `-Wpedantic` (extra ';')

All OS:
* `-Wstrict-prototypes`

The following clang-tidy warnings were fixed/suppressed:

* `bugprone-signed-char-misuse,cert-str34-c`
* `cppcoreguidelines-pro-bounds-constant-array-index`
* `readability-container-contains`
* `modernize-avoid-bind`