### PR TITLE
[FEATURE] Added the possibility to hide the frame of the window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ webview-example
 *.exe
 *.o
 
+.vscode
+
 examples/scrape/scrape

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ webview_test
 webview-example
 *.exe
 *.o
+*.pdb
 
 .vscode
 
 examples/scrape/scrape
+

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -17,7 +17,7 @@ int main() {
 #endif
   webview_t w = webview_create(0, NULL);
   webview_set_title(w, "Basic Example");
-  webview_hide_frame(w);
+  //webview_hide_frame(w);
   webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
   webview_set_html(w, "Thanks for using webview!");
   webview_run(w);

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -17,6 +17,7 @@ int main() {
 #endif
   webview_t w = webview_create(0, NULL);
   webview_set_title(w, "Basic Example");
+  webview_hide_frame(w);
   webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
   webview_set_html(w, "Thanks for using webview!");
   webview_run(w);

--- a/examples/no_frame.c
+++ b/examples/no_frame.c
@@ -16,7 +16,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine,
 int main() {
 #endif
   webview_t w = webview_create(0, NULL);
-  webview_set_title(w, "Basic Example");
+  webview_set_title(w, "No window frame example");
+  webview_hide_frame(w);
   webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
   webview_set_html(w, "Thanks for using webview!");
   webview_run(w);

--- a/examples/no_frame.cc
+++ b/examples/no_frame.cc
@@ -1,0 +1,16 @@
+#include "webview.h"
+
+#ifdef _WIN32
+int WINAPI WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,
+                   LPSTR /*lpCmdLine*/, int /*nCmdShow*/) {
+#else
+int main() {
+#endif
+  webview::webview w(false, nullptr);
+  w.set_title("Basic Example");
+  w.hide_frame();
+  w.set_size(480, 320, WEBVIEW_HINT_NONE);
+  w.set_html("Thanks for using webview!");
+  w.run();
+  return 0;
+}

--- a/script/build.bat
+++ b/script/build.bat
@@ -137,11 +137,13 @@ goto :main
     echo Building C++ examples...
     "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\basic.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\basic%exe_suffix%" || exit /b 1
     "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\bind.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\bind%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\no_frame.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\no_frame%exe_suffix%" || exit /b 1
 
     echo Building C examples...
     "%cxx_compiler%" /Zi /c %cxx_compile_flags% /DWEBVIEW_STATIC "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
     "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
     "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
+    "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\no_frame.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
 
     echo Building test app...
     "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1

--- a/script/build.bat
+++ b/script/build.bat
@@ -129,24 +129,24 @@ goto :main
     if not exist "%build_dir%\library" mkdir "%build_dir%\library"
 
     echo Building shared library...
-    "%cxx_compiler%" /Zi %cxx_compile_flags% /DWEBVIEW_BUILD_SHARED "%project_dir%\webview.cc" "/Fo%build_dir%\library"\ %cxx_link_flags% /link /DLL "/out:%build_dir%\library\webview%shared_lib_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% /DWEBVIEW_BUILD_SHARED "%project_dir%\webview.cc" "/Fo%build_dir%\library"\ %cxx_link_flags% /link /DLL "/out:%build_dir%\library\webview%shared_lib_suffix%" || exit /b 1
 
     if not exist "%build_dir%\examples\c" mkdir "%build_dir%\examples\c"
     if not exist "%build_dir%\examples\cc" mkdir "%build_dir%\examples\cc"
 
     echo Building C++ examples...
-    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\basic.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\basic%exe_suffix%" || exit /b 1
-    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\bind.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\bind%exe_suffix%" || exit /b 1
-    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\no_frame.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\no_frame%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\basic.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\basic%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\bind.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\bind%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\no_frame.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\no_frame%exe_suffix%" || exit /b 1
 
     echo Building C examples...
-    "%cxx_compiler%" /Zi /c %cxx_compile_flags% /DWEBVIEW_STATIC "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
-    "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
-    "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
-    "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\no_frame.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" /c %cxx_compile_flags% /DWEBVIEW_STATIC "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
+    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
+    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
+    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\no_frame.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
 
     echo Building test app...
-    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1
     goto :eof
 
 :task_test

--- a/script/build.bat
+++ b/script/build.bat
@@ -129,22 +129,22 @@ goto :main
     if not exist "%build_dir%\library" mkdir "%build_dir%\library"
 
     echo Building shared library...
-    "%cxx_compiler%" %cxx_compile_flags% /DWEBVIEW_BUILD_SHARED "%project_dir%\webview.cc" "/Fo%build_dir%\library"\ %cxx_link_flags% /link /DLL "/out:%build_dir%\library\webview%shared_lib_suffix%" || exit /b 1
+    "%cxx_compiler%" /Zi %cxx_compile_flags% /DWEBVIEW_BUILD_SHARED "%project_dir%\webview.cc" "/Fo%build_dir%\library"\ %cxx_link_flags% /link /DLL "/out:%build_dir%\library\webview%shared_lib_suffix%" || exit /b 1
 
     if not exist "%build_dir%\examples\c" mkdir "%build_dir%\examples\c"
     if not exist "%build_dir%\examples\cc" mkdir "%build_dir%\examples\cc"
 
     echo Building C++ examples...
-    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\basic.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\basic%exe_suffix%" || exit /b 1
-    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\examples\bind.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\bind%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\basic.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\basic%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\examples\bind.cc" "/Fo%build_dir%\examples\cc"\ %cxx_link_flags% /link "/out:%build_dir%\examples\cc\bind%exe_suffix%" || exit /b 1
 
     echo Building C examples...
-    "%cxx_compiler%" /c %cxx_compile_flags% /DWEBVIEW_STATIC "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
-    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
-    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" /Zi /c %cxx_compile_flags% /DWEBVIEW_STATIC "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
+    "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
+    "%c_compiler%" /Zi %c_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
 
     echo Building test app...
-    "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1
+    "%cxx_compiler%" /Zi %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1
     goto :eof
 
 :task_test

--- a/script/build.bat
+++ b/script/build.bat
@@ -110,8 +110,10 @@ goto :main
         "%project_dir%\webview_test.cc" ^
         "%project_dir%\examples/basic.c" ^
         "%project_dir%\examples/bind.c" ^
+        "%project_dir%\examples/no_frame.c" ^
         "%project_dir%\examples/basic.cc" ^
         "%project_dir%\examples/bind.cc" ^
+        "%project_dir%\examples/no_frame.cc" ^
         || exit /b 1
     goto :eof
 
@@ -143,7 +145,7 @@ goto :main
     "%cxx_compiler%" /c %cxx_compile_flags% /DWEBVIEW_STATIC "%project_dir%\webview.cc" "/Fo%build_dir%\library\webview.obj" %cxx_link_flags% || exit /b 1
     "%c_compiler%" %c_compile_flags% "%project_dir%\examples\basic.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\basic%exe_suffix%" || exit /b 1
     "%c_compiler%" %c_compile_flags% "%project_dir%\examples\bind.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
-    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\no_frame.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\bind%exe_suffix%" || exit /b 1
+    "%c_compiler%" %c_compile_flags% "%project_dir%\examples\no_frame.c" "%build_dir%\library\webview.obj" "/Fo%build_dir%\examples\c"\ %c_link_flags% /link "/out:%build_dir%\examples\c\no_frame%exe_suffix%" || exit /b 1
 
     echo Building test app...
     "%cxx_compiler%" %cxx_compile_flags% "%project_dir%\webview_test.cc" "/Fo%build_dir%"\ %cxx_link_flags% /link "/out:%build_dir%\webview_test%exe_suffix%" || exit /b 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -122,21 +122,21 @@ task_build() {
     mkdir -p "${build_dir}/examples/c" "${build_dir}/examples/cc" || true
 
     echo "Building C++ examples..."
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || return 1
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/no_frame.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/no_frame.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
 
     echo "Building C examples..."
-    "${cxx_compiler}" -g -c "${cxx_compile_flags[@]}" -DWEBVIEW_STATIC "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || return 1
-    "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || return 1
-    "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || return 1
-    "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/no_frame.c" -o "${build_dir}/examples/c/bind.o" || return 1
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || return 1
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/no_frame.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" -c "${cxx_compile_flags[@]}" -DWEBVIEW_STATIC "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || return 1
+    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || return 1
+    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || return 1
+    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/no_frame.c" -o "${build_dir}/examples/c/bind.o" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/no_frame.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
 
     echo "Building test app..."
-    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || return 1
 }
 
 task_test() {
@@ -313,7 +313,7 @@ fi
 tasks=(info clean format deps check build test)
 
 # Task override from command line
-if [[ ${#@} -gt 0 ]]; then
+if [[ ${#@}t 0 ]]; then
     tasks=("${@}")
 fi
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -124,13 +124,16 @@ task_build() {
     echo "Building C++ examples..."
     "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || return 1
     "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/no_frame.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
 
     echo "Building C examples..."
     "${cxx_compiler}" -g -c "${cxx_compile_flags[@]}" -DWEBVIEW_STATIC "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || return 1
     "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || return 1
     "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || return 1
+    "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/no_frame.c" -o "${build_dir}/examples/c/bind.o" || return 1
     "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || return 1
     "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/no_frame.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
 
     echo "Building test app..."
     "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || return 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -104,6 +104,7 @@ task_check() {
     echo "Linting..."
     clang-tidy "${project_dir}/examples/basic.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
     clang-tidy "${project_dir}/examples/bind.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
+    clang-tidy "${project_dir}/examples/no_frame.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
     clang-tidy "${project_dir}/webview_test.cc" -- "${cxx_compile_flags[@]}" "${cxx_link_flags[@]}" || return 1
 }
 
@@ -124,16 +125,16 @@ task_build() {
     echo "Building C++ examples..."
     "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || return 1
     "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/no_frame.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/no_frame.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/no_frame${exe_suffix}" || return 1
 
     echo "Building C examples..."
     "${cxx_compiler}" -c "${cxx_compile_flags[@]}" -DWEBVIEW_STATIC "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || return 1
     "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || return 1
     "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || return 1
-    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/no_frame.c" -o "${build_dir}/examples/c/bind.o" || return 1
+    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/no_frame.c" -o "${build_dir}/examples/c/no_frame.o" || return 1
     "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || return 1
     "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/no_frame.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/no_frame.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/no_frame${exe_suffix}" || return 1
 
     echo "Building test app..."
     "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || return 1
@@ -313,7 +314,7 @@ fi
 tasks=(info clean format deps check build test)
 
 # Task override from command line
-if [[ ${#@}t 0 ]]; then
+if [[ ${#@} -gt 0 ]]; then
     tasks=("${@}")
 fi
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -122,18 +122,18 @@ task_build() {
     mkdir -p "${build_dir}/examples/c" "${build_dir}/examples/cc" || true
 
     echo "Building C++ examples..."
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || return 1
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/basic.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/basic${exe_suffix}" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/examples/bind.cc" "${cxx_link_flags[@]}" -o "${build_dir}/examples/cc/bind${exe_suffix}" || return 1
 
     echo "Building C examples..."
-    "${cxx_compiler}" -c "${cxx_compile_flags[@]}" -DWEBVIEW_STATIC "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || return 1
-    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || return 1
-    "${c_compiler}" -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || return 1
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || return 1
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
+    "${cxx_compiler}" -g -c "${cxx_compile_flags[@]}" -DWEBVIEW_STATIC "${project_dir}/webview.cc" -o "${build_dir}/webview.o" || return 1
+    "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/basic.c" -o "${build_dir}/examples/c/basic.o" || return 1
+    "${c_compiler}" -g -c "${c_compile_flags[@]}" "${project_dir}/examples/bind.c" -o "${build_dir}/examples/c/bind.o" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/basic.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/basic${exe_suffix}" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${build_dir}/examples/c/bind.o" "${build_dir}/webview.o" "${cxx_link_flags[@]}" -o "${build_dir}/examples/c/bind${exe_suffix}" || return 1
 
     echo "Building test app..."
-    "${cxx_compiler}" "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || return 1
+    "${cxx_compiler}" -g "${cxx_compile_flags[@]}" "${project_dir}/webview_test.cc" "${cxx_link_flags[@]}" -o "${build_dir}/webview_test${exe_suffix}" || return 1
 }
 
 task_test() {

--- a/webview.h
+++ b/webview.h
@@ -143,6 +143,9 @@ WEBVIEW_API void *webview_get_window(webview_t w);
 // Updates the title of the native window. Must be called from the UI thread.
 WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 
+// Hides the native window frame
+WEBVIEW_API void webview_hide_frame(webview_t w);
+
 // Window size hints
 #define WEBVIEW_HINT_NONE 0  // Width and height are default size
 #define WEBVIEW_HINT_MIN 1   // Width and height are minimum bounds
@@ -829,8 +832,8 @@ inline id operator"" _str(const char *s, std::size_t) {
 class cocoa_wkwebview_engine {
 public:
   cocoa_wkwebview_engine(bool debug, void *window)
-      : m_debug{debug}, m_window{static_cast<id>(window)}, m_owns_window{
-                                                               !window} {
+      : m_debug{debug}, m_window{static_cast<id>(window)},
+        m_owns_window{!window} {
     auto app = get_shared_application();
     // See comments related to application lifecycle in create_app_delegate().
     if (!m_owns_window) {
@@ -2764,7 +2767,15 @@ if (status === 0) {
         result.empty() ? "undefined" : detail::json_escape(result)));
   }
 
+  void set_window_frame_visible(bool visibility) {
+    _frame_visbility = visibility;
+  }
+
+  bool get_window_frame_visible() { return _frame_visbility; }
+
 private:
+  bool _frame_visbility = true;
+
   void on_message(const std::string &msg) {
     auto seq = detail::json_parse(msg, "id", 0);
     auto name = detail::json_parse(msg, "method", 0);
@@ -2815,8 +2826,12 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title) {
   static_cast<webview::webview *>(w)->set_title(title);
 }
 
-WEBVIEW_API void webview_set_size(webview_t w, int width, int height,
-                                  int hints) {
+WEBVIEW_API void webview_hide_frame(webview_t w) {
+  static_cast<webview::webview *>(w)->set_window_frame_visible(false);
+}
+
+WEBVIEW_API
+void webview_set_size(webview_t w, int width, int height, int hints) {
   static_cast<webview::webview *>(w)->set_size(width, height, hints);
 }
 

--- a/webview.h
+++ b/webview.h
@@ -838,7 +838,7 @@ class cocoa_wkwebview_engine {
 public:
   cocoa_wkwebview_engine(bool debug, void *window)
       : m_debug{debug}, m_window{static_cast<id>(window)},
-        m_owns_window{!window},m_hide_frame{false} {
+        m_owns_window{!window}, m_hide_frame{false} {
     auto app = get_shared_application();
     // See comments related to application lifecycle in create_app_delegate().
     if (!m_owns_window) {
@@ -878,9 +878,7 @@ public:
                        delete f;
                      }));
   }
-  void hide_frame() {
-    m_hide_frame = true;
-  }
+  void hide_frame() { m_hide_frame = true; }
   void set_title(const std::string &title) {
     objc::msg_send<void>(m_window, "setTitle:"_sel,
                          objc::msg_send<id>("NSString"_cls,
@@ -888,7 +886,8 @@ public:
                                             title.c_str()));
   }
   void set_size(int width, int height, int hints) {
-    auto window_border_style = m_hide_frame ? NSWindowStyleMaskBorderless : NSWindowStyleMaskTitled;
+    auto window_border_style =
+        m_hide_frame ? NSWindowStyleMaskBorderless : NSWindowStyleMaskTitled;
     auto style = static_cast<NSWindowStyleMask>(
         window_border_style | NSWindowStyleMaskClosable |
         NSWindowStyleMaskMiniaturizable);
@@ -1114,7 +1113,8 @@ private:
     // Main window
     if (m_owns_window) {
       m_window = objc::msg_send<id>("NSWindow"_cls, "alloc"_sel);
-      auto style = m_hide_frame ? NSWindowStyleMaskBorderless : NSWindowStyleMaskTitled;
+      auto style =
+          m_hide_frame ? NSWindowStyleMaskBorderless : NSWindowStyleMaskTitled;
       m_window = objc::msg_send<id>(
           m_window, "initWithContentRect:styleMask:backing:defer:"_sel,
           CGRectMake(0, 0, 0, 0), style, NSBackingStoreBuffered, NO);

--- a/webview.h
+++ b/webview.h
@@ -603,8 +603,10 @@ public:
                        }),
                        this);
     }
+
     // Initialize webview widget
     m_webview = webkit_web_view_new();
+
     WebKitUserContentManager *manager =
         webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(m_webview));
     g_signal_connect(manager, "script-message-received::external",
@@ -646,6 +648,10 @@ public:
                     }),
                     new std::function<void()>(f),
                     [](void *f) { delete static_cast<dispatch_fn_t *>(f); });
+  }
+
+  void hide_frame() { 
+    gtk_window_set_decorated(GTK_WINDOW(m_window), FALSE); 
   }
 
   void set_title(const std::string &title) {
@@ -873,6 +879,7 @@ public:
                        delete f;
                      }));
   }
+  void hide_frame(){}
   void set_title(const std::string &title) {
     objc::msg_send<void>(m_window, "setTitle:"_sel,
                          objc::msg_send<id>("NSString"_cls,
@@ -2449,6 +2456,8 @@ public:
     PostMessageW(m_message_window, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
   }
 
+  void hide_frame(){}
+
   void set_title(const std::string &title) {
     SetWindowTextW(m_window, widen_string(title).c_str());
   }
@@ -2767,15 +2776,7 @@ if (status === 0) {
         result.empty() ? "undefined" : detail::json_escape(result)));
   }
 
-  void set_window_frame_visible(bool visibility) {
-    _frame_visbility = visibility;
-  }
-
-  bool get_window_frame_visible() { return _frame_visbility; }
-
 private:
-  bool _frame_visbility = true;
-
   void on_message(const std::string &msg) {
     auto seq = detail::json_parse(msg, "id", 0);
     auto name = detail::json_parse(msg, "method", 0);
@@ -2827,7 +2828,7 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title) {
 }
 
 WEBVIEW_API void webview_hide_frame(webview_t w) {
-  static_cast<webview::webview *>(w)->set_window_frame_visible(false);
+ static_cast<webview::webview *>(w)->hide_frame();
 }
 
 WEBVIEW_API

--- a/webview.h
+++ b/webview.h
@@ -650,7 +650,7 @@ public:
                     [](void *f) { delete static_cast<dispatch_fn_t *>(f); });
   }
 
-  void hide_frame() { gtk_window_set_decorated(GTK_WINDOW(m_window), FALSE); }
+  void hide_frame() { gtk_window_set_decorated(GTK_WINDOW(m_window), false); }
 
   void set_title(const std::string &title) {
     gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());

--- a/webview.h
+++ b/webview.h
@@ -650,9 +650,7 @@ public:
                     [](void *f) { delete static_cast<dispatch_fn_t *>(f); });
   }
 
-  void hide_frame() { 
-    gtk_window_set_decorated(GTK_WINDOW(m_window), FALSE); 
-  }
+  void hide_frame() { gtk_window_set_decorated(GTK_WINDOW(m_window), FALSE); }
 
   void set_title(const std::string &title) {
     gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());
@@ -879,7 +877,7 @@ public:
                        delete f;
                      }));
   }
-  void hide_frame(){}
+  void hide_frame() {}
   void set_title(const std::string &title) {
     objc::msg_send<void>(m_window, "setTitle:"_sel,
                          objc::msg_send<id>("NSString"_cls,
@@ -2456,7 +2454,11 @@ public:
     PostMessageW(m_message_window, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
   }
 
-  void hide_frame(){}
+  void hide_frame() {
+    LONG current_style = GetWindowLong(m_window, GWL_STYLE);
+    current_style &= ~(WS_CAPTION | WS_SIZEBOX | WS_BORDER | WS_THICKFRAME);
+    SetWindowLong(m_window, GWL_STYLE, current_style);
+  }
 
   void set_title(const std::string &title) {
     SetWindowTextW(m_window, widen_string(title).c_str());
@@ -2828,7 +2830,7 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title) {
 }
 
 WEBVIEW_API void webview_hide_frame(webview_t w) {
- static_cast<webview::webview *>(w)->hide_frame();
+  static_cast<webview::webview *>(w)->hide_frame();
 }
 
 WEBVIEW_API

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -49,6 +49,31 @@ static void test_c_api() {
   webview_destroy(w);
 }
 
+// =============================================================================
+// TEST: use C API to create a window, hide the frame, run app and terminate it.
+// =============================================================================
+static void cb_assert_arg(webview_t w, void *arg) {
+  assert(w != nullptr);
+  assert(memcmp(arg, "arg", 3) == 0);
+}
+static void cb_terminate(webview_t w, void *arg) {
+  assert(arg == nullptr);
+  webview_terminate(w);
+}
+static void test_c_api() {
+  webview_t w;
+  w = webview_create(false, nullptr);
+  webview_set_size(w, 480, 320, 0);
+  webview_set_title(w, "Test");
+  webview_set_html(w, "set_html ok");
+  webview_hide_frame(w);
+  webview_navigate(w, "data:text/plain,navigate%20ok");
+  webview_dispatch(w, cb_assert_arg, (void *)"arg");
+  webview_dispatch(w, cb_terminate, nullptr);
+  webview_run(w);
+  webview_destroy(w);
+}
+
 // =================================================================
 // TEST: use C API to test binding and unbinding.
 // =================================================================

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -52,15 +52,7 @@ static void test_c_api() {
 // =============================================================================
 // TEST: use C API to create a window, hide the frame, run app and terminate it.
 // =============================================================================
-static void cb_assert_arg(webview_t w, void *arg) {
-  assert(w != nullptr);
-  assert(memcmp(arg, "arg", 3) == 0);
-}
-static void cb_terminate(webview_t w, void *arg) {
-  assert(arg == nullptr);
-  webview_terminate(w);
-}
-static void test_c_api() {
+static void test_c_api_no_frame() {
   webview_t w;
   w = webview_create(false, nullptr);
   webview_set_size(w, 480, 320, 0);
@@ -491,6 +483,7 @@ int main(int argc, char *argv[]) {
   std::unordered_map<std::string, std::function<void()>> all_tests = {
       {"terminate", test_terminate},
       {"c_api", test_c_api},
+      {"c_api_no_frame", test_c_api_no_frame},
       {"c_api_bind", test_c_api_bind},
       {"c_api_version", test_c_api_version},
       {"bidir_comms", test_bidir_comms},


### PR DESCRIPTION
Hi! 
So I added the possibility to hide the frame of the window. Such feature we have it in basically all frameworks to create desktop apps, and also it is useful in case you would like to make your own bar to have a fully customized UI that integrates with the rest of the style.

## API

### Windows

In windows `hide_frame`, I change the window style by calling `SetWindowLong` and changing the window style to styles that have no border.

### GTK (Linux, and BSD)

For gtk what I do is to use `gtk_window_set_decorated` and simply set the decorated window to `false`.

### macOS

For Mac, it was not this straight forward, as the window has to be created with no frame and can not be changed afterward.
What I did is to create an attribute called `m_hide_frame `with default value `false`, if the `hide_frame` is called it will be set to `true`, then i when we call create window I check if m_hide_frame is true and if it is, I set the window style to `NSWindowStyleMaskBorderless`.

I also added the unit test and the created a `no_frame` test program.

For any change, please let me know and I will work on it asap.
