### PR TITLE
- Allow WebView to be put in a regular NSView (Cocoa)

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1182,7 +1182,11 @@ private:
       };
       )"");
     objc::msg_send<void>(m_window, "setContentView:"_sel, m_webview);
-    objc::msg_send<void>(m_window, "makeKeyAndOrderFront:"_sel, nullptr);
+
+    // External window handle can be NSView, so don't try to act on it.
+    if (m_owns_window) {
+      objc::msg_send<void>(m_window, "makeKeyAndOrderFront:"_sel, nullptr);
+    }
   }
   int on_application_should_terminate(id /*delegate*/, id app) {
     dispatch([app, this] {


### PR DESCRIPTION
makeKeyAndOrderFront: only works on NSWindow and therefore shouldn't be executed if an external handle is provided in webview_create(). With this fix, all works as expected in an NSView.