### PR TITLE
Explicitly set GHA image and compiler versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,19 @@ jobs:
     strategy:
       matrix:
         cxx_std: [c++11, c++14, c++17, c++20]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CXX_STD: ${{ matrix.cxx_std }}
     steps:
+      # Set default compiler toolchain version to latest available versions for Ubuntu 22.04 as of 2023-11-27
+      - name: Set default compiler toolchain versions
+        run: |
+          sudo update-alternatives --force --install /usr/bin/gcc gcc /usr/bin/gcc-12 1200 --slave /usr/bin/g++ g++ /usr/bin/g++-12
+          sudo update-alternatives --remove-all clang
+          sudo update-alternatives --remove-all clang++
+          sudo update-alternatives --remove-all clang-format
+          sudo update-alternatives --remove-all clang-tidy
+          sudo update-alternatives --force --install /usr/bin/clang clang /usr/bin/clang-15 1500 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-15 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev xvfb -y


### PR DESCRIPTION
The `ubuntu-22.04` GHA image appears to have been updated in some way since the last commit in `master` which has broken future CI builds.

The issue appears to be that Clang (Tidy) 14 uses GCC 13 headers and somehow that appears to be an issue as shown below:

    /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression [clang-diagnostic-error]
            static constexpr unsigned fractional_width = {_S_fractional_width()};
                                                        ^
    /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: note: undefined function '_S_fractional_width' cannot be used in a constant expression
    /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2275:2: note: declared here
            _S_fractional_width()
            ^

This work "fixes" (works around) this issue by pinning Clang tools to a a more recent version.

While making this change for Clang tools, I thought it would sense to do the same for GCC, and also pin the GHA image to `ubuntu-22.04` instead of `ubuntu-latest`.

Old defaults:
* GCC: 11
* Clang: 14

New defaults:
* GCC: 12
* Clang: 15