### PR TITLE
Reduce interference with user-owned window (GTK)

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -620,6 +620,7 @@ public:
          "external.postMessage(s);}}");
 
     gtk_container_add(GTK_CONTAINER(m_window), GTK_WIDGET(m_webview));
+    gtk_widget_show(GTK_WIDGET(m_webview));
 
     WebKitSettings *settings =
         webkit_web_view_get_settings(WEBKIT_WEB_VIEW(m_webview));

--- a/webview.h
+++ b/webview.h
@@ -585,7 +585,8 @@ class gtk_webkit_engine {
 public:
   gtk_webkit_engine(bool debug, void *window)
       : m_window(static_cast<GtkWidget *>(window)) {
-    if (!m_window) {
+    auto owns_window = !window;
+    if (owns_window) {
       if (gtk_init_check(nullptr, nullptr) == FALSE) {
         return;
       }
@@ -619,7 +620,6 @@ public:
          "external.postMessage(s);}}");
 
     gtk_container_add(GTK_CONTAINER(m_window), GTK_WIDGET(m_webview));
-    gtk_widget_grab_focus(GTK_WIDGET(m_webview));
 
     WebKitSettings *settings =
         webkit_web_view_get_settings(WEBKIT_WEB_VIEW(m_webview));
@@ -630,7 +630,10 @@ public:
       webkit_settings_set_enable_developer_extras(settings, true);
     }
 
-    gtk_widget_show_all(m_window);
+    if (owns_window) {
+      gtk_widget_grab_focus(GTK_WIDGET(m_webview));
+      gtk_widget_show_all(m_window);
+    }
   }
   virtual ~gtk_webkit_engine() = default;
   void *window() { return (void *)m_window; }


### PR DESCRIPTION
Don't attempt to show window or grab focus when a user-owned window is passed in.

Example code:

```c
#include "webview.h"

#include <gtk/gtk.h>

static void activate(GtkApplication *app, gpointer user_data) {
  GtkWidget *window = gtk_application_window_new(app);
  gtk_window_set_title(GTK_WINDOW(window), "Window");
  gtk_window_set_default_size(GTK_WINDOW(window), 480, 320);

  webview_t w = webview_create(0, window);
  webview_set_html(w, "<input "
                      "id=\"input\"><script>document.getElementById(\"input\")."
                      "focus()</script>");

  gtk_widget_show_all(window);

  *(webview_t *)user_data = w;
}

int main(int argc, char **argv) {
  webview_t w = NULL;

  GtkApplication *app =
      gtk_application_new("org.gtk.example", G_APPLICATION_FLAGS_NONE);
  g_signal_connect(app, "activate", G_CALLBACK(activate), &w);

  g_application_run(G_APPLICATION(app), argc, argv);
  g_object_unref(app);

  webview_destroy(w);

  return 0;
}
```