### PR TITLE
Workaround for blank window with WebKit/DMA-BUF/NVIDIA/X11

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -807,6 +807,20 @@ static inline bool is_using_nvidia_driver() {
   return S_ISDIR(buffer.st_mode);
 }
 
+// Checks whether Wayland is used.
+static inline bool is_wayland_display() {
+  if (!get_env("WAYLAND_DISPLAY").empty()) {
+    return true;
+  }
+  if (get_env("XDG_SESSION_TYPE") == "wayland") {
+    return true;
+  }
+  if (get_env("DESKTOP_SESSION").find("wayland") != std::string::npos) {
+    return true;
+  }
+  return false;
+}
+
 // Checks whether WebKit is affected by bug when using DMA-BUF renderer.
 // Returns true if all of the following conditions are met:
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
@@ -822,6 +836,9 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
+    return false;
+  }
+  if (is_wayland_display()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {

--- a/webview.h
+++ b/webview.h
@@ -762,6 +762,7 @@ namespace detail {
 // Namespace containing workaround for WebKit 2.42 when using NVIDIA GPU
 // driver and X11.
 // See WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=261874
+// Please remove all of the code in this namespace when it's no longer needed.
 namespace webkit_dmabuf {
 
 // Get mutex used to make sure we don't call getenv/setenv concurrently.

--- a/webview.h
+++ b/webview.h
@@ -752,10 +752,6 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
 
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
-
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -811,24 +807,11 @@ static inline bool is_using_nvidia_driver() {
   return S_ISDIR(buffer.st_mode);
 }
 
-// Checks whether the default display is using the GDK X11 backend.
-// See: https://docs.gtk.org/gdk3/class.DisplayManager.html
-static inline bool is_x11_display() {
-#ifdef GDK_WINDOWING_X11
-  auto *manager = gdk_display_manager_get();
-  auto *display = gdk_display_manager_get_default_display(manager);
-  return GDK_IS_X11_DISPLAY(display);
-#else
-  return false;
-#endif
-}
-
 // Checks whether WebKit is affected by bug when using DMA-BUF renderer.
 // Returns true if all of the following conditions are met:
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
 //  - Environment variables are empty or not set:
 //    - WEBKIT_DISABLE_DMABUF_RENDERER
-//  - Windowing system is X11.
 //  - NVIDIA GPU driver is used.
 static inline bool is_webkit_dmabuf_bugged() {
   auto wk_major = webkit_get_major_version();
@@ -839,9 +822,6 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
-    return false;
-  }
-  if (!is_x11_display()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {

--- a/webview.h
+++ b/webview.h
@@ -764,6 +764,15 @@ namespace detail {
 // Please remove all of the code in this namespace when it's no longer needed.
 namespace webkit_dmabuf {
 
+namespace x11_symbols {
+struct Display;
+using XOpenDisplay_t = Display *(*)(char *);
+using XCloseDisplay_t = int (*)(Display *);
+
+constexpr auto XOpenDisplay = library_symbol<XOpenDisplay_t>("XOpenDisplay");
+constexpr auto XCloseDisplay = library_symbol<XCloseDisplay_t>("XCloseDisplay");
+} // namespace x11_symbols
+
 // Get mutex used to make sure we don't call getenv/setenv concurrently.
 static std::mutex &get_env_mutex() {
   static std::mutex mutex;
@@ -807,11 +816,35 @@ static inline bool is_using_nvidia_driver() {
   return S_ISDIR(buffer.st_mode);
 }
 
+// Checks whether X11 is used by attempting to connect to the X server using
+// the display pointed by the DISPLAY environment variable.
+static inline bool is_x11_display() {
+  native_library x11{"libX11.so"};
+  if (!x11.is_loaded()) {
+    return false;
+  }
+
+  auto open_fn = x11.get(x11_symbols::XOpenDisplay);
+  auto close_fn = x11.get(x11_symbols::XCloseDisplay);
+  if (!open_fn || !close_fn) {
+    return false;
+  }
+
+  auto *display = open_fn(nullptr);
+  if (!display) {
+    return false;
+  }
+
+  close_fn(display);
+  return true;
+}
+
 // Checks whether WebKit is affected by bug when using DMA-BUF renderer.
 // Returns true if all of the following conditions are met:
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
 //  - Environment variables are empty or not set:
 //    - WEBKIT_DISABLE_DMABUF_RENDERER
+//  - Windowing system is X11.
 //  - NVIDIA GPU driver is used.
 static inline bool is_webkit_dmabuf_bugged() {
   auto wk_major = webkit_get_major_version();
@@ -822,6 +855,9 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
+    return false;
+  }
+  if (!is_x11_display()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {

--- a/webview.h
+++ b/webview.h
@@ -796,9 +796,9 @@ static inline bool is_x11_session() {
 }
 
 static inline bool is_using_nvidia_driver() {
-  static std::array<const char *, 6> cmd{"nvidia-smi",           "--query-gpu",
-                                         "driver_version",       "--format",
-                                         "csv,noheader,nounits", nullptr};
+  static constexpr std::array<const char *, 6> cmd{
+      "nvidia-smi", "--query-gpu",          "driver_version",
+      "--format",   "csv,noheader,nounits", nullptr};
   posix_spawn_file_actions_t actions{};
   posix_spawn_file_actions_t *actionsp{};
   if (posix_spawn_file_actions_init(&actions) == 0) {

--- a/webview.h
+++ b/webview.h
@@ -759,7 +759,7 @@ namespace webview {
 namespace detail {
 
 // Namespace containing workaround for WebKit 2.42 when using NVIDIA GPU
-// driver and X11.
+// driver.
 // See WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=261874
 // Please remove all of the code in this namespace when it's no longer needed.
 namespace webkit_dmabuf {
@@ -812,7 +812,6 @@ static inline bool is_using_nvidia_driver() {
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
 //  - Environment variables are empty or not set:
 //    - WEBKIT_DISABLE_DMABUF_RENDERER
-//  - Windowing system is X11.
 //  - NVIDIA GPU driver is used.
 static inline bool is_webkit_dmabuf_bugged() {
   auto wk_major = webkit_get_major_version();

--- a/webview.h
+++ b/webview.h
@@ -798,11 +798,6 @@ static inline void set_env(const std::string &name, const std::string &value) {
   return set_env(name, value, get_env_mutex());
 }
 
-// Checks whether the current windowing system is X11.
-static inline bool is_x11_session() {
-  return get_env("XDG_SESSION_TYPE") == "x11";
-}
-
 // Checks whether the NVIDIA GPU driver is used by querying the GPU driver
 // version using the nvidia-smi tool.
 // Returns true if the exit code of nvidia-smi is zero; otherwise false.
@@ -855,9 +850,6 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
-    return false;
-  }
-  if (!is_x11_session()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {

--- a/webview.h
+++ b/webview.h
@@ -844,7 +844,6 @@ static inline bool is_using_nvidia_driver() {
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
 //  - Environment variables are empty or not set:
 //    - WEBKIT_DISABLE_DMABUF_RENDERER
-//    - WEBKIT_DISABLE_COMPOSITING_MODE
 //  - Windowing system is X11.
 //  - NVIDIA GPU driver is used.
 static inline bool is_webkit_dmabuf_bugged() {
@@ -856,9 +855,6 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
-    return false;
-  }
-  if (!get_env("WEBKIT_DISABLE_COMPOSITING_MODE").empty()) {
     return false;
   }
   if (!is_x11_session()) {

--- a/webview.h
+++ b/webview.h
@@ -752,6 +752,10 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
 
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -807,11 +811,39 @@ static inline bool is_using_nvidia_driver() {
   return S_ISDIR(buffer.st_mode);
 }
 
+// Checks whether the windowing system is Wayland.
+static inline bool is_wayland_display() {
+  if (!get_env("WAYLAND_DISPLAY").empty()) {
+    return true;
+  }
+  if (get_env("XDG_SESSION_TYPE") == "wayland") {
+    return true;
+  }
+  if (get_env("DESKTOP_SESSION").find("wayland") != std::string::npos) {
+    return true;
+  }
+  return false;
+}
+
+// Checks whether the GDK X11 backend is used.
+// See: https://docs.gtk.org/gdk3/class.DisplayManager.html
+static inline bool is_gdk_x11_backend() {
+#ifdef GDK_WINDOWING_X11
+  auto *manager = gdk_display_manager_get();
+  auto *display = gdk_display_manager_get_default_display(manager);
+  return GDK_IS_X11_DISPLAY(display);
+#else
+  return false;
+#endif
+}
+
 // Checks whether WebKit is affected by bug when using DMA-BUF renderer.
 // Returns true if all of the following conditions are met:
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
 //  - Environment variables are empty or not set:
 //    - WEBKIT_DISABLE_DMABUF_RENDERER
+//  - Windowing system is not Wayland.
+//  - GDK backend is X11.
 //  - NVIDIA GPU driver is used.
 static inline bool is_webkit_dmabuf_bugged() {
   auto wk_major = webkit_get_major_version();
@@ -822,6 +854,12 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
+    return false;
+  }
+  if (is_wayland_display()) {
+    return false;
+  }
+  if (!is_gdk_x11_backend()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {

--- a/webview.h
+++ b/webview.h
@@ -752,6 +752,10 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
 
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -807,11 +811,24 @@ static inline bool is_using_nvidia_driver() {
   return S_ISDIR(buffer.st_mode);
 }
 
+// Checks whether the default display is using the GDK X11 backend.
+// See: https://docs.gtk.org/gdk3/class.DisplayManager.html
+static inline bool is_x11_display() {
+#ifdef GDK_WINDOWING_X11
+  auto *manager = gdk_display_manager_get();
+  auto *display = gdk_display_manager_get_default_display(manager);
+  return GDK_IS_X11_DISPLAY(display);
+#else
+  return false;
+#endif
+}
+
 // Checks whether WebKit is affected by bug when using DMA-BUF renderer.
 // Returns true if all of the following conditions are met:
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
 //  - Environment variables are empty or not set:
 //    - WEBKIT_DISABLE_DMABUF_RENDERER
+//  - Windowing system is X11.
 //  - NVIDIA GPU driver is used.
 static inline bool is_webkit_dmabuf_bugged() {
   auto wk_major = webkit_get_major_version();
@@ -822,6 +839,9 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
+    return false;
+  }
+  if (!is_x11_display()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {

--- a/webview.h
+++ b/webview.h
@@ -761,24 +761,6 @@ namespace detail {
 
 namespace webkit_dmabuf {
 
-namespace webkit_symbols {
-using webkit_web_view_evaluate_javascript_t =
-    void (*)(WebKitWebView *, const char *, gssize, const char *, const char *,
-             GCancellable *, GAsyncReadyCallback, gpointer);
-
-using webkit_web_view_run_javascript_t = void (*)(WebKitWebView *,
-                                                  const gchar *, GCancellable *,
-                                                  GAsyncReadyCallback,
-                                                  gpointer);
-
-constexpr auto webkit_web_view_evaluate_javascript =
-    library_symbol<webkit_web_view_evaluate_javascript_t>(
-        "webkit_web_view_evaluate_javascript");
-constexpr auto webkit_web_view_run_javascript =
-    library_symbol<webkit_web_view_run_javascript_t>(
-        "webkit_web_view_run_javascript");
-} // namespace webkit_symbols
-
 static std::mutex &get_env_mutex() {
   static std::mutex mutex;
   return mutex;

--- a/webview.h
+++ b/webview.h
@@ -807,20 +807,6 @@ static inline bool is_using_nvidia_driver() {
   return S_ISDIR(buffer.st_mode);
 }
 
-// Checks whether Wayland is used.
-static inline bool is_wayland_display() {
-  if (!get_env("WAYLAND_DISPLAY").empty()) {
-    return true;
-  }
-  if (get_env("XDG_SESSION_TYPE") == "wayland") {
-    return true;
-  }
-  if (get_env("DESKTOP_SESSION").find("wayland") != std::string::npos) {
-    return true;
-  }
-  return false;
-}
-
 // Checks whether WebKit is affected by bug when using DMA-BUF renderer.
 // Returns true if all of the following conditions are met:
 //  - WebKit version is >= 2.42 (please narrow this down when there's a fix).
@@ -836,9 +822,6 @@ static inline bool is_webkit_dmabuf_bugged() {
     return false;
   }
   if (!get_env("WEBKIT_DISABLE_DMABUF_RENDERER").empty()) {
-    return false;
-  }
-  if (is_wayland_display()) {
     return false;
   }
   if (!is_using_nvidia_driver()) {


### PR DESCRIPTION
WebKit 2.42 along with X11 and NVIDIA GPU driver triggers bug: https://bugs.webkit.org/show_bug.cgi?id=261874

The bug causes a blank window. Instead of waiting for the problem to be fixed, this work attempts to check for these conditions before setting the environment variable `WEBKIT_DISABLE_DMABUF_RENDERER` to `1`.

If the variable `WEBKIT_DISABLE_DMABUF_RENDERER` has already been set then the workaround is not applied.

I would have preferred not to implement this workaround but we don't know for how long we'll have to wait for a proper fix or a workaround to land in everyone's favorite Linux distro.

For now we can implement a workaround and then monitor the situation.