### PR TITLE
Fix set_size useless for Windows when create with an external window

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -2488,6 +2488,7 @@ public:
       return;
     }
 
+    is_m_window_external=window!=0;
     HINSTANCE hInstance = GetModuleHandle(nullptr);
 
     if (!window) {
@@ -2689,6 +2690,10 @@ public:
   }
 
   void set_size(int width, int height, int hints) {
+    if(is_m_window_external){
+      resize_widget();
+      return;
+    }
     auto style = GetWindowLong(m_window, GWL_STYLE);
     if (hints == WEBVIEW_HINT_FIXED) {
       style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
@@ -2874,6 +2879,7 @@ private:
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init;
   HWND m_window = nullptr;
+  bool is_m_window_external=false;
   HWND m_message_window = nullptr;
   POINT m_minsz = POINT{0, 0};
   POINT m_maxsz = POINT{0, 0};

--- a/webview.h
+++ b/webview.h
@@ -2691,7 +2691,14 @@ public:
 
   void set_size(int width, int height, int hints) {
     if (is_m_window_external) {
-      resize_widget();
+      if (m_controller == nullptr) {
+        return;
+      }
+      RECT bounds = {};
+      GetClientRect(m_window, &bounds);
+      bounds.bottom = bounds.top + height;
+      bounds.right = bounds.left + width;
+      m_controller->put_Bounds(bounds);
       return;
     }
     auto style = GetWindowLong(m_window, GWL_STYLE);

--- a/webview.h
+++ b/webview.h
@@ -2488,7 +2488,7 @@ public:
       return;
     }
 
-    is_m_window_external=window!=0;
+    is_m_window_external = window != 0;
     HINSTANCE hInstance = GetModuleHandle(nullptr);
 
     if (!window) {
@@ -2690,7 +2690,7 @@ public:
   }
 
   void set_size(int width, int height, int hints) {
-    if(is_m_window_external){
+    if (is_m_window_external) {
       resize_widget();
       return;
     }
@@ -2879,7 +2879,7 @@ private:
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init;
   HWND m_window = nullptr;
-  bool is_m_window_external=false;
+  bool is_m_window_external = false;
   HWND m_message_window = nullptr;
   POINT m_minsz = POINT{0, 0};
   POINT m_maxsz = POINT{0, 0};


### PR DESCRIPTION
When use set_size/webview_set_size on Windows while the webview is created with an external window HWND, set_size only resize that external window and will not resize inner webview's window, and actually we want to resize the webview window rather than external window.