### PR TITLE
Fix JSON escaping with UTF-8

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -506,11 +506,9 @@ inline std::string json_escape(const std::string &s, bool add_quotes = true) {
     if (is_ascii_control_char(c)) {
       // Escape as \u00xx
       static constexpr char hex_alphabet[]{"0123456789abcdef"};
-
       auto uc = static_cast<unsigned char>(c);
       auto h = (uc >> 4) & 0x0f;
       auto l = uc & 0x0f;
-
       result += "\\u00";
       // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
       result += hex_alphabet[h];

--- a/webview.h
+++ b/webview.h
@@ -2997,8 +2997,8 @@ delete window._rpc[seq];
 if (result !== undefined) {
   try {
     result = JSON.parse(result);
-  } catch (err) {
-    promise.reject(new Error("Failed to parse binding result as JSON: " + err));
+  } catch {
+    promise.reject(new Error("Failed to parse binding result as JSON"));
     return;
   }
 }

--- a/webview.h
+++ b/webview.h
@@ -233,6 +233,7 @@ WEBVIEW_API const webview_version_info_t *webview_version(void);
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <functional>
 #include <future>
@@ -521,6 +522,8 @@ inline std::string json_escape(const std::string &s, bool add_quotes = true) {
   if (add_quotes) {
     result += '"';
   }
+  // Should have calculated the exact amount of memory needed
+  assert(required_length == result.size());
   return result;
 }
 


### PR DESCRIPTION
This work fixes a bug introduced in #1002 where returning UTF-8-encoded strings from bound C++ functions could cause the JS callbacks to not be invoked. The bug could be triggered with characters encoded with a size greater than 1 byte.

Cases of incorrect escaping of characters:

* `DEL` (`0x7f`) isn't required to be escaped and is therefore no longer being escaped.
* `0x80` through `0x9f` were escaped but `0x80` and up is used for multibyte characters in context with UTF-8-encoding. For example, the UTF-8 byte sequence of the Unicode character `⌨` is `0xe3, 0x8c, 0xa8`; however, `0x8c` would be escaped and break the sequence.
* Characters `\b`, `\f`, `\n`, `\r` and `\t` are now properly escaped.

Existing code reserved more memory than needed for the escaped string. This has been corrected, and an `assert` has been added to make sure that we reserve the exact amount needed.

Some useful code was taken from #1067.

Closes #1066.