### PR TITLE
Fix webview_get_window documentation for Win32

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -135,9 +135,9 @@ WEBVIEW_API void webview_terminate(webview_t w);
 WEBVIEW_API void
 webview_dispatch(webview_t w, void (*fn)(webview_t w, void *arg), void *arg);
 
-// Returns a native window handle pointer. When using a GTK backend the pointer
-// is a GtkWindow pointer, when using a Cocoa backend the pointer is a NSWindow
-// pointer, when using a Win32 backend the pointer is a HWND pointer.
+// Returns the native handle of the window associated with the webview instance.
+// The handle can be a GtkWindow pointer (GTK), NSWindow pointer (Cocoa) or
+// HWND (Win32).
 WEBVIEW_API void *webview_get_window(webview_t w);
 
 // Updates the title of the native window. Must be called from the UI thread.


### PR DESCRIPTION
Documentation for this function claimed that it would return an "`HWND` pointer" (pointer to `HWND`?), but it actually returns an `HWND`.

Reworded the documentation for clarity and readability.