### PR TITLE
Embed WebView2 into a child window (Win32)

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -2622,7 +2622,7 @@ public:
     widget_wc.hInstance = hInstance;
     widget_wc.lpszClassName = L"webview_widget";
     widget_wc.lpfnWndProc =
-        +[](HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) -> LRESULT {
+        (WNDPROC)(+[](HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) -> LRESULT {
       win32_edge_engine *w{};
 
       if (msg == WM_NCCREATE) {
@@ -2651,7 +2651,7 @@ public:
         return DefWindowProcW(hwnd, msg, wp, lp);
       }
       return 0;
-    };
+    });
     auto widget_atom = RegisterClassExW(&widget_wc);
     CreateWindowExW(WS_EX_CONTROLPARENT, L"webview_widget", nullptr, WS_CHILD,
                     0, 0, 0, 0, m_window, nullptr, hInstance, this);

--- a/webview.h
+++ b/webview.h
@@ -2621,8 +2621,8 @@ public:
     widget_wc.cbSize = sizeof(WNDCLASSEX);
     widget_wc.hInstance = hInstance;
     widget_wc.lpszClassName = L"webview_widget";
-    widget_wc.lpfnWndProc =
-        (WNDPROC)(+[](HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) -> LRESULT {
+    widget_wc.lpfnWndProc = (WNDPROC)(+[](HWND hwnd, UINT msg, WPARAM wp,
+                                          LPARAM lp) -> LRESULT {
       win32_edge_engine *w{};
 
       if (msg == WM_NCCREATE) {


### PR DESCRIPTION
Linux/GTK and macOS/Cocoa both support automatic UI layouting and can therefore automatically resize the webview widget when embedded into a non-owned window, but Windows/Win32 has no automatic layout system. I don't believe that we can non-intrusively determine when the widget should be resized. An intrusive way could be to replace the non-owned window's WndProc.

This work creates a UI widget (child window) that WebView2 can render onto, and this widget is embedded into the top-level window. If we expose the native handle of this widget then we can let the owner of the window take responsibility of resizing the widget.