### PR TITLE
Delete webview copy/move constructor/assignment

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -968,6 +968,10 @@ public:
       gtk_widget_show_all(m_window);
     }
   }
+  gtk_webkit_engine(const gtk_webkit_engine &) = delete;
+  gtk_webkit_engine &operator=(const gtk_webkit_engine &) = delete;
+  gtk_webkit_engine(gtk_webkit_engine &&) = delete;
+  gtk_webkit_engine &operator=(gtk_webkit_engine &&) = delete;
   virtual ~gtk_webkit_engine() = default;
   void *window() { return (void *)m_window; }
   void *widget() { return (void *)m_webview; }
@@ -1234,6 +1238,10 @@ public:
       }
     }
   }
+  cocoa_wkwebview_engine(const cocoa_wkwebview_engine &) = delete;
+  cocoa_wkwebview_engine &operator=(const cocoa_wkwebview_engine &) = delete;
+  cocoa_wkwebview_engine(cocoa_wkwebview_engine &&) = delete;
+  cocoa_wkwebview_engine &operator=(cocoa_wkwebview_engine &&) = delete;
   virtual ~cocoa_wkwebview_engine() = default;
   void *window() { return (void *)m_window; }
   void *widget() { return (void *)m_webview; }


### PR DESCRIPTION
Delete the copy/move constructor/assignment operator of the webview class to make it clear that it doesn't support these operations.

Copying doesn't make much sense here. More work is needed to support `std::move` due to the pointer to the webview class being passed around, e.g. to callback functions. When the original webview instance is moved then callbacks will end up trying to use the original instance, which has become invalid and may have been destroyed already.

Win32 already had the constructors/assignment operators deleted so this simply aligns GTK/Cocoa code with Win32 code.