### PR TITLE
Default-construct basic_result<T, ...> with value

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -554,7 +554,7 @@ public:
   using error_type = Error;
   using exception_type = Exception;
 
-  basic_result() = default;
+  basic_result() : basic_result(value_type{}) {}
 
   basic_result(const value_type &value) : m_value{value} {}
   basic_result(value_type &&value) : m_value{std::forward<value_type>(value)} {}

--- a/webview_test.cc
+++ b/webview_test.cc
@@ -402,13 +402,14 @@ static void test_result() {
   using namespace webview::detail;
   using namespace webview;
 
-  assert(!result<int>{}.has_value());
+  assert(result<int>{}.has_value());
+  assert(result<int>{}.value() == 0);
   assert(result<int>{1}.has_value());
+  assert(result<int>{1}.value() == 1);
   assert(!result<int>{}.has_error());
   assert(!result<int>{1}.has_error());
-  assert(!result<int>{}.ok());
+  assert(result<int>{}.ok());
   assert(result<int>{1}.ok());
-  assert(result<int>{1}.value() == 1);
   assert(!result<int>{error_info{}}.ok());
   assert(!result<int>{error_info{}}.has_value());
   assert(result<int>{error_info{}}.has_error());
@@ -417,13 +418,6 @@ static void test_result() {
       error_info{WEBVIEW_ERROR_INVALID_ARGUMENT, "invalid argument"}};
   assert(result_with_error.error().code() == WEBVIEW_ERROR_INVALID_ARGUMENT);
   assert(result_with_error.error().message() == "invalid argument");
-
-  try {
-    result<int>{}.value();
-    assert(!!"Expected exception");
-  } catch (const bad_access &) {
-    // Do nothing
-  }
 
   try {
     result<int>{}.error();


### PR DESCRIPTION
It makes sense for `result` to either have a value or an error, but not to have neither.