### PR TITLE
Add CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.15)
+project (webview)
+
+include_directories(${CMAKE_SOURCE_DIR})
+
+#//////////////////////////
+# sources 
+#//////////////////////////
+
+set(src ${src})
+set(src ${src} ${CMAKE_SOURCE_DIR}/webview.h)
+
+#//////////////////////////
+# executable 
+#//////////////////////////
+
+add_executable(bind WIN32 ${CMAKE_SOURCE_DIR}/examples/bind.cc ${src})
+
+#//////////////////////////
+# link with libraries
+#//////////////////////////
+
+if (MSVC)
+  include_directories("J:\\build\\external\\libs\\Microsoft.Web.WebView2.1.0.1150.38\\build\\native\\include")
+endif()
+
+set(lib_dep ${lib_dep})
+if (MSVC)
+  set(lib_dep ${lib_dep} "J:\\build\\external\\libs\\Microsoft.Web.WebView2.1.0.1150.38\\build\\native\\x64\\WebView2LoaderStatic.lib")
+endif()
+
+target_link_libraries (bind ${lib_dep})

--- a/build.cmake.sh
+++ b/build.cmake.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mkdir -p build
+pushd build
+cmake .. --fresh
+cmake --build . 
+popd


### PR DESCRIPTION
This is a simple prototype to add a CMake build
It builds the 'bind' example using hardcoded paths for Microsoft WebView2.

WebView2 was downloaded using the build script 'build.bat', but Windows includes WebView2 by default,
so downloading the library should not be necessary

The next step is to use the already installed WebView2 in the CMake script 