### PR TITLE
Suppress warnings from WebView2.h in build.sh

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -306,7 +306,7 @@ elif [[ "${target_os}" == "macos" ]]; then
 elif [[ "${target_os}" == "windows" ]]; then
     exe_suffix=.exe
     shared_lib_suffix=.dll
-    cxx_compile_flags+=("-I${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
+    cxx_compile_flags+=(-isystem "${libs_dir}/Microsoft.Web.WebView2.${mswebview2_version}/build/native/include")
     cxx_compile_flags+=("--include=${project_dir}/webview_mingw_support.h")
     cxx_link_flags+=(-mwindows -ladvapi32 -lole32 -lshell32 -lshlwapi -luser32 -lversion)
 fi


### PR DESCRIPTION
Using the compiler flag `-isystem` instead of `-I` in `build.sh` suppresses warnings coming from `WebView2.h`:

```
D:/a/webview/webview/build/external/libs/Microsoft.Web.WebView2.1.0.1150.38/build/native/include/WebView2.h:19:9: warning: unknown pragma ignored [-Wunknown-pragmas]
   19 | #pragma warning( disable: 4049 )  /* more than 64k source lines */
      |         ^
```