### PR TITLE
Fix warnings in C examples

### DIFF
--- a/examples/basic.c
+++ b/examples/basic.c
@@ -13,7 +13,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine,
   (void)lpCmdLine;
   (void)nCmdShow;
 #else
-int main() {
+int main(void) {
 #endif
   webview_t w = webview_create(0, NULL);
   webview_set_title(w, "Basic Example");

--- a/examples/bind.c
+++ b/examples/bind.c
@@ -171,7 +171,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine,
   (void)lpCmdLine;
   (void)nCmdShow;
 #else
-int main() {
+int main(void) {
 #endif
   webview_t w = webview_create(0, NULL);
   context_t context = {.w = w, .count = 0};


### PR DESCRIPTION
`main()` should be declared as `main(void)` in C.

Fixes the following warnings on macOS:

```
/Users/runner/work/webview/webview/examples/basic.c:16:9: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
int main() {
        ^
         void
1 warning generated.
/Users/runner/work/webview/webview/examples/bind.c:174:9: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
int main() {
        ^
         void
1 warning generated.
```