### PR TITLE
Add support for WebKitGTK API 6.0 and GTK 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         cxx_std: [c++11, c++14, c++17, c++20]
+        webkitgtk-package: [libwebkit2gtk-4.0-dev, libwebkit2gtk-4.1-dev, libwebkitgtk-6.0-dev]
     runs-on: ubuntu-22.04
     env:
       CXX_STD: ${{ matrix.cxx_std }}
@@ -21,7 +22,7 @@ jobs:
           sudo update-alternatives --force --install /usr/bin/clang clang /usr/bin/clang-15 1500 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-15 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev xvfb -y
+        run: sudo apt-get update && sudo apt-get install "${{ matrix.webkitgtk-package }}" xvfb -y
       - name: Build and run tests
         run: xvfb-run ./script/build.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New compile-time options for controlling `WEBVIEW_API` ([#893](https://github.com/webview/webview/pull/893))
-- Support for WebKitGTK API 6.0 and GTK 4.
+- Support for WebKitGTK API 6.0 and GTK 4 ([#1125](https://github.com/webview/webview/pull/1125)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New compile-time options for controlling `WEBVIEW_API` ([#893](https://github.com/webview/webview/pull/893))
+- Support for WebKitGTK API 6.0 and GTK 4.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Variable        | Description
 `CXX`           | C++ compiler executable.
 `LIB_PREFIX`    | Library name prefix.
 `PKGCONFIG`     | Alternative `pkgconfig` executable.
-`WEBKITGTK_API` | WebKitGTK API to interface with, e.g. `0x400` for 4.0, `0x401` for 4.1 or `0x600` for 6.0. This will also automatically decide the GTK API. Uses the latest known and available API by default.
+`WEBKITGTK_API` | WebKitGTK API to interface with, e.g. `0x400` for 4.0, `0x401` for 4.1 or `0x600` for 6.0. This will also automatically decide the GTK version. Uses the latest known and available API by default.
 
 ### Cross-compilation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,19 @@ Your compiler must support minimum C++11 except for platforms that require a mor
 
 The [GTK][gtk] and [WebKit2GTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding how to install those those.
 
-Debian-based systems:
+Debian-based systems with GTK 4 and WebKit2GTK 6.0:
+
+* Packages:
+  * Development: `apt install libgtk-4-dev libwebkitgtk-6.0-dev`
+  * Production: `apt install libgtk-4-1 libwebkitgtk-6.0-4`
+
+Debian-based systems with GTK 3 and WebKit2GTK 4.1 (libsoup 3):
+
+* Packages:
+  * Development: `apt install libgtk-3-dev libwebkit2gtk-4.1-dev`
+  * Production: `apt install libgtk-3-0 libwebkit2gtk-4.1-0`
+
+Debian-based systems with GTK 3 and WebKit2GTK 4.0 (libsoup 2):
 
 * Packages:
   * Development: `apt install libgtk-3-dev libwebkit2gtk-4.0-dev`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Your compiler must support minimum C++11 except for platforms that require a mor
 
 ### Linux and BSD
 
-The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding how to install those, and if needed, specify the APIs to use with the [compile-time options](#compile-time-options) `WEBVIEW_WEBKITGTK_API` and `WEBVIEW_GTK_API`.
+The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding which packages to install, and if needed, specify the WebKitGTK API to use with the [compile-time option](#compile-time-options) `WEBVIEW_WEBKITGTK_API`.
 
 #### Packages
 
@@ -210,7 +210,6 @@ Name                   | Description
 `WEBVIEW_COCOA`        | Compile with Cocoa/WebKit.
 `WEBVIEW_EDGE`         | Compile with Win32/WebView2.
 `WEBVIEW_WEBKITGTK_API`| WebKitGTK API to interface with, e.g. `0x400` for 4.0, `0x401` for 4.1 or `0x600` for 6.0.
-`WEBVIEW_GTK_API`      | GTK API to interface with, e.g. `0x300` for 3.0 or `0x400` for 4.0.
 
 ## App Distribution
 

--- a/README.md
+++ b/README.md
@@ -330,14 +330,15 @@ Variable     | Description
 
 Only `build.sh`:
 
-Variable     | Description
------------- | --------------------------------------------------------------
-`HOST_OS`    | Host operating system (`linux`, `macos`, `windows`).
-`TARGET_OS`  | Target operating system for cross-compilation (see `HOST_OS`).
-`CC`         | C compiler executable.
-`CXX`        | C++ compiler executable.
-`LIB_PREFIX` | Library name prefix.
-`PKGCONFIG`  | Alternative `pkgconfig` executable.
+Variable        | Description
+--------------- | --------------------------------------------------------------
+`HOST_OS`       | Host operating system (`linux`, `macos`, `windows`).
+`TARGET_OS`     | Target operating system for cross-compilation (see `HOST_OS`).
+`CC`            | C compiler executable.
+`CXX`           | C++ compiler executable.
+`LIB_PREFIX`    | Library name prefix.
+`PKGCONFIG`     | Alternative `pkgconfig` executable.
+`WEBKITGTK_API` | WebKitGTK API to interface with, e.g. `0x400` for 4.0, `0x401` for 4.1 or `0x600` for 6.0. This will also automatically decide the GTK API. Uses the latest known and available API by default.
 
 ### Cross-compilation
 

--- a/README.md
+++ b/README.md
@@ -30,35 +30,36 @@ Your compiler must support minimum C++11 except for platforms that require a mor
 
 ### Linux and BSD
 
-The [GTK][gtk] and [WebKit2GTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding how to install those those.
+The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding how to install those those.
 
-Debian-based systems with GTK 4 and WebKit2GTK 6.0:
+#### Packages
 
-* Packages:
-  * Development: `apt install libgtk-4-dev libwebkitgtk-6.0-dev`
-  * Production: `apt install libgtk-4-1 libwebkitgtk-6.0-4`
+* Debian:
+  * WebKitGTK 6.0, GTK 4:
+    * Development: `apt install libgtk-4-dev libwebkitgtk-6.0-dev`
+    * Production: `apt install libgtk-4-1 libwebkitgtk-6.0-4`
+  * WebKitGTK 4.1, GTK 3, libsoup 3:
+    * Development: `apt install libgtk-3-dev libwebkit2gtk-4.1-dev`
+    * Production: `apt install libgtk-3-0 libwebkit2gtk-4.1-0`
+  * WebKitGTK 4.0, GTK 3, libsoup 2:
+    * Development: `apt install libgtk-3-dev libwebkit2gtk-4.0-dev`
+    * Production: `apt install libgtk-3-0 libwebkit2gtk-4.0-37`
+* Fedora:
+  * WebKitGTK 6.0, GTK 4:
+    * Development: `dnf install gtk3-devel webkitgtk6.0-devel`
+    * Production: `dnf install gtk3 webkitgtk6.0`
+  * WebKitGTK 4.1, GTK 3, libsoup 3:
+    * Development: `dnf install gtk3-devel webkit2gtk4.1-devel`
+    * Production: `dnf install gtk3 webkit2gtk4.1`
+  * WebKitGTK 4.0, GTK 3, libsoup 2:
+    * Development: `dnf install gtk3-devel webkit2gtk4.0-devel`
+    * Production: `dnf install gtk3 webkit2gtk4.0`
+* FreeBSD:
+  * GTK 3: `pkg install webkit2-gtk4`
+  * GTK 4: `pkg install webkit2-gtk3`
 
-Debian-based systems with GTK 3 and WebKit2GTK 4.1 (libsoup 3):
+#### BSD
 
-* Packages:
-  * Development: `apt install libgtk-3-dev libwebkit2gtk-4.1-dev`
-  * Production: `apt install libgtk-3-0 libwebkit2gtk-4.1-0`
-
-Debian-based systems with GTK 3 and WebKit2GTK 4.0 (libsoup 2):
-
-* Packages:
-  * Development: `apt install libgtk-3-dev libwebkit2gtk-4.0-dev`
-  * Production: `apt install libgtk-3-0 libwebkit2gtk-4.0-37`
-
-Fedora-based systems:
-
-* Packages:
-  * Development: `dnf install gtk3-devel webkit2gtk4.0-devel`
-  * Production: `dnf install gtk3 webkit2gtk4.0`
-
-BSD-based systems:
-
-* FreeBSD packages: `pkg install webkit2-gtk3`
 * Execution on BSD-based systems may require adding the `wxallowed` option (see [mount(8)](https://man.openbsd.org/mount.8))  to your fstab to bypass [W^X](https://en.wikipedia.org/wiki/W%5EX "write xor execute") memory protection for your executable. Please see if it works without disabling this security feature first.
 
 ### Windows
@@ -200,6 +201,16 @@ Name                   | Description
 `WEBVIEW_BUILD_SHARED` | Modifies `WEBVIEW_API` for building a shared library.
 `WEBVIEW_SHARED`       | Modifies `WEBVIEW_API` for using a shared library.
 `WEBVIEW_STATIC`       | Modifies `WEBVIEW_API` for building or using a static library.
+
+#### Backend Selection
+
+Name                   | Description
+----                   | -----------
+`WEBVIEW_GTK`          | Compile with GTK/WebKitGTK.
+`WEBVIEW_COCOA`        | Compile with Cocoa/WebKit.
+`WEBVIEW_EDGE`         | Compile with Win32/WebView2.
+`WEBVIEW_WEBKITGTK_API`| WebKitGTK API to interface with, e.g. `0x400` for 4.0, `0x401` for 4.1 or `0x600` for 6.0.
+`WEBVIEW_GTK_API`      | GTK API to interface with, e.g. `0x300` for 3.0 or `0x400` for 4.0.
 
 ## App Distribution
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Your compiler must support minimum C++11 except for platforms that require a mor
 
 ### Linux and BSD
 
-The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding how to install those those.
+The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding how to install those, and if needed, specify the APIs to use with the [compile-time options](#compile-time-options) `WEBVIEW_WEBKITGTK_API` and `WEBVIEW_GTK_API`.
 
 #### Packages
 
@@ -290,7 +290,7 @@ Here are some of the noteworthy ways our implementation of the loader differs fr
 * Does not support configuring WebView2 using environment variables such as `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER`.
 * Microsoft Edge Insider (preview) channels are not supported.
 
-The following compile-time options can be used to change how the library integrates the WebView2 loader:
+The following [compile-time options](#compile-time-options) can be used to change how the library integrates the WebView2 loader:
 
 * `WEBVIEW_MSWEBVIEW2_BUILTIN_IMPL=<1|0>` - Enables or disables the built-in implementation of the WebView2 loader. Enabling this avoids the need for `WebView2Loader.dll` but if the DLL is present then the DLL takes priority. This option is enabled by default.
 * `WEBVIEW_MSWEBVIEW2_EXPLICIT_LINK=<1|0>` - Enables or disables explicit linking of `WebView2Loader.dll`. Enabling this avoids the need for import libraries (`*.lib`). This option is enabled by default if `WEBVIEW_MSWEBVIEW2_BUILTIN_IMPL` is enabled.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Your compiler must support minimum C++11 except for platforms that require a mor
 
 ### Linux and BSD
 
-The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding which packages to install, and if needed, specify the WebKitGTK API to use with the [compile-time option](#compile-time-options) `WEBVIEW_WEBKITGTK_API`.
+The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development and distribution. You need to check your package repositories regarding which packages to install.
 
 #### Packages
 
@@ -209,7 +209,6 @@ Name                   | Description
 `WEBVIEW_GTK`          | Compile with GTK/WebKitGTK.
 `WEBVIEW_COCOA`        | Compile with Cocoa/WebKit.
 `WEBVIEW_EDGE`         | Compile with Win32/WebView2.
-`WEBVIEW_WEBKITGTK_API`| WebKitGTK API to interface with, e.g. `0x400` for 4.0, `0x401` for 4.1 or `0x600` for 6.0.
 
 ## App Distribution
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Build and run the example:
 
 ```sh
 # Linux
-g++ basic.cc -std=c++11 -Ilibs/webview $(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0) -o build/basic && ./build/basic
+g++ basic.cc -std=c++11 -Ilibs/webview $(pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1) -o build/basic && ./build/basic
 # macOS
 g++ basic.cc -std=c++11 -Ilibs/webview -framework WebKit -o build/basic && ./build/basic
 # Windows/MinGW
@@ -153,9 +153,9 @@ Build the library and example, then run it:
 
 ```sh
 # Linux
-g++ -c libs/webview/webview.cc -std=c++11 -DWEBVIEW_STATIC $(pkg-config --cflags gtk+-3.0 webkit2gtk-4.0) -o build/webview.o
+g++ -c libs/webview/webview.cc -std=c++11 -DWEBVIEW_STATIC $(pkg-config --cflags gtk+-3.0 webkit2gtk-4.1) -o build/webview.o
 gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o
-g++ build/basic.o build/webview.o $(pkg-config --libs gtk+-3.0 webkit2gtk-4.0) -o build/basic && build/basic
+g++ build/basic.o build/webview.o $(pkg-config --libs gtk+-3.0 webkit2gtk-4.1) -o build/basic && build/basic
 # macOS
 g++ -c libs/webview/webview.cc -std=c++11 -DWEBVIEW_STATIC -o build/webview.o
 gcc -c basic.c -std=c99 -Ilibs/webview -o build/basic.o

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The [GTK][gtk] and [WebKitGTK][webkitgtk] libraries are required for development
     * Development: `dnf install gtk3-devel webkit2gtk4.0-devel`
     * Production: `dnf install gtk3 webkit2gtk4.0`
 * FreeBSD:
-  * GTK 3: `pkg install webkit2-gtk4`
-  * GTK 4: `pkg install webkit2-gtk3`
+  * GTK 4: `pkg install webkit2-gtk4`
+  * GTK 3: `pkg install webkit2-gtk3`
 
 #### BSD
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -292,7 +292,7 @@ fi
 # GTK library
 if [[ "${target_os}" == "linux" ]]; then
     if [[ "${webkitgtk_api}" -ge 0x600 ]]; then
-        pkgconfig_libs+=(gtk4 x11)
+        pkgconfig_libs+=(gtk4)
         gtk_api=0x400
     elif [[ "${webkitgtk_api}" -ge 0x400 ]]; then
         pkgconfig_libs+=(gtk+-3.0)

--- a/script/build.sh
+++ b/script/build.sh
@@ -170,9 +170,9 @@ task_info() {
     if [[ "${target_os}" == "linux" ]]; then
         echo "-- pkg-config: Executable: ${pkgconfig_exe}"
         echo "-- pkg-config: Libraries: ${pkgconfig_libs[@]}"
+        echo "-- WebKitGTK API: ${webkitgtk_api}"
+        echo "-- GTK: ${gtk_version}"
     fi
-    echo "-- WebKitGTK API: ${webkitgtk_api}"
-    echo "-- GTK: ${gtk_version}"
 }
 
 run_task() {

--- a/script/build.sh
+++ b/script/build.sh
@@ -172,7 +172,7 @@ task_info() {
         echo "-- pkg-config: Libraries: ${pkgconfig_libs[@]}"
     fi
     echo "-- WebKitGTK API: ${webkitgtk_api}"
-    echo "-- GTK API: ${gtk_api}"
+    echo "-- GTK: ${gtk_version}"
 }
 
 run_task() {
@@ -289,12 +289,12 @@ if [[ "${target_os}" == "linux" ]]; then
     # GTK library
     if [[ "${webkitgtk_api}" -ge 0x600 ]]; then
         pkgconfig_libs+=(gtk4)
-        gtk_api=0x400
+        gtk_version=0x400
     elif [[ "${webkitgtk_api}" -ge 0x400 ]]; then
         pkgconfig_libs+=(gtk+-3.0)
-        gtk_api=0x300
+        gtk_version=0x300
     else
-        echo "ERROR: Unable to detect GTK API/library." >&2
+        echo "ERROR: Unable to detect GTK version/library." >&2
         exit 1
     fi
 fi

--- a/script/build.sh
+++ b/script/build.sh
@@ -312,7 +312,7 @@ external_dir=${build_dir}/external
 libs_dir=${external_dir}/libs
 tools_dir=${external_dir}/tools
 warning_flags=(-Wall -Wextra -pedantic)
-common_compile_flags=("${warning_flags[@]}" "-I${project_dir}" "-DWEBVIEW_WEBKITGTK_API=${webkitgtk_api}" "-DWEBVIEW_GTK_API=${gtk_api}")
+common_compile_flags=("${warning_flags[@]}" "-I${project_dir}" "-DWEBVIEW_WEBKITGTK_API=${webkitgtk_api}")
 common_link_flags=("${warning_flags[@]}")
 c_compile_flags=()
 c_link_flags=()

--- a/script/build.sh
+++ b/script/build.sh
@@ -259,11 +259,11 @@ if [[ ! -z "${PKGCONFIG+x}" ]]; then
     pkgconfig_exe=${PKGCONFIG}
 fi
 
-# Detect WebKitGTK API
-if [[ ! -z "${WEBKITGTK_API+x}" ]]; then
-    webkitgtk_api=${WEBKITGTK_API}
-elif [[ "${target_os}" == "linux" ]]; then
-    if "${pkgconfig_exe}" --exists webkitgtk-6.0; then
+if [[ "${target_os}" == "linux" ]]; then
+    # Detect WebKitGTK API
+    if [[ ! -z "${WEBKITGTK_API+x}" ]]; then
+        webkitgtk_api=${WEBKITGTK_API}
+    elif "${pkgconfig_exe}" --exists webkitgtk-6.0; then
         webkitgtk_api=0x600
     elif "${pkgconfig_exe}" --exists webkit2gtk-4.1; then
         webkitgtk_api=0x401
@@ -273,10 +273,8 @@ elif [[ "${target_os}" == "linux" ]]; then
         echo "ERROR: Unable to detect WebKitGTK API." >&2
         exit 1
     fi
-fi
 
-# WebKitGTK library
-if [[ "${target_os}" == "linux" ]]; then
+    # WebKitGTK library
     if [[ "${webkitgtk_api}" == 0x600 ]]; then
         pkgconfig_libs+=(webkitgtk-6.0 javascriptcoregtk-6.0)
     elif [[ "${webkitgtk_api}" == 0x401 ]]; then
@@ -287,10 +285,8 @@ if [[ "${target_os}" == "linux" ]]; then
         echo "ERROR: Unable to detect WebKitGTK library." >&2
         exit 1
     fi
-fi
 
-# GTK library
-if [[ "${target_os}" == "linux" ]]; then
+    # GTK library
     if [[ "${webkitgtk_api}" -ge 0x600 ]]; then
         pkgconfig_libs+=(gtk4)
         gtk_api=0x400

--- a/script/build.sh
+++ b/script/build.sh
@@ -312,7 +312,7 @@ external_dir=${build_dir}/external
 libs_dir=${external_dir}/libs
 tools_dir=${external_dir}/tools
 warning_flags=(-Wall -Wextra -pedantic)
-common_compile_flags=("${warning_flags[@]}" "-I${project_dir}" "-DWEBVIEW_WEBKITGTK_API=${webkitgtk_api}")
+common_compile_flags=("${warning_flags[@]}" "-I${project_dir}")
 common_link_flags=("${warning_flags[@]}")
 c_compile_flags=()
 c_link_flags=()

--- a/webview.h
+++ b/webview.h
@@ -1298,7 +1298,6 @@ window.__webview__.onUnbind(" +
   result<void *> widget() { return widget_impl(); }
   result<void *> browser_controller() { return browser_controller_impl(); };
   noresult run() { return run_impl(); }
-  noresult run_iteration(bool block) { return run_iteration_impl(block); }
   noresult terminate() { return terminate_impl(); }
   noresult dispatch(std::function<void()> f) { return dispatch_impl(f); }
   noresult set_title(const std::string &title) { return set_title_impl(title); }
@@ -1322,7 +1321,6 @@ protected:
   virtual result<void *> widget_impl() = 0;
   virtual result<void *> browser_controller_impl() = 0;
   virtual noresult run_impl() = 0;
-  virtual noresult run_iteration_impl(bool block) = 0;
   virtual noresult terminate_impl() = 0;
   virtual noresult dispatch_impl(std::function<void()> f) = 0;
   virtual noresult set_title_impl(const std::string &title) = 0;
@@ -1854,11 +1852,6 @@ protected:
     while (!m_quit) {
       g_main_context_iteration(nullptr, TRUE);
     }
-    return {};
-  }
-
-  noresult run_iteration_impl(bool block) override {
-    g_main_context_iteration(nullptr, block ? TRUE : FALSE);
     return {};
   }
 

--- a/webview.h
+++ b/webview.h
@@ -1853,15 +1853,15 @@ protected:
   }
 
   noresult run_impl() override {
-    m_quit = false;
-    while (!m_quit) {
+    m_stop_run_loop = false;
+    while (!m_stop_run_loop) {
       g_main_context_iteration(nullptr, TRUE);
     }
     return {};
   }
 
   noresult terminate_impl() override {
-    return dispatch_impl([&] { m_quit = true; });
+    return dispatch_impl([&] { m_stop_run_loop = true; });
   }
 
   noresult dispatch_impl(std::function<void()> f) override {
@@ -2030,7 +2030,7 @@ private:
   GtkWidget *m_window{};
   GtkWidget *m_webview{};
   WebKitUserContentManager *m_user_content_manager{};
-  bool m_quit{};
+  bool m_stop_run_loop{};
 };
 
 } // namespace detail

--- a/webview.h
+++ b/webview.h
@@ -2033,8 +2033,6 @@ private:
   bool m_quit{};
 };
 
-using gtk_webkit_engine = gtk_webkit_engine;
-
 } // namespace detail
 
 using browser_engine = detail::gtk_webkit_engine;

--- a/webview.h
+++ b/webview.h
@@ -1756,6 +1756,11 @@ public:
     g.min_height = height;
     GdkWindowHints h = GDK_HINT_MIN_SIZE;
     gtk_window_set_geometry_hints(GTK_WINDOW(window), nullptr, &g, h);
+#else
+    // Avoid "unused parameter" warnings
+    (void)window;
+    (void)width;
+    (void)height;
 #endif
   }
 

--- a/webview.h
+++ b/webview.h
@@ -1767,6 +1767,11 @@ public:
     g.max_height = height;
     GdkWindowHints h = GDK_HINT_MAX_SIZE;
     gtk_window_set_geometry_hints(GTK_WINDOW(window), nullptr, &g, h);
+#else
+    // Avoid "unused parameter" warnings
+    (void)window;
+    (void)width;
+    (void)height;
 #endif
   }
 };
@@ -1797,7 +1802,7 @@ public:
       (*handler)(manager, get_string_from_js_result(r));
     };
 
-    auto deleter = +[](gpointer data, GClosure *closure) {
+    auto deleter = +[](gpointer data, GClosure *) {
       delete static_cast<on_script_message_received_t *>(data);
     };
 

--- a/webview.h
+++ b/webview.h
@@ -1535,7 +1535,12 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 //
 // ====================================================================
 //
-// This implementation uses webkit2gtk backend.
+// This implementation uses webkit2gtk backend. It requires GTK and
+// WebKitGTK libraries. Proper compiler flags can be retrieved via:
+//
+//   pkg-config --cflags --libs gtk4 webkitgtk-6.0
+//   pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1
+//   pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0
 //
 // ====================================================================
 //

--- a/webview.h
+++ b/webview.h
@@ -308,7 +308,7 @@ WEBVIEW_API webview_error_t webview_set_title(webview_t w, const char *title);
  * Remarks:
  * - Using WEBVIEW_HINT_MIN and WEBVIEW_HINT_MAX for setting window bounds is
  *   not supported with GTK 4 because X11-specific functions such as
- *   gtk_window_set_geometry_hints was removed. These flags do nothing when
+ *   gtk_window_set_geometry_hints were removed. These flags do nothing when
  *   using GTK 4.
  *
  * @param w The webview instance.

--- a/webview.h
+++ b/webview.h
@@ -1292,6 +1292,7 @@ window.__webview__.onUnbind(" +
   result<void *> widget() { return widget_impl(); }
   result<void *> browser_controller() { return browser_controller_impl(); };
   noresult run() { return run_impl(); }
+  noresult run_iteration() { return run_iteration_impl(); }
   noresult terminate() { return terminate_impl(); }
   noresult dispatch(std::function<void()> f) { return dispatch_impl(f); }
   noresult set_title(const std::string &title) { return set_title_impl(title); }
@@ -1315,6 +1316,7 @@ protected:
   virtual result<void *> widget_impl() = 0;
   virtual result<void *> browser_controller_impl() = 0;
   virtual noresult run_impl() = 0;
+  virtual noresult run_iteration_impl() = 0;
   virtual noresult terminate_impl() = 0;
   virtual noresult dispatch_impl(std::function<void()> f) = 0;
   virtual noresult set_title_impl(const std::string &title) = 0;
@@ -1529,21 +1531,36 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 //
 // ====================================================================
 //
-// This implementation uses webkit2gtk backend. It requires gtk+3.0 and
-// webkit2gtk-4.0 libraries. Proper compiler flags can be retrieved via:
-//
-//   pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0
+// This implementation uses webkit2gtk backend.
 //
 // ====================================================================
 //
 #include <cstdlib>
 
+#ifndef WEBVIEW_WEBKITGTK_API
+#define WEBVIEW_WEBKITGTK_API 0x400
+#endif
+
+#ifndef WEBVIEW_GTK_API
+#define WEBVIEW_GTK_API 0x300
+#endif
+
+#if WEBVIEW_WEBKITGTK_API >= 0x600
+#include <jsc/jsc.h>
+#include <gtk/gtk.h>
+#include <webkit/webkit.h>
+
+#ifdef GDK_WINDOWING_X11
+#include <gdk/x11/gdkx.h>
+#endif
+#elif WEBVIEW_WEBKITGTK_API >= 0x400
 #include <JavaScriptCore/JavaScript.h>
 #include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 #endif
 
 #include <fcntl.h>
@@ -1600,9 +1617,8 @@ static inline bool is_wayland_display() {
 // See: https://docs.gtk.org/gdk3/class.DisplayManager.html
 static inline bool is_gdk_x11_backend() {
 #ifdef GDK_WINDOWING_X11
-  auto *manager = gdk_display_manager_get();
-  auto *display = gdk_display_manager_get_default_display(manager);
-  return GDK_IS_X11_DISPLAY(display); // NOLINT(misc-const-correctness)
+  auto* gdk_display = gdk_display_get_default();
+  return GDK_IS_X11_DISPLAY(gdk_display); // NOLINT(misc-const-correctness)
 #else
   return false;
 #endif
@@ -1649,6 +1665,8 @@ static inline void apply_webkit_dmabuf_workaround() {
 }
 } // namespace webkit_dmabuf
 
+#if WEBVIEW_WEBKITGTK_API >= 0x600
+
 namespace webkit_symbols {
 using webkit_web_view_evaluate_javascript_t =
     void (*)(WebKitWebView *, const char *, gssize, const char *, const char *,
@@ -1686,9 +1704,330 @@ private:
   WebKitUserScript *m_script{};
 };
 
-class gtk_webkit_engine : public engine_base {
+class gtk4_webkit6_engine : public engine_base {
 public:
-  gtk_webkit_engine(bool debug, void *window)
+  gtk4_webkit6_engine(bool debug, void *window)
+      : m_owns_window{!window}, m_window(static_cast<GtkWidget *>(window)) {
+    if (m_owns_window) {
+      if (!gtk_init_check()) {
+        throw exception{WEBVIEW_ERROR_UNSPECIFIED, "GTK init failed"};
+      }
+      m_window = gtk_window_new();
+      on_window_created();
+      g_signal_connect(G_OBJECT(m_window), "destroy",
+                       G_CALLBACK(+[](GtkWidget *, gpointer arg) {
+                         auto *w = static_cast<gtk4_webkit6_engine *>(arg);
+                         // Widget destroyed along with window.
+                         w->m_webview = nullptr;
+                         w->m_window = nullptr;
+                         w->on_window_destroyed();
+                       }),
+                       this);
+    }
+    webkit_dmabuf::apply_webkit_dmabuf_workaround();
+    // Initialize webview widget
+    m_webview = webkit_web_view_new();
+    WebKitUserContentManager *manager = m_user_content_manager =
+        webkit_web_view_get_user_content_manager(WEBKIT_WEB_VIEW(m_webview));
+    g_signal_connect(manager, "script-message-received::__webview__",
+                     G_CALLBACK(+[](WebKitUserContentManager *,
+                                    JSCValue *r, gpointer arg) {
+                       auto *w = static_cast<gtk4_webkit6_engine *>(arg);
+                       char *s = get_string_from_js_result(r);
+                       w->on_message(s);
+                       g_free(s);
+                     }),
+                     this);
+    webkit_user_content_manager_register_script_message_handler(manager,
+                                                                "__webview__",
+                                                                nullptr);
+    add_init_script("function(message) {\n\
+  return window.webkit.messageHandlers.__webview__.postMessage(message);\n\
+}");
+
+    gtk_window_set_child(GTK_WINDOW(m_window), GTK_WIDGET(m_webview));
+    gtk_widget_set_visible(GTK_WIDGET(m_webview), TRUE);
+
+    WebKitSettings *settings =
+        webkit_web_view_get_settings(WEBKIT_WEB_VIEW(m_webview));
+    webkit_settings_set_javascript_can_access_clipboard(settings, true);
+    if (debug) {
+      webkit_settings_set_enable_write_console_messages_to_stdout(settings,
+                                                                  true);
+      webkit_settings_set_enable_developer_extras(settings, true);
+    }
+
+    if (m_owns_window) {
+      gtk_widget_grab_focus(GTK_WIDGET(m_webview));
+      gtk_widget_set_visible(GTK_WIDGET(m_window), TRUE);
+    }
+  }
+
+  gtk4_webkit6_engine(const gtk4_webkit6_engine &) = delete;
+  gtk4_webkit6_engine &operator=(const gtk4_webkit6_engine &) = delete;
+  gtk4_webkit6_engine(gtk4_webkit6_engine &&) = delete;
+  gtk4_webkit6_engine &operator=(gtk4_webkit6_engine &&) = delete;
+
+  virtual ~gtk4_webkit6_engine() {
+    if (m_webview) {
+      gtk_window_set_child(GTK_WINDOW(m_window), nullptr);
+      m_webview = nullptr;
+    }
+    if (m_window) {
+      if (m_owns_window) {
+        // Disconnect handlers to avoid callbacks invoked during destruction.
+        g_signal_handlers_disconnect_by_data(GTK_WINDOW(m_window), this);
+        gtk_window_close(GTK_WINDOW(m_window));
+        on_window_destroyed(true);
+      }
+      m_window = nullptr;
+    }
+    if (m_owns_window) {
+      // Needed for the window to close immediately.
+      deplete_run_loop_event_queue();
+    }
+  }
+
+protected:
+  result<void *> window_impl() override {
+    if (m_window) {
+      return m_window;
+    }
+    return error_info{WEBVIEW_ERROR_INVALID_STATE};
+  }
+
+  result<void *> widget_impl() override {
+    if (m_webview) {
+      return m_webview;
+    }
+    return error_info{WEBVIEW_ERROR_INVALID_STATE};
+  }
+
+  result<void *> browser_controller_impl() override {
+    if (m_webview) {
+      return m_webview;
+    }
+    return error_info{WEBVIEW_ERROR_INVALID_STATE};
+  }
+
+  noresult run_impl() override {
+    m_quit = false;
+    while (!m_quit) {
+      g_main_context_iteration(nullptr, TRUE);
+    }
+    return {};
+  }
+
+  noresult run_iteration_impl() override {
+    g_main_context_iteration(nullptr, TRUE);
+    return {};
+  }
+
+  noresult terminate_impl() override {
+    return dispatch_impl([&] { m_quit = true; });
+  }
+
+  noresult dispatch_impl(std::function<void()> f) override {
+    g_idle_add_full(G_PRIORITY_HIGH_IDLE, (GSourceFunc)([](void *f) -> int {
+                      (*static_cast<dispatch_fn_t *>(f))();
+                      return G_SOURCE_REMOVE;
+                    }),
+                    new std::function<void()>(f),
+                    [](void *f) { delete static_cast<dispatch_fn_t *>(f); });
+    return {};
+  }
+
+  noresult set_title_impl(const std::string &title) override {
+    gtk_window_set_title(GTK_WINDOW(m_window), title.c_str());
+    return {};
+  }
+
+  noresult set_size_impl(int width, int height, webview_hint_t hints) override {
+    gtk_window_set_resizable(GTK_WINDOW(m_window), hints != WEBVIEW_HINT_FIXED);
+    if (hints == WEBVIEW_HINT_NONE) {
+      gtk_window_set_default_size(GTK_WINDOW(m_window), width, height);
+    } else if (hints == WEBVIEW_HINT_FIXED) {
+      gtk_widget_set_size_request(m_window, width, height);
+    } else {
+      gtk_widget_realize(m_window);
+      auto* gdk_display = gdk_display_get_default();
+#if defined(GDK_WINDOWING_X11)
+      if (GDK_IS_X11_DISPLAY(gdk_display)) {
+        auto* gtk_native_window = gtk_widget_get_native(m_window);
+        auto* gdk_surface = gtk_native_get_surface(gtk_native_window);
+        auto x11_window = gdk_x11_surface_get_xid(gdk_surface);
+        auto x11_display = gdk_x11_display_get_xdisplay(gdk_display);
+
+        auto* x11_size_hints = XAllocSizeHints();
+        x11_size_hints->flags = (hints == WEBVIEW_HINT_MIN ? PMinSize : PMaxSize);
+        x11_size_hints->min_width = x11_size_hints->max_width = width;
+        x11_size_hints->min_height = x11_size_hints->max_height = height;
+        XSetWMNormalHints(x11_display, x11_window, x11_size_hints);
+        XFree(x11_size_hints);
+      }
+#elif defined(GDK_WINDOWING_WAYLAND)
+#error Wayland not implemented yet
+#else
+#error Unsupported GDK backend
+#endif
+    }
+    return {};
+  }
+
+  noresult navigate_impl(const std::string &url) override {
+    webkit_web_view_load_uri(WEBKIT_WEB_VIEW(m_webview), url.c_str());
+    return {};
+  }
+
+  noresult set_html_impl(const std::string &html) override {
+    webkit_web_view_load_html(WEBKIT_WEB_VIEW(m_webview), html.c_str(),
+                              nullptr);
+    return {};
+  }
+
+  noresult eval_impl(const std::string &js) override {
+    // URI is null before content has begun loading.
+    if (!webkit_web_view_get_uri(WEBKIT_WEB_VIEW(m_webview))) {
+      return {};
+    }
+    auto &lib = get_webkit_library();
+    auto wkmajor = webkit_get_major_version();
+    auto wkminor = webkit_get_minor_version();
+    if ((wkmajor == 2 && wkminor >= 40) || wkmajor > 2) {
+      if (auto fn =
+              lib.get(webkit_symbols::webkit_web_view_evaluate_javascript)) {
+        fn(WEBKIT_WEB_VIEW(m_webview), js.c_str(),
+           static_cast<gssize>(js.size()), nullptr, nullptr, nullptr, nullptr,
+           nullptr);
+        return {};
+      }
+    } else if (auto fn =
+                   lib.get(webkit_symbols::webkit_web_view_run_javascript)) {
+      fn(WEBKIT_WEB_VIEW(m_webview), js.c_str(), nullptr, nullptr, nullptr);
+      return {};
+    }
+    return error_info{WEBVIEW_ERROR_UNSPECIFIED, "No underlying implementation found for eval()"};
+  }
+
+  user_script add_user_script_impl(const std::string &js) override {
+    auto *wk_script = webkit_user_script_new(
+        js.c_str(), WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
+        WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, nullptr, nullptr);
+    webkit_user_content_manager_add_script(m_user_content_manager, wk_script);
+    user_script script{js, std::unique_ptr<user_script::impl>{
+                               new user_script::impl{wk_script}}};
+    webkit_user_script_unref(wk_script);
+    return script;
+  }
+
+  void remove_all_user_scripts_impl(
+      const std::list<user_script> & /*scripts*/) override {
+    webkit_user_content_manager_remove_all_scripts(m_user_content_manager);
+  }
+
+  bool are_user_scripts_equal_impl(const user_script &first,
+                                   const user_script &second) override {
+    auto *wk_first = first.get_impl().get_native();
+    auto *wk_second = second.get_impl().get_native();
+    return wk_first == wk_second;
+  }
+
+private:
+  static char *get_string_from_js_result(JSCValue *r) {
+    char* s = jsc_value_to_string(r);
+    return s;
+  }
+
+  static const native_library &get_webkit_library() {
+    static const native_library non_loaded_lib;
+    static native_library loaded_lib;
+
+    if (loaded_lib.is_loaded()) {
+      return loaded_lib;
+    }
+
+    constexpr std::array<const char *, 3> lib_names{"libwebkitgtk-6.0.so",
+                                                    "libwebkit2gtk-4.1.so",
+                                                    "libwebkit2gtk-4.0.so"};
+    auto found =
+        std::find_if(lib_names.begin(), lib_names.end(), [](const char *name) {
+          return native_library::is_loaded(name);
+        });
+
+    if (found == lib_names.end()) {
+      return non_loaded_lib;
+    }
+
+    loaded_lib = native_library(*found);
+
+    auto loaded = loaded_lib.is_loaded();
+    if (!loaded) {
+      return non_loaded_lib;
+    }
+
+    return loaded_lib;
+  }
+
+  // Blocks while depleting the run loop of events.
+  void deplete_run_loop_event_queue() {
+    bool done{};
+    dispatch([&] { done = true; });
+    while (!done) {
+      run_iteration_impl();
+    }
+  }
+
+  bool m_owns_window{};
+  GtkWidget *m_window{};
+  GtkWidget *m_webview{};
+  WebKitUserContentManager *m_user_content_manager{};
+  bool m_quit{};
+};
+
+using gtk_webkit_engine = gtk4_webkit6_engine;
+
+#elif WEBVIEW_WEBKITGTK_API >= 0x400
+
+namespace webkit_symbols {
+using webkit_web_view_evaluate_javascript_t =
+    void (*)(WebKitWebView *, const char *, gssize, const char *, const char *,
+             GCancellable *, GAsyncReadyCallback, gpointer);
+
+using webkit_web_view_run_javascript_t = void (*)(WebKitWebView *,
+                                                  const gchar *, GCancellable *,
+                                                  GAsyncReadyCallback,
+                                                  gpointer);
+
+constexpr auto webkit_web_view_evaluate_javascript =
+    library_symbol<webkit_web_view_evaluate_javascript_t>(
+        "webkit_web_view_evaluate_javascript");
+constexpr auto webkit_web_view_run_javascript =
+    library_symbol<webkit_web_view_run_javascript_t>(
+        "webkit_web_view_run_javascript");
+} // namespace webkit_symbols
+
+class user_script::impl {
+public:
+  impl(WebKitUserScript *script) : m_script{script} {
+    webkit_user_script_ref(script);
+  }
+
+  ~impl() { webkit_user_script_unref(m_script); }
+
+  impl(const impl &) = delete;
+  impl &operator=(const impl &) = delete;
+  impl(impl &&) = delete;
+  impl &operator=(impl &&) = delete;
+
+  WebKitUserScript *get_native() const { return m_script; }
+
+private:
+  WebKitUserScript *m_script{};
+};
+
+class gtk3_webkit4_engine : public engine_base {
+public:
+  gtk3_webkit4_engine(bool debug, void *window)
       : m_owns_window{!window}, m_window(static_cast<GtkWidget *>(window)) {
     if (m_owns_window) {
       if (!gtk_init_check(nullptr, nullptr)) {
@@ -1698,7 +2037,7 @@ public:
       on_window_created();
       g_signal_connect(G_OBJECT(m_window), "destroy",
                        G_CALLBACK(+[](GtkWidget *, gpointer arg) {
-                         auto *w = static_cast<gtk_webkit_engine *>(arg);
+                         auto *w = static_cast<gtk3_webkit4_engine *>(arg);
                          // Widget destroyed along with window.
                          w->m_webview = nullptr;
                          w->m_window = nullptr;
@@ -1714,7 +2053,7 @@ public:
     g_signal_connect(manager, "script-message-received::__webview__",
                      G_CALLBACK(+[](WebKitUserContentManager *,
                                     WebKitJavascriptResult *r, gpointer arg) {
-                       auto *w = static_cast<gtk_webkit_engine *>(arg);
+                       auto *w = static_cast<gtk3_webkit4_engine *>(arg);
                        char *s = get_string_from_js_result(r);
                        w->on_message(s);
                        g_free(s);
@@ -1744,12 +2083,12 @@ public:
     }
   }
 
-  gtk_webkit_engine(const gtk_webkit_engine &) = delete;
-  gtk_webkit_engine &operator=(const gtk_webkit_engine &) = delete;
-  gtk_webkit_engine(gtk_webkit_engine &&) = delete;
-  gtk_webkit_engine &operator=(gtk_webkit_engine &&) = delete;
+  gtk3_webkit4_engine(const gtk3_webkit4_engine &) = delete;
+  gtk3_webkit4_engine &operator=(const gtk3_webkit4_engine &) = delete;
+  gtk3_webkit4_engine(gtk3_webkit4_engine &&) = delete;
+  gtk3_webkit4_engine &operator=(gtk3_webkit4_engine &&) = delete;
 
-  virtual ~gtk_webkit_engine() {
+  virtual ~gtk3_webkit4_engine() {
     if (m_webview) {
       gtk_widget_destroy(GTK_WIDGET(m_webview));
       m_webview = nullptr;
@@ -1951,6 +2290,9 @@ private:
   GtkWidget *m_webview{};
   WebKitUserContentManager *m_user_content_manager{};
 };
+
+using gtk_webkit_engine = gtk3_webkit4_engine;
+#endif
 
 } // namespace detail
 

--- a/webview.h
+++ b/webview.h
@@ -306,10 +306,10 @@ WEBVIEW_API webview_error_t webview_set_title(webview_t w, const char *title);
  * Updates the size of the native window.
  *
  * Remarks:
- * - Using WEBVIEW_HINT_MIN and WEBVIEW_HINT_MAX for setting window bounds is
- *   not supported with GTK 4 because X11-specific functions such as
- *   gtk_window_set_geometry_hints were removed. These flags do nothing when
- *   using GTK 4.
+ * - Using WEBVIEW_HINT_MAX for setting the maximum window size is not
+ *   supported with GTK 4 because X11-specific functions such as
+ *   gtk_window_set_geometry_hints were removed. This option has no effect
+ *   when using GTK 4.
  *
  * @param w The webview instance.
  * @param width New width.
@@ -1748,22 +1748,6 @@ public:
 #endif
   }
 
-  static void window_set_min_size(GtkWindow *window, int width, int height) {
-// X11-specific features are available in GTK 3 but not GTK 4
-#if GTK_MAJOR_VERSION < 4
-    GdkGeometry g{};
-    g.min_width = width;
-    g.min_height = height;
-    GdkWindowHints h = GDK_HINT_MIN_SIZE;
-    gtk_window_set_geometry_hints(GTK_WINDOW(window), nullptr, &g, h);
-#else
-    // Avoid "unused parameter" warnings
-    (void)window;
-    (void)width;
-    (void)height;
-#endif
-  }
-
   static void window_set_max_size(GtkWindow *window, int width, int height) {
 // X11-specific features are available in GTK 3 but not GTK 4
 #if GTK_MAJOR_VERSION < 4
@@ -1987,10 +1971,8 @@ protected:
     gtk_window_set_resizable(GTK_WINDOW(m_window), hints != WEBVIEW_HINT_FIXED);
     if (hints == WEBVIEW_HINT_NONE) {
       gtk_compat::window_set_size(GTK_WINDOW(m_window), width, height);
-    } else if (hints == WEBVIEW_HINT_FIXED) {
+    } else if (hints == WEBVIEW_HINT_FIXED || hints == WEBVIEW_HINT_MIN) {
       gtk_widget_set_size_request(m_window, width, height);
-    } else if (hints == WEBVIEW_HINT_MIN) {
-      gtk_compat::window_set_min_size(GTK_WINDOW(m_window), width, height);
     } else if (hints == WEBVIEW_HINT_MAX) {
       gtk_compat::window_set_max_size(GTK_WINDOW(m_window), width, height);
     }

--- a/webview.h
+++ b/webview.h
@@ -1546,27 +1546,26 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 //
 #include <cstdlib>
 
-// Default WebKitGTK API
-#ifndef WEBVIEW_WEBKITGTK_API
-#define WEBVIEW_WEBKITGTK_API 0x400
-#endif
-
-#if WEBVIEW_WEBKITGTK_API >= 0x600
 #include <gtk/gtk.h>
+
+#if GTK_MAJOR_VERSION >= 4
+
 #include <jsc/jsc.h>
 #include <webkit/webkit.h>
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/x11/gdkx.h>
 #endif
-#elif WEBVIEW_WEBKITGTK_API >= 0x400
+
+#elif GTK_MAJOR_VERSION >= 3
+
 #include <JavaScriptCore/JavaScript.h>
-#include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
 #endif
+
 #endif
 
 #include <fcntl.h>
@@ -1795,7 +1794,7 @@ public:
  */
 class webkitgtk_compat {
 public:
-#if WEBVIEW_WEBKITGTK_API >= 0x600
+#if GTK_MAJOR_VERSION >= 4
   using wk_handler_js_value_t = JSCValue;
 #else
   using wk_handler_js_value_t = WebKitJavascriptResult;
@@ -1832,7 +1831,7 @@ public:
     return s;
   }
 
-#if WEBVIEW_WEBKITGTK_API < 0x600
+#if GTK_MAJOR_VERSION < 4
   static std::string get_string_from_js_result(WebKitJavascriptResult *r) {
 #if (WEBKIT_MAJOR_VERSION == 2 && WEBKIT_MINOR_VERSION >= 22) ||               \
     WEBKIT_MAJOR_VERSION > 2
@@ -1855,7 +1854,7 @@ public:
 
   static void user_content_manager_register_script_message_handler(
       WebKitUserContentManager *manager, const gchar *name) {
-#if WEBVIEW_WEBKITGTK_API >= 0x600
+#if GTK_MAJOR_VERSION >= 4
     webkit_user_content_manager_register_script_message_handler(manager, name,
                                                                 nullptr);
 #else
@@ -2058,7 +2057,7 @@ protected:
   }
 
 private:
-#if WEBVIEW_WEBKITGTK_API >= 0x600
+#if GTK_MAJOR_VERSION >= 4
   static char *get_string_from_js_result(JSCValue *r) {
     return jsc_value_to_string(r);
   }

--- a/webview.h
+++ b/webview.h
@@ -1670,24 +1670,6 @@ static inline void apply_webkit_dmabuf_workaround() {
 }
 } // namespace webkit_dmabuf
 
-namespace webkit_symbols {
-using webkit_web_view_evaluate_javascript_t =
-    void (*)(WebKitWebView *, const char *, gssize, const char *, const char *,
-             GCancellable *, GAsyncReadyCallback, gpointer);
-
-using webkit_web_view_run_javascript_t = void (*)(WebKitWebView *,
-                                                  const gchar *, GCancellable *,
-                                                  GAsyncReadyCallback,
-                                                  gpointer);
-
-constexpr auto webkit_web_view_evaluate_javascript =
-    library_symbol<webkit_web_view_evaluate_javascript_t>(
-        "webkit_web_view_evaluate_javascript");
-constexpr auto webkit_web_view_run_javascript =
-    library_symbol<webkit_web_view_run_javascript_t>(
-        "webkit_web_view_run_javascript");
-} // namespace webkit_symbols
-
 class user_script::impl {
 public:
   impl(WebKitUserScript *script) : m_script{script} {

--- a/webview.h
+++ b/webview.h
@@ -1551,11 +1551,6 @@ inline std::string json_parse(const std::string &s, const std::string &key,
 #define WEBVIEW_WEBKITGTK_API 0x400
 #endif
 
-// Default GTK API
-#ifndef WEBVIEW_GTK_API
-#define WEBVIEW_GTK_API 0x300
-#endif
-
 #if WEBVIEW_WEBKITGTK_API >= 0x600
 #include <gtk/gtk.h>
 #include <jsc/jsc.h>
@@ -1719,7 +1714,7 @@ private:
 class gtk_compat {
 public:
   static gboolean init_check() {
-#if WEBVIEW_GTK_API >= 0x400
+#if GTK_MAJOR_VERSION >= 4
     return gtk_init_check();
 #else
     return gtk_init_check(nullptr, nullptr);
@@ -1727,7 +1722,7 @@ public:
   }
 
   static GtkWidget *window_new() {
-#if WEBVIEW_GTK_API >= 0x400
+#if GTK_MAJOR_VERSION >= 4
     return gtk_window_new();
 #else
     return gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -1735,7 +1730,7 @@ public:
   }
 
   static void window_set_child(GtkWindow *window, GtkWidget *widget) {
-#if WEBVIEW_GTK_API >= 0x400
+#if GTK_MAJOR_VERSION >= 4
     gtk_window_set_child(window, widget);
 #else
     gtk_container_add(GTK_CONTAINER(window), widget);
@@ -1743,7 +1738,7 @@ public:
   }
 
   static void window_remove_child(GtkWindow *window, GtkWidget *widget) {
-#if WEBVIEW_GTK_API >= 0x400
+#if GTK_MAJOR_VERSION >= 4
     if (gtk_window_get_child(window) == widget) {
       gtk_window_set_child(window, nullptr);
     }
@@ -1753,7 +1748,7 @@ public:
   }
 
   static void widget_set_visible(GtkWidget *widget, bool visible) {
-#if WEBVIEW_GTK_API >= 0x400
+#if GTK_MAJOR_VERSION >= 4
     gtk_widget_set_visible(widget, visible ? TRUE : FALSE);
 #else
     if (visible) {
@@ -1765,7 +1760,7 @@ public:
   }
 
   static void window_set_size(GtkWindow *window, int width, int height) {
-#if WEBVIEW_GTK_API >= 0x400
+#if GTK_MAJOR_VERSION >= 4
     gtk_window_set_default_size(window, width, height);
 #else
     gtk_window_resize(window, width, height);
@@ -1774,7 +1769,7 @@ public:
 
   static void window_set_min_size(GtkWindow *window, int width, int height) {
 // X11-specific features are available in GTK 3 but not GTK 4
-#if WEBVIEW_GTK_API < 0x400
+#if GTK_MAJOR_VERSION < 4
     GdkGeometry g{};
     g.min_width = width;
     g.min_height = height;
@@ -1785,7 +1780,7 @@ public:
 
   static void window_set_max_size(GtkWindow *window, int width, int height) {
 // X11-specific features are available in GTK 3 but not GTK 4
-#if WEBVIEW_GTK_API < 0x400
+#if GTK_MAJOR_VERSION < 4
     GdkGeometry g{};
     g.max_width = width;
     g.max_height = height;


### PR DESCRIPTION
Adds support for compiling the webview library with WebKitGTK API 6.0 and GTK 4.

## Related changes

* CI: Builds and tests with WebKitGTK API 4.0, 4.1 and 6.0.
* Readme:
  * Updated with more information regarding packages on Linux.
  * Updated WebKitGTK API to 4.1 in examples.
  * Added information on backend selection with macros.
* Build script now automatically chooses a WebKitGTK API and GTK version, either by the value of the environment variable `WEBKITGTK_API` or from most modern API to least modern API (6.0, 4.1, 4.0).
* Since `gtk_main()` and `gtk_main_quit()` were removed from GTK 4, `webview::terminate()` now sets a flag that will cause `webview::run()` to return.

## Compatibility changes

Since `webkit_web_view_run_javascript()` became deprecated in WebKitGTK 2.40, compiler warnings were issued until we decided to dynamically import that function as well as the modern `webkit_web_view_evaluate_javascript()`, and call them based on which version of the WebKitGTK library was loaded.

With the changes to add support for WebKitGTK API 6.0 and GTK 4, some existing functions in those libraries have either been removed, replaced or had their signatures changed.

Compiling in support for all the different versions at the same time will likely be difficult to maintain over time, so the code that decided whether to call `webkit_web_view_run_javascript()` or `webkit_web_view_evaluate_javascript()` was changed in this PR from being a runtime decision to being a compile-time decision.

In PR #1022, I said that a compile-time decision didn't seem like a good option. I would still have preferred a better solution, but I believe it will take a lot more work to maintain runtime support for multiple variations of GTK and WebKitGTK APIs.

Calling `webview_set_size()` with `WEBVIEW_HINT_MAX` to set the maximum window size is not supported with GTK 4 because X11-specific functions such as `gtk_window_set_geometry_hints()` were removed with no replacement. This option has no effect when using GTK 4. Documentation has been updated to reflect this.

Since `gtk_window_resize()` was removed in GTK 4, `gtk_window_set_default_size()` is called instead, but this means that `webview_set_size()` can only set the initial size of the window when specifying `WEBVIEW_HINT_NONE`.