### PR TITLE
Use cxx_std_11 compile feature

### DIFF
--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -53,6 +53,8 @@ macro(webview_init)
         endif()
 
         # Default language standards
+        # All of CMAKE_<LANG>_STANDARD, CMAKE_<LANG>_REQUIRED and CMAKE_<LANG>_EXTENSIONS must be set
+        # Note that we also use the cxx_std_11 compile feature for consumers
         set(CMAKE_C_STANDARD 99 CACHE STRING "")
         set(CMAKE_C_STANDARD_REQUIRED YES)
         set(CMAKE_C_EXTENSIONS NO)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,6 +7,8 @@ target_include_directories(
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(webview_core_headers INTERFACE ${WEBVIEW_DEPENDENCIES})
+# Note that we also use CMAKE_CXX_STANDARD which can override this
+target_compile_features(webview_core_headers INTERFACE cxx_std_11)
 set_target_properties(webview_core_headers PROPERTIES
     EXPORT_NAME core_headers)
 


### PR DESCRIPTION
Sets the `cxx_std_11` compile feature on the `webview_core_headers` CMake target so that the minimum C++ standard used by targets that link it is C++11. This can be overridden by the `CMAKE_CXX_STANDARD` variable.