### PR TITLE
Fix clang-format conflict before and after v16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,7 +47,7 @@ BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true

--- a/core/include/webview/webview.h
+++ b/core/include/webview/webview.h
@@ -2202,8 +2202,9 @@ private:
 class cocoa_wkwebview_engine : public engine_base {
 public:
   cocoa_wkwebview_engine(bool debug, void *window)
-      : m_debug{debug}, m_window{static_cast<id>(window)}, m_owns_window{
-                                                               !window} {
+      : m_debug{debug},
+        m_window{static_cast<id>(window)},
+        m_owns_window{!window} {
     auto app = get_shared_application();
     // See comments related to application lifecycle in create_app_delegate().
     if (!m_owns_window) {


### PR DESCRIPTION
clang-format-16 and later (18) do not agree with clang-format-15 and earlier (9) on how to format the member initializers in the constructor of cocoa_wkwebview_engine.

By enabling ConstructorInitializerAllOnOneLineOrOnePerLine, the initializers are formatted consistently either on a single line or on separate lines if they can't fit on a single line.

This option was introduced in clang-format 3.7 and is currently deprecated. The replacement appears to be PackConstructorInitializers, which was introduced in clang-format-14. The deprecated option is used here to retain the same clang-format (9) compatibility.