### PR TITLE
added inline to get_file_version_string and cast_to_webview

### DIFF
--- a/core/include/webview/webview.h
+++ b/core/include/webview/webview.h
@@ -2838,7 +2838,8 @@ auto parse_version(const T (&version)[Length]) noexcept {
   return parse_version(std::basic_string<T>(version, Length));
 }
 
-std::wstring get_file_version_string(const std::wstring &file_path) noexcept {
+inline std::wstring
+get_file_version_string(const std::wstring &file_path) noexcept {
   DWORD dummy_handle; // Unused
   DWORD info_buffer_length =
       GetFileVersionInfoSizeW(file_path.c_str(), &dummy_handle);
@@ -4374,7 +4375,7 @@ using webview = browser_engine;
 
 namespace detail {
 
-webview *cast_to_webview(void *w) {
+inline webview *cast_to_webview(void *w) {
   if (!w) {
     throw exception{WEBVIEW_ERROR_INVALID_ARGUMENT,
                     "Cannot cast null pointer to webview instance"};


### PR DESCRIPTION
### TL;DR; 
This PR addresses linker issues similar to those found in issue #378 , by adding inline to `get_file_version_string` and `cast_to_webview`

### Details:
I am able to get this project to build an run sucessfully if all of the webview code is contained in a single source file `main.cc` but if I split the code and use multiple source files, it introduces linker errors similar to issue #378.

here is key info from my build output so you can see the environment/compiler/build tools etc. 

```bash
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.22631.
-- The CXX compiler identification is MSVC 19.40.33813.0
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe - skipped
-- The C compiler identification is MSVC 19.40.33813.0
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe - skipped
-- Found MSWebView2: P:/04_Computer_Science/_cpp/celaris/celaris-src/src-celaris/build/_deps/microsoft_web_webview2-src/build/native/include  
```

and here are the details of the linker errors:

```bash
bindings.obj : error LNK2005: "class std::basic_string<wchar_t,struct std::char_traits<wchar_t>,class std::allocator<wchar_t> > __cdecl webview::detail::get_file_
version_string(class std::basic_string<wchar_t,struct std::char_traits<wchar_t>,class std::allocator<wchar_t> > const &)" (?get_file_version_string@detail@webview 
@@YA?AV?$basic_string@_WU?$char_traits@_W@std@@V?$allocator@_W@2@@std@@AEBV34@@Z) already defined in main.obj [P:\04_Computer_Science\_cpp\celaris\celaris-src\src 
-celaris\build\src-celaris\celaris.vcxproj]
bindings.obj : error LNK2005: "class webview::detail::win32_edge_engine * __cdecl webview::detail::cast_to_webview(void *)" (?cast_to_webview@detail@webview@@YAPE 
AVwin32_edge_engine@12@PEAX@Z) already defined in main.obj [P:\04_Computer_Science\_cpp\celaris\celaris-src\src-celaris\build\src-celaris\celaris.vcxproj]
P:\04_Computer_Science\_cpp\celaris\celaris-src\src-celaris\build\bin\Debug\celaris.exe : fatal error LNK1169: one or more multiply defined symbols found [P:\04_C
omputer_Science\_cpp\celaris\celaris-src\src-celaris\build\src-celaris\celaris.vcxproj]
```

### Development Notes
> modifications to this code base were done using Linux Pop!_OS 22.04 LTS using GNU 11.4.0 with all tests passing sucessfully.