### PR TITLE
Fix Web Inspector layout (macOS)

### DIFF
--- a/core/include/webview/detail/platform/darwin/cocoa.hh
+++ b/core/include/webview/detail/platform/darwin/cocoa.hh
@@ -47,6 +47,15 @@ enum NSApplicationActivationPolicy : NSInteger {
 
 enum NSModalResponse : NSInteger { NSModalResponseOK = 1 };
 
+enum NSAutoresizingMaskOptions : NSUInteger {
+  NSViewMinXMargin = 1,
+  NSViewWidthSizable = 2,
+  NSViewMaxXMargin = 4,
+  NSViewMinYMargin = 8,
+  NSViewHeightSizable = 16,
+  NSViewMaxYMargin = 32
+};
+
 } // namespace detail
 } // namespace webview
 


### PR DESCRIPTION
Docking the Web Inspector (Developer Tools) pane to the bottom of the main window resulted in portions of the the web view to be pushed out of bounds. The pane would also flicker when docked to the right side.

The cause of the issue appears to be that when the Web Inspector is opened, it's automatically added into the view hierarchy as a sibling of the web view, but the web view was set as the window's content view.

In order to make the web view and Web Inspector more self-contained, a new widget is now containing both, with proper auto-resizing.