### PR TITLE
Runtime compatibility with old macOS

### DIFF
--- a/core/include/webview/detail/backends/cocoa_webkit.hh
+++ b/core/include/webview/detail/backends/cocoa_webkit.hh
@@ -547,15 +547,25 @@ private:
     objc::msg_send<id>(preferences, "setValue:forKey:"_sel, yes_value,
                        "fullScreenEnabled"_str);
 
-    // Equivalent Obj-C:
-    // [[config preferences] setValue:@YES forKey:@"javaScriptCanAccessClipboard"];
-    objc::msg_send<id>(preferences, "setValue:forKey:"_sel, yes_value,
-                       "javaScriptCanAccessClipboard"_str);
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_available)
+    if (__builtin_available(macOS 10.13, *)) {
+      // Equivalent Obj-C:
+      // [[config preferences] setValue:@YES forKey:@"javaScriptCanAccessClipboard"];
+      objc::msg_send<id>(preferences, "setValue:forKey:"_sel, yes_value,
+                         "javaScriptCanAccessClipboard"_str);
 
-    // Equivalent Obj-C:
-    // [[config preferences] setValue:@YES forKey:@"DOMPasteAllowed"];
-    objc::msg_send<id>(preferences, "setValue:forKey:"_sel, yes_value,
-                       "DOMPasteAllowed"_str);
+      // Equivalent Obj-C:
+      // [[config preferences] setValue:@YES forKey:@"DOMPasteAllowed"];
+      objc::msg_send<id>(preferences, "setValue:forKey:"_sel, yes_value,
+                         "DOMPasteAllowed"_str);
+    }
+#else
+#error __builtin_available not supported by compiler
+#endif
+#else
+#error __has_builtin not supported by compiler
+#endif
 
     auto ui_delegate = create_webkit_ui_delegate();
     objc::msg_send<void>(m_webview, "initWithFrame:configuration:"_sel,

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -208,7 +208,8 @@ protected:
     var bytes = new Uint8Array(16);\n\
     crypto.getRandomValues(bytes);\n\
     return Array.prototype.slice.call(bytes).map(function(n) {\n\
-      return n.toString(16).padStart(2, '0');\n\
+      var s = n.toString(16);\n\
+      return ((s.length % 2) == 1 ? '0' : '') + s;\n\
     }).join('');\n\
   }\n\
   var Webview = (function() {\n\

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -237,7 +237,7 @@ protected:
       if (result !== undefined) {\n\
         try {\n\
           result = JSON.parse(result);\n\
-        } catch {\n\
+        } catch (e) {\n\
           promise.reject(new Error(\"Failed to parse binding result as JSON\"));\n\
           return;\n\
         }\n\

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -248,7 +248,7 @@ protected:
       }\n\
     };\n\
     Webview_.prototype.onBind = function(name) {\n\
-      if (Object.hasOwn(window, name)) {\n\
+      if (window.hasOwnProperty(name)) {\n\
         throw new Error('Property \"' + name + '\" already exists');\n\
       }\n\
       window[name] = (function() {\n\
@@ -257,7 +257,7 @@ protected:
       }).bind(this);\n\
     };\n\
     Webview_.prototype.onUnbind = function(name) {\n\
-      if (!Object.hasOwn(window, name)) {\n\
+      if (!window.hasOwnProperty(name)) {\n\
         throw new Error('Property \"' + name + '\" does not exist');\n\
       }\n\
       delete window[name];\n\


### PR DESCRIPTION
These changes allow an app built with the webview library to run on older versions of macOS.

Tested with the following versions of the operating system:

* OS X El Capitan 10.11
* macOS High Sierra 10.13
* macOS Sequoia 15