### PR TITLE
Fix amalgamation script failing on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         image:
           - macos-14
           - ubuntu-22.04
-          #- windows-2022
+          - windows-2022
         python-version:
           - "3.9"
           - "3.10"
@@ -56,8 +56,8 @@ jobs:
             clang-format-exe: clang-format
           - image: ubuntu-22.04
             clang-format-exe: clang-format-15
-          #- image: windows-2022
-          #  clang-format-exe: clang-format
+          - image: windows-2022
+            clang-format-exe: clang-format
     steps:
       - uses: actions/checkout@v4
       - if: runner.os == 'Linux'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
           - ubuntu-22.04
           #- windows-2022
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         image:
-          #- macos-14
+          - macos-14
           - ubuntu-22.04
           #- windows-2022
         python-version:
@@ -52,8 +52,8 @@ jobs:
           - "3.11"
           - "3.12"
         include:
-          #- image: macos-14
-          #  clang-format-exe: clang-format
+          - image: macos-14
+            clang-format-exe: clang-format
           - image: ubuntu-22.04
             clang-format-exe: clang-format-15
           #- image: windows-2022
@@ -62,6 +62,8 @@ jobs:
       - uses: actions/checkout@v4
       - if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y clang-format-15
+      - if: runner.os == 'macOS'
+        run: brew install clang-format
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,44 @@ jobs:
       gcovr-version: ${{ needs.vars.outputs.gcovr-version }}
       pr: true
 
+  amalgamate:
+    needs:
+      - check
+      - vars
+    runs-on: ${{ matrix.image }}
+    strategy:
+      matrix:
+        image:
+          #- macos-14
+          - ubuntu-22.04
+          #- windows-2022
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        include:
+          #- image: macos-14
+          #  clang-format-exe: clang-format
+          - image: ubuntu-22.04
+            clang-format-exe: clang-format-15
+          #- image: windows-2022
+          #  clang-format-exe: clang-format
+    steps:
+      - uses: actions/checkout@v4
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y clang-format-15
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          python3 scripts/amalgamate.py \
+            "--clang-format-exe=${{ matrix.clang-format-exe }}" \
+            --base core/include/webview \
+            --output webviev_amalgamation.h webview.h
+        shell: bash
+
   merge-package-artifacts:
     needs: build
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ This project uses the CMake build system.
 
 In addition to the dependencies mentioned earlier in this document for developing *with* the webview library, the following are used during development *of* the webview library.
 
+* Amalgamation:
+  * Python >= 3.9
 * Checks:
   * `clang-format`
   * `clang-tidy`


### PR DESCRIPTION
The amalgamation script fails on Windows due to file locking/sharing issues.

This work creates a temporary directory instead without keeping any temporary files open.

A CI job was also added for testing the amalgamation script with different versions of Python on different platforms so that this type of issue will be caught sooner.

The minimum Python version required by this script is 3.9 because of the `graphlib` module used.