### PR TITLE
Fix deletion of incomplete type user_script::impl

### DIFF
--- a/core/include/webview/detail/backends/cocoa_webkit.hh
+++ b/core/include/webview/detail/backends/cocoa_webkit.hh
@@ -297,8 +297,9 @@ protected:
         WKUserScriptInjectionTimeAtDocumentStart, YES);
     // Script is retained when added.
     objc::msg_send<void>(m_manager, "addUserScript:"_sel, wk_script);
-    user_script script{js, std::unique_ptr<user_script::impl>{
-                               new user_script::impl{wk_script}}};
+    user_script script{
+        js, user_script::impl_ptr{new user_script::impl{wk_script},
+                                  [](user_script::impl *p) { delete p; }}};
     objc::msg_send<void>(wk_script, "release"_sel);
     return script;
   }

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -265,8 +265,9 @@ protected:
         js.c_str(), WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
         WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, nullptr, nullptr);
     webkit_user_content_manager_add_script(m_user_content_manager, wk_script);
-    user_script script{js, std::unique_ptr<user_script::impl>{
-                               new user_script::impl{wk_script}}};
+    user_script script{
+        js, user_script::impl_ptr{new user_script::impl{wk_script},
+                                  [](user_script::impl *p) { delete p; }}};
     webkit_user_script_unref(wk_script);
     return script;
   }

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -683,8 +683,9 @@ protected:
     }
     // TODO: There's a non-zero chance that we didn't get the script ID.
     //       We need to convey the error somehow.
-    return user_script{js, std::unique_ptr<user_script::impl>{
-                               new user_script::impl{script_id, wjs}}};
+    return user_script{
+        js, user_script::impl_ptr{new user_script::impl{script_id, wjs},
+                                  [](user_script::impl *p) { delete p; }}};
   }
 
   void

--- a/core/include/webview/detail/user_script.hh
+++ b/core/include/webview/detail/user_script.hh
@@ -26,6 +26,7 @@
 #ifndef WEBVIEW_DETAIL_USER_SCRIPT_HH
 #define WEBVIEW_DETAIL_USER_SCRIPT_HH
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -36,8 +37,10 @@ namespace detail {
 class user_script {
 public:
   class impl;
+  using impl_deleter = std::function<void(impl *)>;
+  using impl_ptr = std::unique_ptr<impl, impl_deleter>;
 
-  user_script(const std::string &code, std::unique_ptr<impl> &&impl_)
+  user_script(const std::string &code, impl_ptr &&impl_)
       : m_code{code}, m_impl{std::move(impl_)} {}
 
   user_script(const user_script &other) = delete;
@@ -61,7 +64,7 @@ public:
 
 private:
   std::string m_code;
-  std::unique_ptr<impl> m_impl;
+  impl_ptr m_impl;
 };
 
 } // namespace detail


### PR DESCRIPTION
When compiling in C++23 mode using Clang, compilation failed in `~unique_ptr()` due to user_script::impl being an incomplete type.

Issue was observed with Clang 16 and 18 on Linux/macOS, with C++23 set via `CMAKE_CXX_STANDARD`. C++20 and earlier did not yield an error.

The issue could not be observed with GCC 13.2 and 14.2 on Linux.

Fixes #1215