### PR TITLE
Add environment on Edge Webview

### DIFF
--- a/core/include/webview/api.h
+++ b/core/include/webview/api.h
@@ -58,7 +58,7 @@ extern "C" {
  *         May be returned if WebView2 is unavailable on Windows.
  */
 WEBVIEW_API webview_t webview_create(int debug, void *window,
-                                     void *env = nullptr);
+                                     void *env);
 
 /**
  * Destroys a webview instance and closes the native window.

--- a/core/include/webview/api.h
+++ b/core/include/webview/api.h
@@ -57,8 +57,7 @@ extern "C" {
  * @retval WEBVIEW_ERROR_MISSING_DEPENDENCY
  *         May be returned if WebView2 is unavailable on Windows.
  */
-WEBVIEW_API webview_t webview_create(int debug, void *window,
-                                     void *env);
+WEBVIEW_API webview_t webview_create(int debug, void *window, void *env);
 
 /**
  * Destroys a webview instance and closes the native window.

--- a/core/include/webview/api.h
+++ b/core/include/webview/api.h
@@ -57,7 +57,8 @@ extern "C" {
  * @retval WEBVIEW_ERROR_MISSING_DEPENDENCY
  *         May be returned if WebView2 is unavailable on Windows.
  */
-WEBVIEW_API webview_t webview_create(int debug, void *window);
+WEBVIEW_API webview_t webview_create(int debug, void *window,
+                                     void *env = nullptr);
 
 /**
  * Destroys a webview instance and closes the native window.

--- a/core/include/webview/c_api_impl.hh
+++ b/core/include/webview/c_api_impl.hh
@@ -86,12 +86,12 @@ inline webview *cast_to_webview(void *w) {
 } // namespace detail
 } // namespace webview
 
-WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
+WEBVIEW_API webview_t webview_create(int debug, void *wnd, void *env) {
   using namespace webview::detail;
   webview::webview *w{};
   auto err = api_filter(
       [=]() -> webview::result<webview::webview *> {
-        return new webview::webview{static_cast<bool>(debug), wnd};
+        return new webview::webview{static_cast<bool>(debug), wnd, env};
       },
       [&](webview::webview *w_) { w = w_; });
   if (err == WEBVIEW_ERROR_OK) {

--- a/core/include/webview/detail/backends/cocoa_webkit.hh
+++ b/core/include/webview/detail/backends/cocoa_webkit.hh
@@ -80,7 +80,7 @@ private:
 
 class cocoa_wkwebview_engine : public engine_base {
 public:
-  cocoa_wkwebview_engine(bool debug, void *window, void *env = nullptr)
+  cocoa_wkwebview_engine(bool debug, void *window, void *env)
       : m_debug{debug},
         m_window{static_cast<id>(window)},
         m_owns_window{!window} {

--- a/core/include/webview/detail/backends/cocoa_webkit.hh
+++ b/core/include/webview/detail/backends/cocoa_webkit.hh
@@ -80,7 +80,7 @@ private:
 
 class cocoa_wkwebview_engine : public engine_base {
 public:
-  cocoa_wkwebview_engine(bool debug, void *window)
+  cocoa_wkwebview_engine(bool debug, void *window, void *env = nullptr)
       : m_debug{debug},
         m_window{static_cast<id>(window)},
         m_owns_window{!window} {

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -91,11 +91,13 @@ public:
 private:
   WebKitUserScript *m_script{};
 };
+#define UNUSEDPARAMETERENVIRONMENT(x) (void)(x)
 
 class gtk_webkit_engine : public engine_base {
 public:
   gtk_webkit_engine(bool debug, void *window, void *env)
       : m_owns_window{!window}, m_window(static_cast<GtkWidget *>(window)) {
+    UNUSEDPARAMETERENVIRONMENT(env);
     if (m_owns_window) {
       if (!gtk_compat::init_check()) {
         throw exception{WEBVIEW_ERROR_UNSPECIFIED, "GTK init failed"};

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -94,7 +94,7 @@ private:
 
 class gtk_webkit_engine : public engine_base {
 public:
-  gtk_webkit_engine(bool debug, void *window, void *env = nullptr)
+  gtk_webkit_engine(bool debug, void *window, void *env)
       : m_owns_window{!window}, m_window(static_cast<GtkWidget *>(window)) {
     if (m_owns_window) {
       if (!gtk_compat::init_check()) {

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -94,7 +94,7 @@ private:
 
 class gtk_webkit_engine : public engine_base {
 public:
-  gtk_webkit_engine(bool debug, void *window)
+  gtk_webkit_engine(bool debug, void *window, void *env = nullptr)
       : m_owns_window{!window}, m_window(static_cast<GtkWidget *>(window)) {
     if (m_owns_window) {
       if (!gtk_compat::init_check()) {

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -303,7 +303,7 @@ private:
 
 class win32_edge_engine : public engine_base {
 public:
-  win32_edge_engine(bool debug, void *window, void *envOptions = nullptr)
+  win32_edge_engine(bool debug, void *window, void *envOptions)
       : m_owns_window{!window} {
     if (!is_webview2_available()) {
       throw exception{WEBVIEW_ERROR_MISSING_DEPENDENCY,

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -303,7 +303,7 @@ private:
 
 class win32_edge_engine : public engine_base {
 public:
-  win32_edge_engine(bool debug, void *window) : m_owns_window{!window} {
+  win32_edge_engine(bool debug, void *window, void *envOptions) : m_owns_window{!window} {
     if (!is_webview2_available()) {
       throw exception{WEBVIEW_ERROR_MISSING_DEPENDENCY,
                       "WebView2 is unavailable"};
@@ -517,7 +517,7 @@ public:
     auto cb =
         std::bind(&win32_edge_engine::on_message, this, std::placeholders::_1);
 
-    embed(m_widget, debug, cb).ensure_ok();
+    embed(m_widget, debug, cb, static_cast<ICoreWebView2EnvironmentOptions *>(envOptions)).ensure_ok();
   }
 
   virtual ~win32_edge_engine() {
@@ -704,7 +704,7 @@ protected:
   }
 
 private:
-  noresult embed(HWND wnd, bool debug, msg_cb_t cb) {
+  noresult embed(HWND wnd, bool debug, msg_cb_t cb, ICoreWebView2EnvironmentOptions *envOption) {
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
     flag.test_and_set();
 
@@ -736,7 +736,7 @@ private:
 
     m_com_handler->set_attempt_handler([&] {
       return m_webview2_loader.create_environment_with_options(
-          nullptr, userDataFolder, nullptr, m_com_handler);
+          nullptr, userDataFolder, envOption, m_com_handler);
     });
     m_com_handler->try_create_environment();
 

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -303,7 +303,7 @@ private:
 
 class win32_edge_engine : public engine_base {
 public:
-  win32_edge_engine(bool debug, void *window, void *envOptions)
+  win32_edge_engine(bool debug, void *window, void *envOptions = nullptr)
       : m_owns_window{!window} {
     if (!is_webview2_available()) {
       throw exception{WEBVIEW_ERROR_MISSING_DEPENDENCY,

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -303,7 +303,8 @@ private:
 
 class win32_edge_engine : public engine_base {
 public:
-  win32_edge_engine(bool debug, void *window, void *envOptions) : m_owns_window{!window} {
+  win32_edge_engine(bool debug, void *window, void *envOptions)
+      : m_owns_window{!window} {
     if (!is_webview2_available()) {
       throw exception{WEBVIEW_ERROR_MISSING_DEPENDENCY,
                       "WebView2 is unavailable"};
@@ -516,8 +517,9 @@ public:
 
     auto cb =
         std::bind(&win32_edge_engine::on_message, this, std::placeholders::_1);
-
-    embed(m_widget, debug, cb, static_cast<ICoreWebView2EnvironmentOptions *>(envOptions)).ensure_ok();
+    embed(m_widget, debug, cb,
+          static_cast<ICoreWebView2EnvironmentOptions *>(envOptions))
+        .ensure_ok();
   }
 
   virtual ~win32_edge_engine() {
@@ -704,7 +706,8 @@ protected:
   }
 
 private:
-  noresult embed(HWND wnd, bool debug, msg_cb_t cb, ICoreWebView2EnvironmentOptions *envOption) {
+  noresult embed(HWND wnd, bool debug, msg_cb_t cb,
+                 ICoreWebView2EnvironmentOptions *envOption) {
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
     flag.test_and_set();
 

--- a/core/tests/src/tests.cc
+++ b/core/tests/src/tests.cc
@@ -29,7 +29,7 @@ void cb_terminate(webview_t w, void *arg) {
 
 TEST_CASE("Use C API to create a window, run app and terminate it") {
   webview_t w;
-  w = webview_create(false, nullptr);
+  w = webview_create(false, nullptr, nullptr);
   webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
   webview_set_title(w, "Test");
   webview_set_html(w, "set_html ok");
@@ -97,7 +97,7 @@ TEST_CASE("Use C API to test binding and unbinding") {
   auto html = "<script>\n"
               "  window.test(0);\n"
               "</script>";
-  auto w = webview_create(1, nullptr);
+  auto w = webview_create(1, nullptr, nullptr);
   context.w = w;
   // Attempting to remove non-existing binding is OK
   webview_unbind(w, "test");

--- a/core/tests/src/tests.cc
+++ b/core/tests/src/tests.cc
@@ -12,7 +12,7 @@
 #include <cstdint>
 
 TEST_CASE("Start app loop and terminate it") {
-  webview::webview w(false, nullptr);
+  webview::webview w(false, nullptr, nullptr);
   w.dispatch([&]() { w.terminate(); });
   w.run();
 }
@@ -122,7 +122,7 @@ TEST_CASE("Test synchronous binding and unbinding") {
     return js;
   };
   unsigned int number = 0;
-  webview::webview w(false, nullptr);
+  webview::webview w(false, nullptr, nullptr);
   auto test = [&](const std::string &req) -> std::string {
     auto increment = [&](const std::string & /*req*/) -> std::string {
       ++number;
@@ -183,7 +183,7 @@ TEST_CASE("The string returned from a binding call must be JSON") {
   }
 </script>)html";
 
-  webview::webview w(true, nullptr);
+  webview::webview w(true, nullptr, nullptr);
 
   w.bind("loadData", [](const std::string & /*req*/) -> std::string {
     return "\"hello\"";
@@ -213,7 +213,7 @@ TEST_CASE("The string returned of a binding call must not be JS") {
   }
 </script>)html";
 
-  webview::webview w(true, nullptr);
+  webview::webview w(true, nullptr, nullptr);
 
   w.bind("loadData", [](const std::string & /*req*/) -> std::string {
     // Try to load malicious JS code
@@ -247,7 +247,7 @@ TEST_CASE("webview_version()") {
 
 struct test_webview : webview::browser_engine {
   using cb_t = std::function<void(test_webview *, int, const std::string &)>;
-  test_webview(cb_t cb) : webview::browser_engine(true, nullptr), m_cb(cb) {}
+  test_webview(cb_t cb) : webview::browser_engine(true, nullptr, nullptr), m_cb(cb) {}
   void on_message(const std::string &msg) override { m_cb(this, i++, msg); }
   int i = 0;
   cb_t m_cb;

--- a/core/tests/src/tests.cc
+++ b/core/tests/src/tests.cc
@@ -247,7 +247,8 @@ TEST_CASE("webview_version()") {
 
 struct test_webview : webview::browser_engine {
   using cb_t = std::function<void(test_webview *, int, const std::string &)>;
-  test_webview(cb_t cb) : webview::browser_engine(true, nullptr, nullptr), m_cb(cb) {}
+  test_webview(cb_t cb)
+      : webview::browser_engine(true, nullptr, nullptr), m_cb(cb) {}
   void on_message(const std::string &msg) override { m_cb(this, i++, msg); }
   int i = 0;
   cb_t m_cb;

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -15,7 +15,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine,
 #else
 int main(void) {
 #endif
-  webview_t w = webview_create(0, NULL);
+  webview_t w = webview_create(0, NULL, NULL);
   webview_set_title(w, "Basic Example");
   webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);
   webview_set_html(w, "Thanks for using webview!");

--- a/examples/basic.cc
+++ b/examples/basic.cc
@@ -9,7 +9,7 @@ int WINAPI WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,
 int main() {
 #endif
   try {
-    webview::webview w(false, nullptr);
+    webview::webview w(false, nullptr, nullptr);
     w.set_title("Basic Example");
     w.set_size(480, 320, WEBVIEW_HINT_NONE);
     w.set_html("Thanks for using webview!");

--- a/examples/bind.c
+++ b/examples/bind.c
@@ -173,7 +173,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR lpCmdLine,
 #else
 int main(void) {
 #endif
-  webview_t w = webview_create(0, NULL);
+  webview_t w = webview_create(0, NULL, NULL);
   context_t context = {.w = w, .count = 0};
   webview_set_title(w, "Bind Example");
   webview_set_size(w, 480, 320, WEBVIEW_HINT_NONE);

--- a/examples/bind.cc
+++ b/examples/bind.cc
@@ -47,7 +47,7 @@ int main() {
   try {
     long count = 0;
 
-    webview::webview w(true, nullptr);
+    webview::webview w(true, nullptr, nullptr);
     w.set_title("Bind Example");
     w.set_size(480, 320, WEBVIEW_HINT_NONE);
 


### PR DESCRIPTION
# Allow `ICoreWebView2EnvironmentOptions` to be Passed to Constructor

## Description

This pull request introduces a modification to the WebView library, allowing the `ICoreWebView2EnvironmentOptions` to be passed directly to the constructor. This enhancement provides greater flexibility in configuring WebView2 environments with custom options, such as disabling features or setting specific browser arguments.

---

## Changes

- Updated the constructor to accept an `ICoreWebView2EnvironmentOptions` parameter.
- Modified relevant parts of the initialization process to utilize the provided environment options.

---

## Implementation Details

### Constructor Modification

The constructor is now capable of receiving an `ICoreWebView2EnvironmentOptions` parameter.

**Example:**
```cpp
#include <WebView2EnvironmentOptions.h>
#include <iostream>
#include "webview/webview.h"


#ifdef _WIN32
int WINAPI WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hPrevInst*/,
                   LPSTR /*lpCmdLine*/, int /*nCmdShow*/) {
#else
int main() {
#endif
  try {
    auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
    options->put_AdditionalBrowserArguments(L"--flag-switches-begin --disable-features=ElasticOverscroll,OverscrollHistoryNavigation --flag-switches-end");
   
    webview::webview w(false, nullptr, options.Get());
    w.set_title("Basic Example");
    w.set_size(480, 320, WEBVIEW_HINT_NONE);
    w.set_html("Thanks for using webview!");
    w.run();
  } catch (const webview::exception &e) {
    std::cerr << e.what() << '\n';
    return 1;
  }

  return 0;
}

```
