### PR TITLE
Fix link errors

### DIFF
--- a/cmake/modules/FindMSWebView2.cmake
+++ b/cmake/modules/FindMSWebView2.cmake
@@ -16,5 +16,12 @@ if(MSWebView2_FOUND)
         set_target_properties(MSWebView2::headers PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${MSWebView2_INCLUDE_DIR}")
         target_compile_features(MSWebView2::headers INTERFACE cxx_std_14)
+
+        if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+            set(MSWebView2_LIB ${MSWebView2_INCLUDE_DIR}/../x64/WebView2LoaderStatic.lib)
+        else()
+            set(MSWebView2_LIB ${MSWebView2_INCLUDE_DIR}/../x86/WebView2LoaderStatic.lib)
+        endif()
+        target_link_libraries(MSWebView2::headers INTERFACE ${MSWebView2_LIB})
     endif()
 endif()


### PR DESCRIPTION
for -DWEBVIEW_MSWEBVIEW2_BUILTIN_IMPL=0 & -DWEBVIEW_MSWEBVIEW2_EXPLICIT_LINK=0, it will occurs link errors.

built-in implementation of the WebView2 loader(create_environment_with_options) seems has some error to load older version of Webview2, so I use CreateCoreWebView2EnvironmentWithOptions instead, but it not link to WebView2LoaderStatic.lib

https://github.com/webview/webview/issues/1233
