### PR TITLE
Include macros.h

### DIFF
--- a/core/include/webview/detail/backends/cocoa_webkit.hh
+++ b/core/include/webview/detail/backends/cocoa_webkit.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_BACKENDS_COCOA_WEBKIT_HH) &&                              \
-    defined(WEBVIEW_PLATFORM_DARWIN) && defined(WEBVIEW_COCOA)
+#ifndef WEBVIEW_BACKENDS_COCOA_WEBKIT_HH
 #define WEBVIEW_BACKENDS_COCOA_WEBKIT_HH
+
+#include "../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_DARWIN) && defined(WEBVIEW_COCOA)
 
 //
 // ====================================================================
@@ -685,4 +688,5 @@ using browser_engine = detail::cocoa_wkwebview_engine;
 
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_BACKENDS_COCOA_WEBKIT_H

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_BACKENDS_GTK_WEBKITGTK_HH) &&                             \
-    defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
+#ifndef WEBVIEW_BACKENDS_GTK_WEBKITGTK_HH
 #define WEBVIEW_BACKENDS_GTK_WEBKITGTK_HH
+
+#include "../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
 
 //
 // ====================================================================
@@ -333,4 +336,5 @@ using browser_engine = detail::gtk_webkit_engine;
 
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_BACKENDS_GTK_WEBKITGTK_H

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_BACKENDS_WIN32_EDGE_HH) &&                                \
-    defined(WEBVIEW_PLATFORM_WINDOWS) && defined(WEBVIEW_EDGE)
+#ifndef WEBVIEW_BACKENDS_WIN32_EDGE_HH
 #define WEBVIEW_BACKENDS_WIN32_EDGE_HH
+
+#include "../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS) && defined(WEBVIEW_EDGE)
 
 //
 // ====================================================================
@@ -889,4 +892,5 @@ using browser_engine = detail::win32_edge_engine;
 
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_BACKENDS_WIN32_EDGE_H

--- a/core/include/webview/detail/platform/darwin/cocoa.hh
+++ b/core/include/webview/detail/platform/darwin/cocoa.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_DARWIN_COCOA_HH) &&                              \
-    defined(WEBVIEW_PLATFORM_DARWIN)
+#ifndef WEBVIEW_PLATFORM_DARWIN_COCOA_HH
 #define WEBVIEW_PLATFORM_DARWIN_COCOA_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_DARWIN) && defined(WEBVIEW_COCOA)
 
 #include <objc/NSObjCRuntime.h>
 
@@ -59,4 +62,5 @@ enum NSAutoresizingMaskOptions : NSUInteger {
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_DARWIN_COCOA_HH

--- a/core/include/webview/detail/platform/darwin/objc.hh
+++ b/core/include/webview/detail/platform/darwin/objc.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_DARWIN_OBJC_HH) &&                               \
-    defined(WEBVIEW_PLATFORM_DARWIN)
+#ifndef WEBVIEW_PLATFORM_DARWIN_OBJC_HH
 #define WEBVIEW_PLATFORM_DARWIN_OBJC_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_DARWIN)
 
 #include <cstddef>
 
@@ -109,4 +112,5 @@ inline id operator"" _str(const char *s, std::size_t) {
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_DARWIN_OBJC_HH

--- a/core/include/webview/detail/platform/darwin/webkit.hh
+++ b/core/include/webview/detail/platform/darwin/webkit.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_DARWIN_WEBKIT_HH) &&                             \
-    defined(WEBVIEW_PLATFORM_DARWIN) && defined(WEBVIEW_COCOA)
+#ifndef WEBVIEW_PLATFORM_DARWIN_WEBKIT_HH
 #define WEBVIEW_PLATFORM_DARWIN_WEBKIT_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_DARWIN) && defined(WEBVIEW_COCOA)
 
 #include <objc/NSObjCRuntime.h>
 
@@ -39,4 +42,5 @@ enum WKUserScriptInjectionTime : NSInteger {
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_DARWIN_WEBKIT_HH

--- a/core/include/webview/detail/platform/linux/gtk/compat.hh
+++ b/core/include/webview/detail/platform/linux/gtk/compat.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_LINUX_GTK_COMPAT_HH) &&                          \
-    defined(WEBVIEW_PLATFORM_LINUX)
+#ifndef WEBVIEW_PLATFORM_LINUX_GTK_COMPAT_HH
 #define WEBVIEW_PLATFORM_LINUX_GTK_COMPAT_HH
+
+#include "../../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
 
 #include <gtk/gtk.h>
 
@@ -125,4 +128,5 @@ public:
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_LINUX_GTK_COMPAT_HH

--- a/core/include/webview/detail/platform/linux/webkitgtk/compat.hh
+++ b/core/include/webview/detail/platform/linux/webkitgtk/compat.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_LINUX_WEBKITGTK_COMPAT_HH) &&                    \
-    defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
+#ifndef WEBVIEW_PLATFORM_LINUX_WEBKITGTK_COMPAT_HH
 #define WEBVIEW_PLATFORM_LINUX_WEBKITGTK_COMPAT_HH
+
+#include "../../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
 
 #include <functional>
 #include <string>
@@ -132,4 +135,5 @@ public:
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_LINUX_WEBKITGTK_COMPAT_HH

--- a/core/include/webview/detail/platform/linux/webkitgtk/dmabuf.hh
+++ b/core/include/webview/detail/platform/linux/webkitgtk/dmabuf.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_BACKENDS_GTK_WEBKITGTK_DMABUF_HH) &&                      \
-    defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
+#ifndef WEBVIEW_BACKENDS_GTK_WEBKITGTK_DMABUF_HH
 #define WEBVIEW_BACKENDS_GTK_WEBKITGTK_DMABUF_HH
+
+#include "../../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
 
 #include <cstdlib>
 #include <string>
@@ -157,4 +160,5 @@ static inline void apply_webkit_dmabuf_workaround() {
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_BACKENDS_GTK_WEBKITGTK_DMABUF_HH

--- a/core/include/webview/detail/platform/windows/com_init_wrapper.hh
+++ b/core/include/webview/detail/platform/windows/com_init_wrapper.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_COM_INIT_WRAPPER_HH) &&                  \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_COM_INIT_WRAPPER_HH
 #define WEBVIEW_PLATFORM_WINDOWS_COM_INIT_WRAPPER_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 //
 // ====================================================================
@@ -112,4 +115,5 @@ private:
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_COM_INIT_WRAPPER_HH

--- a/core/include/webview/detail/platform/windows/dpi.hh
+++ b/core/include/webview/detail/platform/windows/dpi.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_DPI_HH) &&                               \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_DPI_HH
 #define WEBVIEW_PLATFORM_WINDOWS_DPI_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 //
 // ====================================================================
@@ -153,4 +156,5 @@ inline SIZE make_window_frame_size(HWND window, int width, int height,
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_DPI_HH

--- a/core/include/webview/detail/platform/windows/dwmapi.hh
+++ b/core/include/webview/detail/platform/windows/dwmapi.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_DWMAPI_HH) &&                            \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_DWMAPI_HH
 #define WEBVIEW_PLATFORM_WINDOWS_DWMAPI_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include "../../native_library.hh"
 
@@ -57,4 +60,5 @@ constexpr auto DwmSetWindowAttribute =
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_DWMAPI_HH

--- a/core/include/webview/detail/platform/windows/iid.hh
+++ b/core/include/webview/detail/platform/windows/iid.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_IID_HH) &&                               \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_IID_HH
 #define WEBVIEW_PLATFORM_WINDOWS_IID_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -68,4 +71,5 @@ To *cast_if_equal_iid(From *from, REFIID riid, const cast_info_t<To> &info,
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_IID_HH

--- a/core/include/webview/detail/platform/windows/ntdll.hh
+++ b/core/include/webview/detail/platform/windows/ntdll.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_NTDLL_HH) &&                             \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_NTDLL_HH
 #define WEBVIEW_PLATFORM_WINDOWS_NTDLL_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include "../../native_library.hh"
 
@@ -48,4 +51,5 @@ constexpr auto RtlGetVersion = library_symbol<RtlGetVersion_t>("RtlGetVersion");
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_NTDLL_HH

--- a/core/include/webview/detail/platform/windows/reg_key.hh
+++ b/core/include/webview/detail/platform/windows/reg_key.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_REG_KEY_HH) &&                           \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_REG_KEY_HH
 #define WEBVIEW_PLATFORM_WINDOWS_REG_KEY_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include <string>
 #include <vector>
@@ -125,4 +128,5 @@ private:
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_REG_KEY_HH

--- a/core/include/webview/detail/platform/windows/shcore.hh
+++ b/core/include/webview/detail/platform/windows/shcore.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_SHCORE_HH) &&                            \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_SHCORE_HH
 #define WEBVIEW_PLATFORM_WINDOWS_SHCORE_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include "../../native_library.hh"
 
@@ -49,4 +52,5 @@ constexpr auto SetProcessDpiAwareness =
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_SHCORE_HH

--- a/core/include/webview/detail/platform/windows/theme.hh
+++ b/core/include/webview/detail/platform/windows/theme.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_THEME_HH) &&                             \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_THEME_HH
 #define WEBVIEW_PLATFORM_WINDOWS_THEME_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include "../../native_library.hh"
 #include "dwmapi.hh"
@@ -66,4 +69,5 @@ inline void apply_window_theme(HWND window) {
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_THEME_HH

--- a/core/include/webview/detail/platform/windows/user32.hh
+++ b/core/include/webview/detail/platform/windows/user32.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_USER32_HH) &&                            \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_USER32_HH
 #define WEBVIEW_PLATFORM_WINDOWS_USER32_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include "../../native_library.hh"
 
@@ -80,4 +83,5 @@ constexpr auto AreDpiAwarenessContextsEqual =
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_USER32_HH

--- a/core/include/webview/detail/platform/windows/version.hh
+++ b/core/include/webview/detail/platform/windows/version.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_PLATFORM_WINDOWS_VERSION_HH) &&                           \
-    defined(WEBVIEW_PLATFORM_WINDOWS)
+#ifndef WEBVIEW_PLATFORM_WINDOWS_VERSION_HH
 #define WEBVIEW_PLATFORM_WINDOWS_VERSION_HH
+
+#include "../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS)
 
 #include "ntdll.hh"
 
@@ -140,4 +143,5 @@ inline int compare_os_version(unsigned int major, unsigned int minor,
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_PLATFORM_WINDOWS_VERSION_HH

--- a/core/include/webview/detail/platform/windows/webview2/loader.hh
+++ b/core/include/webview/detail/platform/windows/webview2/loader.hh
@@ -23,9 +23,12 @@
  * SOFTWARE.
  */
 
-#if !defined(WEBVIEW_BACKENDS_WEBVIEW2_LOADER_HH) &&                           \
-    defined(WEBVIEW_PLATFORM_WINDOWS) && defined(WEBVIEW_EDGE)
+#ifndef WEBVIEW_BACKENDS_WEBVIEW2_LOADER_HH
 #define WEBVIEW_BACKENDS_WEBVIEW2_LOADER_HH
+
+#include "../../../../macros.h"
+
+#if defined(WEBVIEW_PLATFORM_WINDOWS) && defined(WEBVIEW_EDGE)
 
 #include "../../../native_library.hh"
 #include "../iid.hh"
@@ -372,4 +375,5 @@ static constexpr auto add_script_to_execute_on_document_created_completed =
 } // namespace detail
 } // namespace webview
 
+#endif
 #endif // WEBVIEW_BACKENDS_WEBVIEW2_LOADER_HH


### PR DESCRIPTION
Re-enables code syntax highlighting in code editors for files that enable code based on whether platform/backend-specific macros are defined.

Example:

    #if defined(WEBVIEW_PLATFORM_LINUX) && defined(WEBVIEW_GTK)
    #endif

Without the `macros.h` header, `WEBVIEW_PLATFORM_LINUX` and `WEBVIEW_GTK` would by default appear to be undefined in code editors.