### PR TITLE
CI test timeout

### DIFF
--- a/.github/actions/cmake/action.yaml
+++ b/.github/actions/cmake/action.yaml
@@ -59,6 +59,10 @@ inputs:
   test-wrapper-cmd:
     description: Test wrapper command
     required: false
+  test-timeout:
+    description: Test timeout in seconds
+    required: false
+    default: '10'
   upload-coverage-artifacts:
     description: Upload coverage artifacts?
     required: false
@@ -147,6 +151,9 @@ runs:
             --output-on-failure
             --build-config "${config}"
           )
+          if [[ ! -z "${{ inputs.test-timeout }}" ]]; then
+            cmake_cmd+=(--timeout "${{ inputs.test-timeout }}")
+          fi
           "${cmake_cmd[@]}"
         done
       shell: ${{ inputs.shell }}

--- a/.github/actions/cmake/action.yaml
+++ b/.github/actions/cmake/action.yaml
@@ -56,13 +56,13 @@ inputs:
     description: CMake source directory
     required: false
     default: .
-  test-wrapper-cmd:
-    description: Test wrapper command
-    required: false
   test-timeout:
     description: Test timeout in seconds
     required: false
     default: '60'
+  test-wrapper-cmd:
+    description: Test wrapper command
+    required: false
   upload-coverage-artifacts:
     description: Upload coverage artifacts?
     required: false

--- a/.github/actions/cmake/action.yaml
+++ b/.github/actions/cmake/action.yaml
@@ -62,7 +62,7 @@ inputs:
   test-timeout:
     description: Test timeout in seconds
     required: false
-    default: '10'
+    default: '60'
   upload-coverage-artifacts:
     description: Upload coverage artifacts?
     required: false

--- a/core/tests/src/tests.cc
+++ b/core/tests/src/tests.cc
@@ -9,7 +9,9 @@
 #include "webview/webview.h"
 
 #include <cassert>
+#include <chrono>
 #include <cstdint>
+#include <thread>
 
 TEST_CASE("Start app loop and terminate it") {
   webview::webview w(false, nullptr);
@@ -485,3 +487,15 @@ TEST_CASE("Ensure that narrow/wide string conversion works on Windows") {
   REQUIRE(narrow_string(std::wstring(2, L'\0')) == std::string(2, '\0'));
 }
 #endif
+
+TEST_CASE("Temporary test to ensure that timeout works (9s)") {
+  std::this_thread::sleep_for(std::chrono::seconds{9});
+}
+
+TEST_CASE("Temporary test to ensure that timeout works (10s)") {
+  std::this_thread::sleep_for(std::chrono::seconds{10});
+}
+
+TEST_CASE("Temporary test to ensure that timeout works (11s)") {
+  std::this_thread::sleep_for(std::chrono::seconds{11});
+}

--- a/core/tests/src/tests.cc
+++ b/core/tests/src/tests.cc
@@ -9,9 +9,7 @@
 #include "webview/webview.h"
 
 #include <cassert>
-#include <chrono>
 #include <cstdint>
-#include <thread>
 
 TEST_CASE("Start app loop and terminate it") {
   webview::webview w(false, nullptr);
@@ -487,15 +485,3 @@ TEST_CASE("Ensure that narrow/wide string conversion works on Windows") {
   REQUIRE(narrow_string(std::wstring(2, L'\0')) == std::string(2, '\0'));
 }
 #endif
-
-TEST_CASE("Temporary test to ensure that timeout works (9s)") {
-  std::this_thread::sleep_for(std::chrono::seconds{9});
-}
-
-TEST_CASE("Temporary test to ensure that timeout works (10s)") {
-  std::this_thread::sleep_for(std::chrono::seconds{10});
-}
-
-TEST_CASE("Temporary test to ensure that timeout works (11s)") {
-  std::this_thread::sleep_for(std::chrono::seconds{11});
-}


### PR DESCRIPTION
Sets a 60 second timeout for tests. There used to be a timeout in the past but after the switch to CMake/CTest and the test driver rewrite, no timeout had been set.

Dummy tests that sleep the thread show that the timeout works (10s here but later changed to 60s):

```
      Start  6: Temporary test to ensure that timeout works (10s)
 6/17 Test  #6: Temporary test to ensure that timeout works (10s) .........***Timeout  10.01 sec

      Start  7: Temporary test to ensure that timeout works (11s)
 7/17 Test  #7: Temporary test to ensure that timeout works (11s) .........***Timeout  10.01 sec

      Start  8: Temporary test to ensure that timeout works (9s)
 8/17 Test  #8: Temporary test to ensure that timeout works (9s) ..........   Passed    9.03 sec
```