### PR TITLE
fix: refine message loop handling to prevent blocking

### DIFF
--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -747,6 +747,7 @@ private:
     bool got_quit_msg = false;
     MSG msg;
     while (flag.test_and_set() && !got_quit_msg) {
+      Sleep(1);
       while (PeekMessageW(&msg, nullptr, 0, 0, PM_NOREMOVE)) {
         if (0 >= GetMessageW(&msg, nullptr, 0, 0)) {
           got_quit_msg = true;

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -746,10 +746,12 @@ private:
     // Pump the message loop until WebView2 has finished initialization.
     bool got_quit_msg = false;
     MSG msg;
+    BOOL ret;
     while (flag.test_and_set() && !got_quit_msg) {
       Sleep(1);
       while (PeekMessageW(&msg, nullptr, 0, 0, PM_NOREMOVE)) {
-        if (0 >= GetMessageW(&msg, nullptr, 0, 0)) {
+        ret = GetMessageW(&msg, nullptr, 0, 0);
+        if (0 == ret || -1 == ret) {
           got_quit_msg = true;
           break;
         }

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -746,13 +746,15 @@ private:
     // Pump the message loop until WebView2 has finished initialization.
     bool got_quit_msg = false;
     MSG msg;
-    while (flag.test_and_set() && GetMessageW(&msg, nullptr, 0, 0) >= 0) {
-      if (msg.message == WM_QUIT) {
-        got_quit_msg = true;
-        break;
+    while (flag.test_and_set() && !got_quit_msg) {
+      while (PeekMessageW(&msg, nullptr, 0, 0, PM_NOREMOVE)) {
+        if (0 >= GetMessageW(&msg, nullptr, 0, 0)) {
+          got_quit_msg = true;
+          break;
+        }
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
       }
-      TranslateMessage(&msg);
-      DispatchMessageW(&msg);
     }
     if (got_quit_msg) {
       return error_info{WEBVIEW_ERROR_CANCELED};


### PR DESCRIPTION
`GetMessageW` sometimes blocks the thread and freezes the program. This changes it to calling non-blocking `PeekMessageW` with `PM_NOREMOVE` first and then calling `GetMessageW` once there is a message available.