### PR TITLE
C++11 compatibility for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The most up-to-date documentation is right in the source code. Improving the doc
 
 ## Prerequisites
 
-Your compiler must support minimum C++11 except for platforms that require a more modern version.
+Your compiler must support minimum C++11.
 
 This project uses CMake and Ninja, and while recommended for your convenience, these tools aren't required for using the library.
 

--- a/cmake/modules/FindMSWebView2.cmake
+++ b/cmake/modules/FindMSWebView2.cmake
@@ -15,6 +15,6 @@ if(MSWebView2_FOUND)
         add_library(MSWebView2::headers INTERFACE IMPORTED)
         set_target_properties(MSWebView2::headers PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${MSWebView2_INCLUDE_DIR}")
-        target_compile_features(MSWebView2::headers INTERFACE cxx_std_14)
+        target_compile_features(MSWebView2::headers INTERFACE cxx_std_11)
     endif()
 endif()

--- a/core/include/webview/detail/platform/windows/com_init_wrapper.hh
+++ b/core/include/webview/detail/platform/windows/com_init_wrapper.hh
@@ -104,7 +104,8 @@ public:
     if (this == &other) {
       return *this;
     }
-    m_initialized = std::exchange(other.m_initialized, false);
+    m_initialized = other.m_initialized;
+    other.m_initialized = false;
     return *this;
   }
 

--- a/core/include/webview/detail/platform/windows/com_init_wrapper.hh
+++ b/core/include/webview/detail/platform/windows/com_init_wrapper.hh
@@ -98,7 +98,10 @@ public:
 
   com_init_wrapper(const com_init_wrapper &other) = delete;
   com_init_wrapper &operator=(const com_init_wrapper &other) = delete;
-  com_init_wrapper(com_init_wrapper &&other) noexcept { *this = std::move(other); }
+
+  com_init_wrapper(com_init_wrapper &&other) noexcept {
+    *this = std::move(other);
+  }
 
   com_init_wrapper &operator=(com_init_wrapper &&other) noexcept {
     if (this == &other) {

--- a/core/include/webview/detail/platform/windows/com_init_wrapper.hh
+++ b/core/include/webview/detail/platform/windows/com_init_wrapper.hh
@@ -98,9 +98,9 @@ public:
 
   com_init_wrapper(const com_init_wrapper &other) = delete;
   com_init_wrapper &operator=(const com_init_wrapper &other) = delete;
-  com_init_wrapper(com_init_wrapper &&other) { *this = std::move(other); }
+  com_init_wrapper(com_init_wrapper &&other) noexcept { *this = std::move(other); }
 
-  com_init_wrapper &operator=(com_init_wrapper &&other) {
+  com_init_wrapper &operator=(com_init_wrapper &&other) noexcept {
     if (this == &other) {
       return *this;
     }

--- a/core/include/webview/detail/platform/windows/dpi.hh
+++ b/core/include/webview/detail/platform/windows/dpi.hh
@@ -133,9 +133,8 @@ constexpr int scale_value_for_dpi(int value, int from_dpi, int to_dpi) {
 }
 
 constexpr SIZE scale_size(int width, int height, int from_dpi, int to_dpi) {
-  auto scaled_width = scale_value_for_dpi(width, from_dpi, to_dpi);
-  auto scaled_height = scale_value_for_dpi(height, from_dpi, to_dpi);
-  return {scaled_width, scaled_height};
+  return {scale_value_for_dpi(width, from_dpi, to_dpi),
+          scale_value_for_dpi(height, from_dpi, to_dpi)};
 }
 
 inline SIZE make_window_frame_size(HWND window, int width, int height,

--- a/core/include/webview/detail/platform/windows/dpi.hh
+++ b/core/include/webview/detail/platform/windows/dpi.hh
@@ -115,8 +115,7 @@ inline bool enable_non_client_dpi_scaling_if_needed(HWND window) {
 }
 
 constexpr int get_default_window_dpi() {
-  constexpr const int default_dpi = 96; // USER_DEFAULT_SCREEN_DPI
-  return default_dpi;
+  return 96; // USER_DEFAULT_SCREEN_DPI
 }
 
 inline int get_window_dpi(HWND window) {

--- a/core/include/webview/detail/platform/windows/version.hh
+++ b/core/include/webview/detail/platform/windows/version.hh
@@ -54,7 +54,8 @@ namespace detail {
 template <typename T>
 std::array<unsigned int, 4>
 parse_version(const std::basic_string<T> &version) noexcept {
-  auto parse_component = [](auto sb, auto se) -> unsigned int {
+  using iterator = typename std::basic_string<T>::const_iterator;
+  auto parse_component = [](iterator sb, iterator se) -> unsigned int {
     try {
       auto n = std::stol(std::basic_string<T>(sb, se));
       return n < 0 ? 0 : n;
@@ -82,7 +83,7 @@ parse_version(const std::basic_string<T> &version) noexcept {
 }
 
 template <typename T, std::size_t Length>
-auto parse_version(const T (&version)[Length]) noexcept {
+std::array<unsigned int, 4> parse_version(const T (&version)[Length]) noexcept {
   return parse_version(std::basic_string<T>(version, Length));
 }
 

--- a/core/include/webview/detail/platform/windows/webview2/loader.hh
+++ b/core/include/webview/detail/platform/windows/webview2/loader.hh
@@ -216,7 +216,7 @@ private:
     if (!found_client.found) {
       return -1;
     }
-    auto client_dll = native_library(found_client.dll_path.c_str());
+    auto client_dll = native_library(found_client.dll_path);
     if (auto fn = client_dll.get(
             webview2_symbols::CreateWebViewEnvironmentWithOptionsInternal)) {
       return fn(true, found_client.runtime_type, user_data_dir, env_options,

--- a/core/include/webview/detail/platform/windows/webview2/loader.hh
+++ b/core/include/webview/detail/platform/windows/webview2/loader.hh
@@ -201,10 +201,19 @@ public:
 private:
 #if WEBVIEW_MSWEBVIEW2_BUILTIN_IMPL == 1
   struct client_info_t {
-    bool found = false;
+    bool found{};
     std::wstring dll_path;
     std::wstring version;
-    webview2_runtime_type runtime_type;
+    webview2_runtime_type runtime_type{};
+
+    client_info_t() = default;
+
+    client_info_t(bool found, std::wstring dll_path, std::wstring version,
+                  webview2_runtime_type runtime_type)
+        : found{found},
+          dll_path{std::move(dll_path)},
+          version{std::move(version)},
+          runtime_type{runtime_type} {}
   };
 
   HRESULT create_environment_with_options_impl(
@@ -307,7 +316,7 @@ private:
     }
 
     auto client_dll_path = make_client_dll_path(ebwebview_value);
-    return {true, client_dll_path, client_version_string,
+    return {true, std::move(client_dll_path), std::move(client_version_string),
             webview2_runtime_type::installed};
   }
 
@@ -322,7 +331,7 @@ private:
       return {};
     }
 
-    return {true, client_dll_path, client_version_string,
+    return {true, std::move(client_dll_path), std::move(client_version_string),
             webview2_runtime_type::embedded};
   }
 


### PR DESCRIPTION
This work makes some changes that are necessary for lowering the minimum required C++ standard on Windows from C++14 to C++11.

I can't recall why `cxx_std_14` was set instead of `cxx_std_11` for the `MSWebView2::headers` CMake target but it may have been under the wrong belief that it wouldn't work with `cxx_std_11`. Now it does appear to work with the MinGW distributions we test with so making this change seems reasonable to me.

Some code for Windows were using C++14 features and have been replaced to be compatible with C++11.

While at it, the move constructor and assignment operator of `com_init_wrapper` should have been marked with `noexcept` and has therefore been marked as such.