### PR TITLE
Mention thread safety in readme and C API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,12 @@ Here are some of the noteworthy ways our implementation of the loader differs fr
 
 [Customization options](#Customization) can be used to change how the library integrates the WebView2 loader.
 
+## Thread Safety
+
+Since library functions generally do not have thread safety guarantees, `webview_dispatch()` (C) / `webview::dispatch()` (C++) can be used to schedule code to execute on the main/GUI thread and thereby make that execution safe in multi-threaded applications.
+
+The main/GUI thread should be the thread that calls `webview_run()` (C) / `webview::run()` (C++).
+
 ## Development
 
 This project uses the CMake build system.

--- a/core/include/webview/api.h
+++ b/core/include/webview/api.h
@@ -83,7 +83,10 @@ WEBVIEW_API webview_error_t webview_terminate(webview_t w);
 
 /**
  * Schedules a function to be invoked on the thread with the run/event loop.
- * Use this function e.g. to interact with the library or native handles.
+ *
+ * Since library functions generally do not have thread safety guarantees,
+ * this function can be used to schedule code to execute on the main/GUI
+ * thread and thereby make that execution safe in multi-threaded applications.
  *
  * @param w The webview instance.
  * @param fn The function to be invoked.


### PR DESCRIPTION
Updates documentation to mention current thread safety guarantees in the library.

@citkane, this may be of interest to you.