### PR TITLE
Fix window rendering glitch and refactor win32 edge

### DIFF
--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -790,8 +790,8 @@ private:
                         "put_IsStatusBarEnabled failed"};
     }
     add_init_script("function(message) {\n\
-   return window.chrome.webview.postMessage(message);\n\
- }");
+  return window.chrome.webview.postMessage(message);\n\
+}");
     resize_webview();
     m_controller->put_IsVisible(TRUE);
     ShowWindow(m_widget, SW_SHOW);

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -475,7 +475,7 @@ protected:
       // Sadly we need to pump the event loop in order to get the script ID.
       run_event_loop_while([&] { return !done; });
       // The user's `set_size` may have been executed from the depleted event queue,
-      // so guard against putting the default `set_size` back onto the queue.
+      // and if so, guard against putting the default `set_size` back onto the queue.
       if (!m_is_window_shown) {
         default_size_guard(false);
         dispatch_size_default(m_owns_window);


### PR DESCRIPTION
This PR:
- Fixes a visual issue where the default size was set before the user size, causing a rendering glitch
- Refactors win32_edge to a more standardised backend code flow