### PR TITLE
Add utility to print to console

### DIFF
--- a/core/include/webview/aggregate_utility.hh
+++ b/core/include/webview/aggregate_utility.hh
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "../../src/utility/console.cc"

--- a/core/include/webview/aggregate_utility.hh
+++ b/core/include/webview/aggregate_utility.hh
@@ -1,3 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Serge Zaitsev
+ * Copyright (c) 2022 Steffen André Langnes
+ * Copyright (c) 2025 Michael Jonker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #include "../../src/utility/console.cc"

--- a/core/include/webview/aggregate_utility.hh
+++ b/core/include/webview/aggregate_utility.hh
@@ -24,6 +24,9 @@
  * SOFTWARE.
  */
 
-#pragma once
+#ifndef WEBVIEW_AGGREGATE_UTILITY_HH
+#define WEBVIEW_AGGREGATE_UTILITY_HH
 
 #include "../../src/utility/console.cc"
+
+#endif // WEBVIEW_AGGREGATE_UTILITY_HH

--- a/core/include/webview/c_api_impl.hh
+++ b/core/include/webview/c_api_impl.hh
@@ -34,7 +34,10 @@
 #include "json_deprecated.hh"
 #include "macros.h"
 #include "types.h"
+#include "utility/console.hh"
 #include "version.h"
+
+using namespace webview::utility;
 
 namespace webview {
 namespace detail {
@@ -90,6 +93,7 @@ inline webview *cast_to_webview(void *w) {
 
 WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
   using namespace webview::detail;
+  console::attach("webview_create");
   webview::webview *w{};
   auto err = api_filter(
       [=]() -> webview::result<webview::webview *> {

--- a/core/include/webview/c_api_impl.hh
+++ b/core/include/webview/c_api_impl.hh
@@ -93,7 +93,7 @@ inline webview *cast_to_webview(void *w) {
 
 WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
   using namespace webview::detail;
-  console::attach("webview_create");
+  console::attach_console("webview_create");
   webview::webview *w{};
   auto err = api_filter(
       [=]() -> webview::result<webview::webview *> {

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -28,6 +28,7 @@
 #define WEBVIEW_UTILITY_CONSOLE_HH
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
 
+#include "webview/errors.h"
 #include <mutex>
 #include <string>
 
@@ -77,7 +78,9 @@ public:
   static void warn(std::string message);
 
   /// Prints an error message in red to the console stderr.
-  static void error(std::string message);
+  /// @par[in] err Optionally provide a Webview error code.
+  static void error(std::string message,
+                    webview_error_t err = WEBVIEW_ERROR_UNSPECIFIED);
 
   /// Attaches a Webview owned console to the  Windows process if no user console is already attached.
   /// It informs the user of this process level change.

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -101,25 +101,26 @@ private:
 
 #if defined(_WIN32)
 
-  /// Determines if the user owns a console attached to the process.
-  static bool user_owns_console();
+  /// Gets and stores the existing Windows console modes for `stdout` and `stderr`.
+  static void get_store_ex_modes();
 
-  /// Gets the existing Windows console modes for `stdout` and `stderr`.
-  static void get_ex_modes();
-
-  /// Sets the user's Windows console mode for `stdout` and `stderr`
-  /// back to original states.
+  /// Re-sets the user's Windows console mode for `stdout` and `stderr`
+  /// back to stored original states.
   static void reset_user_modes();
 
-  /// Attempts to enable virtual terminal processing (for ASCI escaped colours)
-  /// in all Windows consoles for `stdout` and `stderr`.
+  /// Attempts to set `ENABLE_VIRTUAL_TERMINAL_PROCESSING`
+  /// (enabling ASCI escaped colours) on modes for `stdout` and `stderr`.
   static void set_evtp_modes();
 
-  /// Checks if enable virtual terminal processing is already set on a mode.
+  /// Checks if `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is already set on a mode.
   static bool has_evtp_mode(DWORD dw_mode);
 
-  /// Reopens `stdout` and `stderr` to point to a newly attached console.
-  static void redirect_stream(_iobuf *stream);
+  /// Reopens an output stream to point to an attached console.
+  static void redirect_o_stream(_iobuf *stream);
+
+  /// Determines if the user owns the console attached to the process.
+  /// @return Lazily initiated static const flag of ownership
+  static bool user_owns_console();
 
   /// Flags if Webview is in ownership of an attached console
   static bool wv_owns_console;

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -24,7 +24,8 @@
  * SOFTWARE.
  */
 
-#pragma once
+#ifndef WEBVIEW_UTILITY_CONSOLE_HH
+#define WEBVIEW_UTILITY_CONSOLE_HH
 
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
 
@@ -36,7 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #ifdef _MSC_VER
-#ifndef _WIN32_WINNT
+#ifndef _WIN32_WINNT 0x0601
 #define _WIN32_WINNT 0x0601
 #endif
 #endif
@@ -146,3 +147,4 @@ private:
 } // namespace webview
 
 #endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)
+#endif // WEBVIEW_UTILITY_CONSOLE_HH

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -27,54 +27,117 @@
 #pragma once
 
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
+
+#include <mutex>
 #include <string>
 
-struct colours_t {
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef _MSC_VER
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601
+#endif
+#endif
+
+#include <io.h>
+#include <windows.h>
+
+#endif // defined(_WIN32)
+
+struct console_colours_t {
   int yellow;
   int red;
   int dim;
+};
+struct console_prefix_t {
+  const char *warn;
+  const char *error;
+  const char *info;
 };
 
 namespace webview {
 namespace utility {
 
-/// A static utility class to log colourised warnings and errors to the process console.
+/// A static utility class to prints colourised warnings and errors to the process console.
 class console {
 public:
-  /// Logs info in dim to stdout
+  /// Prints info in dim to the console stdout.
   static void info(std::string message);
 
-  /// Logs a warning in yellow to stdout
+  /// Prints a warning in yellow to the console stdout.
   static void warn(std::string message);
 
-  /// Logs an error in red to stderr
+  /// Prints an error in red to the console stderr.
   static void error(std::string message);
 
-private:
-  /// Performs console initialisation differently for Windows and *Nix like systems
-  static void init_console();
+  /// Attaches a Windows console to Webview if no user console is already attached.
+  static void attach(std::string attach_location);
 
-  /// Frees the console for Windows systems else the process will hang/error at exit.
+private:
+  /// Prepares the console for printing.
+  static void capture_console();
+
+  /// Frees the console for Windows systems.
+  /// - prevents hang/error at exit.
+  /// - resets user managed console state.
   static void free_console();
 
   /// Sets an appropriate colour to a message string.
   static std::string set_colour(int color, std::string message);
 
   /// UTF console colour code int values.
-  static colours_t colours;
+  static console_colours_t colours;
 
-  // Flags if the console ASCI escape mode was successfully set.
+  /// Message prefix strings.
+  static console_prefix_t prefix;
+
+  // Flags if the Windows console ASCI escape mode succeeded.
   // This is always true for *Nix systems.
-  static bool is_console_mode_set;
+  static bool mode_set_success;
+
+  static std::mutex mutex;
 
 #if defined(_WIN32)
 
-  /// Determines if the user has already attached a console to the process.
-  /// This function is lazy initialised with a local static variable cached.
-  static bool user_has_console();
+  /// Determines if the user owns a console attached to the process.
+  static bool user_owns_console();
+
+  /// Gets the existing Windows console modes for `stdout` and `stderr`.
+  static void get_ex_modes();
+
+  /// Sets the user's Windows console mode for `stdout` and `stderr`
+  /// back to original states.
+  static void reset_user_modes();
+
+  /// Attempts to enable virtual terminal processing (for ASCI escaped colours)
+  /// in all Windows consoles for `stdout` and `stderr`.
+  static void set_evtp_modes();
+
+  /// Checks if enable virtual terminal processing is already set on a mode.
+  static bool has_evtp_mode(DWORD dw_mode);
+
+  /// Reopens `stdout` and `stderr` to point to a newly attached console.
+  static void redirect_stream(_iobuf *stream);
 
   /// Flags if Webview is in ownership of an attached console
-  static bool wv_has_console;
+  static bool wv_owns_console;
+
+  /// The existing console `stdout` mode.
+  static DWORD out_mode;
+
+  /// The existing console `stderr` mode.
+  static DWORD err_mode;
+
+  /// Handle to `stdout`.
+  static HANDLE h_out;
+
+  /// Handle to `stderr`.
+  static HANDLE h_err;
+
+  /// Dummy out file
+  static FILE *dummy_out;
 
 #endif // defined(_WIN32)
 

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -36,15 +36,15 @@
 #define WIN32_LEAN_AND_MEAN
 #endif // WIN32_LEAN_AND_MEAN
 #ifdef _MSC_VER
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601
+#endif // _WIN32_WINNT
 #ifndef WINBOOL
 #define WINBOOL BOOL
 #endif // WINBOOL
 #endif // _MSC_VER
-
 #include <io.h>
 #include <windows.h>
-
 #endif // defined(_WIN32)
 
 struct console_colours_t {

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -114,7 +114,8 @@ private:
 
   /// Attempts to set `ENABLE_VIRTUAL_TERMINAL_PROCESSING`
   /// (enabling ASCI escaped colours) on modes for `stdout` and `stderr`.
-  static void set_evtp_modes();
+  /// @return `true` if successful
+  static bool set_evtp_modes();
 
   /// Checks if `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is already set on a mode.
   static bool has_evtp_mode(DWORD dw_mode);
@@ -126,9 +127,9 @@ private:
   /// @return Lazily initiated static const flag
   static bool user_owns_console();
 
-  /// Sets the `stdout` and `stderr` file handles if not already set and
+  /// Gets the `stdout` and `stderr` file handles and
   /// assigns them to class properties.
-  static void get_set_o_handles();
+  static void get_output_handles();
 
   /// Flags if Webview is in ownership of an attached console
   static bool wv_owns_console;

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -37,9 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #endif // WIN32_LEAN_AND_MEAN
 #ifdef _MSC_VER
-#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601
-#endif // _WIN32_WINNT
 #endif // _MSC_VER
 
 #include <io.h>

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -41,6 +41,9 @@ namespace utility {
 /// A static utility class to log colourised warnings and errors to the process console.
 class console {
 public:
+  /// Logs info in dim to stdout
+  static void info(std::string message);
+
   /// Logs a warning in yellow to stdout
   static void warn(std::string message);
 

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -37,9 +37,9 @@
 #define WIN32_LEAN_AND_MEAN
 #endif // WIN32_LEAN_AND_MEAN
 #ifdef _MSC_VER
-#ifndef _WIN32_WINNT 0x0601
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601
-#endif // _WIN32_WINNT 0x0601
+#endif // _WIN32_WINNT
 #endif // _MSC_VER
 
 #include <io.h>

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -146,9 +146,6 @@ private:
   /// Handle to the `stderr` file.
   static HANDLE h_err;
 
-  /// Dummy out file
-  static FILE *dummy_out;
-
 #endif // defined(_WIN32)
 
 }; // class console

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -42,6 +42,14 @@
 #endif                      // _MSC_VER
 #include <io.h>
 #include <windows.h>
+struct modes_t {
+  DWORD out;
+  DWORD err;
+};
+struct handles_t {
+  HANDLE out;
+  HANDLE err;
+};
 #endif // defined(_WIN32)
 
 struct console_colours_t {
@@ -123,28 +131,22 @@ private:
   /// Reopens an output stream to point to an attached console.
   static void redirect_o_stream(_iobuf *stream);
 
-  /// Determines if the user owns the console attached to the process.
-  /// @return Lazily initiated static const flag
-  static bool user_owns_console();
-
   /// Gets the `stdout` and `stderr` file handles and
   /// assigns them to class properties.
   static void get_output_handles();
 
-  /// Flags if Webview is in ownership of an attached console
+  /// Determines if the user owns the console attached to the process.
+  /// @return Lazily initiated static const flag
+  static bool user_owns_console();
+
+  /// The stored existing console modes.
+  static modes_t modes;
+
+  /// Handles to the console out files.
+  static handles_t handles;
+
+  /// Flags if Webview owns the console.
   static bool wv_owns_console;
-
-  /// The stored existing console `stdout` mode.
-  static DWORD out_mode;
-
-  /// The stored existing console `stderr` mode.
-  static DWORD err_mode;
-
-  /// Handle to the `stdout` file.
-  static HANDLE h_out;
-
-  /// Handle to the `stderr` file.
-  static HANDLE h_err;
 
 #endif // defined(_WIN32)
 

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -37,9 +37,9 @@
 #endif // WIN32_LEAN_AND_MEAN
 #ifdef _MSC_VER
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0601
-#endif // _WIN32_WINNT
-#endif // _MSC_VER
+#define _WIN32_WINNT 0x0501 //Win XP
+#endif                      // _WIN32_WINNT
+#endif                      // _MSC_VER
 #include <io.h>
 #include <windows.h>
 #endif // defined(_WIN32)

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -35,12 +35,12 @@
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
-#endif
+#endif // WIN32_LEAN_AND_MEAN
 #ifdef _MSC_VER
 #ifndef _WIN32_WINNT 0x0601
 #define _WIN32_WINNT 0x0601
-#endif
-#endif
+#endif // _WIN32_WINNT 0x0601
+#endif // _MSC_VER
 
 #include <io.h>
 #include <windows.h>

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -26,7 +26,6 @@
 
 #ifndef WEBVIEW_UTILITY_CONSOLE_HH
 #define WEBVIEW_UTILITY_CONSOLE_HH
-
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
 
 #include <mutex>
@@ -76,17 +75,19 @@ public:
 
 private:
   /// Prepares the console for printing.
+  /// The internal implementation varies between Windows and *Nix.
   static void capture_console();
 
   /// Frees the console for Windows systems.
   /// - prevents hang/error at exit.
   /// - resets user managed console state.
+  /// NOOP for *Nix
   static void free_console();
 
-  /// Sets an appropriate colour to a message string.
+  /// Sets an ASCI escaped console colour to a message string.
   static std::string set_colour(int color, std::string message);
 
-  /// UTF console colour code int values.
+  /// ASCI colour int values.
   static console_colours_t colours;
 
   /// Message prefix strings.

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -42,11 +42,11 @@
 #endif                      // _MSC_VER
 #include <io.h>
 #include <windows.h>
-struct modes_t {
+struct console_modes_t {
   DWORD out;
   DWORD err;
 };
-struct handles_t {
+struct console_handles_t {
   HANDLE out;
   HANDLE err;
 };
@@ -140,10 +140,10 @@ private:
   static bool user_owns_console();
 
   /// The stored existing console modes.
-  static modes_t modes;
+  static console_modes_t modes;
 
   /// Handles to the console out files.
-  static handles_t handles;
+  static console_handles_t handles;
 
   /// Flags if Webview owns the console.
   static bool wv_owns_console;

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -1,3 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Serge Zaitsev
+ * Copyright (c) 2022 Steffen André Langnes
+ * Copyright (c) 2025 Michael Jonker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -39,9 +39,6 @@
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601
 #endif // _WIN32_WINNT
-#ifndef WINBOOL
-#define WINBOOL BOOL
-#endif // WINBOOL
 #endif // _MSC_VER
 #include <io.h>
 #include <windows.h>
@@ -74,10 +71,10 @@ public:
   /// Prints an error message in red to the console stderr.
   static void error(std::string message);
 
-  /// Attaches a Webview owned Windows process console if no user console is already attached.
-  /// Informs the user of this process level change.
+  /// Attaches a Webview owned console to the  Windows process if no user console is already attached.
+  /// It informs the user of this process level change.
   /// NOOP in *Nix.
-  static void attach(std::string attach_location);
+  static void attach_console(std::string attach_location);
 
 private:
   /// Prepares the console for printing.
@@ -101,14 +98,15 @@ private:
 
   // Flags if the Windows console ASCI escape mode succeeded.
   // This is initiated as always `true` for *Nix systems.
-  static bool mode_set_success;
+  static bool stat_out_modes;
 
   static std::mutex mutex;
 
 #if defined(_WIN32)
 
-  /// Gets and stores the existing Windows console modes for `stdout` and `stderr`.
-  static void store_ex_modes();
+  /// Gets the existing console modes for `stdout` and `stderr`
+  /// and stores them to class properties.
+  static void get_ex_console_modes();
 
   /// Re-sets the user's Windows console modes back to stored original states
   /// for `stdout` and `stderr`.
@@ -128,6 +126,10 @@ private:
   /// @return Lazily initiated static const flag
   static bool user_owns_console();
 
+  /// Sets the `stdout` and `stderr` file handles if not already set and
+  /// assigns them to class properties.
+  static void get_set_o_handles();
+
   /// Flags if Webview is in ownership of an attached console
   static bool wv_owns_console;
 
@@ -137,10 +139,10 @@ private:
   /// The stored existing console `stderr` mode.
   static DWORD err_mode;
 
-  /// Handle to `stdout`.
+  /// Handle to the `stdout` file.
   static HANDLE h_out;
 
-  /// Handle to `stderr`.
+  /// Handle to the `stderr` file.
   static HANDLE h_err;
 
   /// Dummy out file

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -32,6 +32,7 @@
 struct colours_t {
   int yellow;
   int red;
+  int dim;
 };
 
 namespace webview {

--- a/core/include/webview/utility/console.hh
+++ b/core/include/webview/utility/console.hh
@@ -1,0 +1,55 @@
+#pragma once
+
+#if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
+#include <string>
+
+struct colours_t {
+  int yellow;
+  int red;
+};
+
+namespace webview {
+namespace utility {
+
+/// A static utility class to log colourised warnings and errors to the process console.
+class console {
+public:
+  /// Logs a warning in yellow to stdout
+  static void warn(std::string message);
+
+  /// Logs an error in red to stderr
+  static void error(std::string message);
+
+private:
+  /// Performs console initialisation differently for Windows and *Nix like systems
+  static void init_console();
+
+  /// Frees the console for Windows systems else the process will hang/error at exit.
+  static void free_console();
+
+  /// Sets an appropriate colour to a message string.
+  static std::string set_colour(int color, std::string message);
+
+  /// UTF console colour code int values.
+  static colours_t colours;
+
+  // Flags if the console ASCI escape mode was successfully set.
+  // This is always true for *Nix systems.
+  static bool is_console_mode_set;
+
+#if defined(_WIN32)
+
+  /// Determines if the user has already attached a console to the process.
+  /// This function is lazy initialised with a local static variable cached.
+  static bool user_has_console();
+
+  /// Flags if Webview is in ownership of an attached console
+  static bool wv_has_console;
+
+#endif // defined(_WIN32)
+
+}; // class console
+} // namespace utility
+} // namespace webview
+
+#endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/include/webview/webview.h
+++ b/core/include/webview/webview.h
@@ -26,6 +26,7 @@
 #ifndef WEBVIEW_H
 #define WEBVIEW_H
 
+#include "aggregate_utility.hh"
 #include "api.h"
 #include "c_api_impl.hh"
 

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -46,10 +46,11 @@ void console::warn(std::string message) {
   free_console();
 };
 
-void console::error(std::string message) {
+void console::error(std::string message, webview_error_t err) {
   std::lock_guard<std::mutex> lock(mutex);
   capture_console();
-  message = set_colour(colours.red, prefix.error + message);
+  auto err_string = "[" + std::to_string(err) + "]";
+  message = set_colour(colours.red, prefix.error + err_string + message);
   static_cast<void>(fprintf(stderr, "%s\n", message.c_str()));
   free_console();
 };

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -32,15 +32,13 @@ std::string console::set_colour(int color, std::string message) {
 colours_t console::colours{33, 31};
 
 #if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
+
 #include <handleapi.h>
+// consoleapi.h needs handleapi.h preceeding
+#include <consoleapi.h>
+#include <consoleapi3.h>
 #include <io.h>
-#include <windows.h>
-#ifdef _MSC_VER
-#pragma comment(lib, "ole32.lib")
-#endif
+
 void console::init_console() {
   std::cout.flush();
   std::cerr.flush();

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -1,5 +1,32 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Serge Zaitsev
+ * Copyright (c) 2022 Steffen André Langnes
+ * Copyright (c) 2025 Michael Jonker
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #pragma once
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
+
 #include "webview/utility/console.hh"
 #include <iostream>
 

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -24,7 +24,8 @@
  * SOFTWARE.
  */
 
-#pragma once
+#ifndef WEBVIEW_UTILITY_CONSOLE_CC
+#define WEBVIEW_UTILITY_CONSOLE_CC
 #if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
 
 #include "webview/utility/console.hh"
@@ -188,7 +189,7 @@ HANDLE console::h_out;
 HANDLE console::h_err;
 FILE *console::dummy_out;
 
-#else
+#else // defined(_WIN32)
 
 void console::capture_console() {
   std::cout.flush();
@@ -201,3 +202,4 @@ bool console::mode_set_success{true};
 
 #endif // defined(_WIN32) #else
 #endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)
+#endif // WEBVIEW_UTILITY_CONSOLE_CC

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -196,7 +196,6 @@ DWORD console::out_mode = 0;
 DWORD console::err_mode = 0;
 HANDLE console::h_out;
 HANDLE console::h_err;
-FILE *console::dummy_out;
 
 #endif // !defined(_WIN32) #else
 #endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -1,0 +1,106 @@
+#pragma once
+#if defined(__cplusplus) && !defined(WEBVIEW_HEADER)
+#include "webview/utility/console.hh"
+#include <iostream>
+
+using namespace webview::utility;
+
+void console::warn(std::string message) {
+  init_console();
+  std::string prefix = "[WEBVIEW][WARNING]: ";
+  message = set_colour(colours.yellow, prefix + message);
+  printf("%s\n", message.c_str());
+  free_console();
+};
+
+void console::error(std::string message) {
+  init_console();
+  std::string prefix = "[WEBVIEW][ERROR]: ";
+  message = set_colour(colours.red, prefix + message);
+  std::cerr << message << "\n";
+  free_console();
+};
+
+std::string console::set_colour(int color, std::string message) {
+  if (!is_console_mode_set) {
+    return message;
+  };
+  message = "\x1B[" + std::to_string(color) + "m" + message + "\033[0m";
+  return message;
+}
+
+colours_t console::colours{33, 31};
+
+#if defined(_WIN32)
+
+#include <handleapi.h>
+#include <io.h>
+#include <windows.h>
+
+void console::init_console() {
+  std::cout.flush();
+  std::cerr.flush();
+  if (user_has_console()) {
+    return;
+  }
+  /* 
+   * We attach/free the console after every log operation to avoid deeply embedding the console system into 
+   * the Webview class destructor. 
+   * Console output should be minimal, and performance overhead for this negligable.
+   */
+  AttachConsole(ATTACH_PARENT_PROCESS);
+
+  if (wv_has_console) {
+    return;
+  }
+  auto std_out = freopen("CONOUT$", "w", stdout);
+  auto std_err = freopen("CONOUT$", "w", stderr);
+  /*
+   * Below here we enable virtual terminal processing to attempt getting ASCI escaped colours in legacy
+   * Windows systems.
+   */
+  auto fd_out = _fileno(std_out);
+  auto fd_err = _fileno(std_err);
+  auto h_out = reinterpret_cast<HANDLE>(_get_osfhandle(fd_out));
+  auto h_err = reinterpret_cast<HANDLE>(_get_osfhandle(fd_err));
+  DWORD dwMode = 0;
+  auto stat_out =
+      SetConsoleMode(h_out, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+  auto stat_err =
+      SetConsoleMode(h_err, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+  is_console_mode_set = stat_out && stat_err;
+
+  wv_has_console = true;
+};
+
+void console::free_console() {
+  if (!user_has_console()) {
+    FreeConsole();
+  }
+};
+
+bool console::user_has_console() {
+  static const bool has_console = [] {
+    return GetConsoleWindow() != nullptr;
+  }();
+  return has_console;
+}
+
+bool console::wv_has_console{};
+
+bool console::is_console_mode_set{};
+
+#else
+
+void console::init_console() {
+  std::cout.flush();
+  std::cerr.flush();
+};
+
+void console::free_console() {}
+
+bool console::is_console_mode_set = true;
+
+#endif // defined(_WIN32) #else
+#endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -110,9 +110,10 @@ void console::init_console() {
       SetConsoleMode(h_out, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
   auto stat_err =
       SetConsoleMode(h_err, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-
   is_console_mode_set = stat_out && stat_err;
 
+  info("Webview has attached the Windows console.\nIf you wish to mangage the "
+       "console, call `AttachConsole` before `webview_create`");
   wv_has_console = true;
 };
 

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -32,12 +32,15 @@ std::string console::set_colour(int color, std::string message) {
 colours_t console::colours{33, 31};
 
 #if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifdef _MSC_VER
+#define _WIN32_WINNT 0x0601
+#endif
 
-#include <handleapi.h>
-// consoleapi.h needs handleapi.h preceeding
-#include <consoleapi.h>
-#include <consoleapi3.h>
 #include <io.h>
+#include <windows.h>
 
 void console::init_console() {
   std::cout.flush();

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -32,7 +32,9 @@ std::string console::set_colour(int color, std::string message) {
 colours_t console::colours{33, 31};
 
 #if defined(_WIN32)
-
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <handleapi.h>
 #include <io.h>
 #include <windows.h>

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -31,23 +31,6 @@
 #include "webview/utility/console.hh"
 #include <iostream>
 
-// We repeat this from console.hh because MSVC is complaining/erroring
-#if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif // WIN32_LEAN_AND_MEAN
-#ifdef _MSC_VER
-#define _WIN32_WINNT 0x0601
-#ifndef WINBOOL
-#define WINBOOL BOOL
-#endif // WINBOOL
-#endif // _MSC_VER
-
-#include <io.h>
-#include <windows.h>
-
-#endif // defined(_WIN32)
-
 using namespace webview::utility;
 
 std::mutex console::mutex;
@@ -120,7 +103,7 @@ void console::capture_console() {
   if (user_owns_console()) {
     std::cout.flush();
     std::cerr.flush();
-    get_store_ex_modes();
+    store_ex_modes();
     set_evtp_modes();
     return;
   }
@@ -135,7 +118,7 @@ void console::capture_console() {
 
   redirect_o_stream(stdout);
   redirect_o_stream(stderr);
-  get_store_ex_modes();
+  store_ex_modes();
   set_evtp_modes();
   wv_owns_console = true;
 };
@@ -155,7 +138,7 @@ bool console::user_owns_console() {
   return has_console;
 }
 
-void console::get_store_ex_modes() {
+void console::store_ex_modes() {
   if (h_out && h_err) {
     return;
   }

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -32,118 +32,172 @@
 
 using namespace webview::utility;
 
-void console::info(std::string message) {
-  init_console();
-  std::string prefix = "[WEBVIEW][INFO]: ";
-  message = set_colour(colours.dim, prefix + message);
-  printf("%s\n", message.c_str());
-  free_console();
-};
+std::mutex console::mutex;
+console_colours_t console::colours{93, 91, 90};
+console_prefix_t console::prefix{
+    "[WEBVIEW][WARNING]: ", "[WEBVIEW][ERROR]: ", "[WEBVIEW][INFO]: "};
 
 void console::warn(std::string message) {
-  init_console();
-  std::string prefix = "[WEBVIEW][WARNING]: ";
-  message = set_colour(colours.yellow, prefix + message);
+  std::lock_guard<std::mutex> lock(mutex);
+  capture_console();
+  message = set_colour(colours.yellow, prefix.warn + message);
   printf("%s\n", message.c_str());
   free_console();
 };
 
 void console::error(std::string message) {
-  init_console();
-  std::string prefix = "[WEBVIEW][ERROR]: ";
-  message = set_colour(colours.red, prefix + message);
-  std::cerr << message << "\n";
+  std::lock_guard<std::mutex> lock(mutex);
+  capture_console();
+  message = set_colour(colours.red, prefix.error + message);
+  static_cast<void>(fprintf(stderr, "%s\n", message.c_str()));
+  free_console();
+};
+
+void console::info(std::string message) {
+  std::lock_guard<std::mutex> lock(mutex);
+  capture_console();
+  message = set_colour(colours.dim, prefix.info + message);
+  printf("%s\n", message.c_str());
   free_console();
 };
 
 std::string console::set_colour(int color, std::string message) {
-  if (!is_console_mode_set) {
+  if (!mode_set_success) {
     return message;
   };
   message = "\033[" + std::to_string(color) + "m" + message + "\033[0m";
   return message;
 }
 
-colours_t console::colours{93, 91, 90};
-
 #if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifdef _MSC_VER
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0601
-#endif
-#endif
 
-#include <io.h>
-#include <windows.h>
+void console::attach(std::string attach_location) {
+  if (user_owns_console() || wv_owns_console) {
+    return;
+  };
+  auto message =
+      "Webview will attach the Windows "
+      "console.\nIf you want to mangage the "
+      "console yourself, direct your outputs and call `AttachConsole` before "
+      "`" +
+      attach_location + "` in your code.";
+  info(message);
+};
 
-void console::init_console() {
-  std::cout.flush();
-  std::cerr.flush();
-  if (user_has_console()) {
+void console::capture_console() {
+
+  if (user_owns_console()) {
+    std::cout.flush();
+    std::cerr.flush();
+    get_ex_modes();
+    set_evtp_modes();
     return;
   }
-  /* 
-   * We attach/free the console after every log operation to avoid deeply embedding the console system into 
-   * the Webview class destructor. 
-   * Console output should be minimal, and performance overhead for this negligable.
-   */
-  AttachConsole(ATTACH_PARENT_PROCESS);
 
-  if (wv_has_console) {
+  // We attach/free the Webview owned console after every log operation to avoid
+  // deeply embedding the console utility into the Webview class destructor.
+  // Console output usage should be minimal, and performance overhead negligable.
+  auto got_console = AttachConsole(ATTACH_PARENT_PROCESS);
+  if (!got_console || wv_owns_console) {
     return;
   }
-  auto std_out = freopen("CONOUT$", "w", stdout);
-  auto std_err = freopen("CONOUT$", "w", stderr);
-  /*
-   * Below here we enable virtual terminal processing to attempt getting ASCI escaped colours in legacy
-   * Windows systems.
-   */
-  auto fd_out = _fileno(std_out);
-  auto fd_err = _fileno(std_err);
-  auto h_out = reinterpret_cast<HANDLE>(_get_osfhandle(fd_out));
-  auto h_err = reinterpret_cast<HANDLE>(_get_osfhandle(fd_err));
-  DWORD dwMode = 0;
-  auto stat_out =
-      SetConsoleMode(h_out, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-  auto stat_err =
-      SetConsoleMode(h_err, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-  is_console_mode_set = stat_out && stat_err;
 
-  info("Webview has attached the Windows console.\nIf you wish to mangage the "
-       "console, call `AttachConsole` before `webview_create` in your code.");
-  wv_has_console = true;
+  redirect_stream(stdout);
+  redirect_stream(stderr);
+  get_ex_modes();
+  set_evtp_modes();
+  wv_owns_console = true;
 };
 
 void console::free_console() {
-  if (!user_has_console()) {
-    FreeConsole();
+  if (user_owns_console()) {
+    reset_user_modes();
+    return;
   }
+  FreeConsole();
 };
 
-bool console::user_has_console() {
+bool console::user_owns_console() {
   static const bool has_console = [] {
     return GetConsoleWindow() != nullptr;
   }();
   return has_console;
 }
 
-bool console::wv_has_console{};
+void console::get_ex_modes() {
+  if (h_out && h_err) {
+    return;
+  }
+  h_out = GetStdHandle(STD_OUTPUT_HANDLE);
+  // Maybe a user has attached a console, but not created a stream
+  if (h_out == INVALID_HANDLE_VALUE) {
+    redirect_stream(stdout);
+    h_out = GetStdHandle(STD_OUTPUT_HANDLE);
+  }
+  h_err = GetStdHandle(STD_ERROR_HANDLE);
+  // Maybe a user has attached a console, but not created a stream
+  if (h_err == INVALID_HANDLE_VALUE) {
+    redirect_stream(stderr);
+    h_err = GetStdHandle(STD_OUTPUT_HANDLE);
+  }
+  GetConsoleMode(h_out, &out_mode);
+  GetConsoleMode(h_err, &err_mode);
+}
 
-bool console::is_console_mode_set{};
+void console::reset_user_modes() {
+  SetConsoleMode(h_out, out_mode);
+  SetConsoleMode(h_err, err_mode);
+}
+
+void console::set_evtp_modes() {
+  // Webview only needs to set console modes once.
+  if (wv_owns_console) {
+    return;
+  }
+  WINBOOL stat_out_mode;
+  WINBOOL stat_err_mode;
+  if (has_evtp_mode(out_mode)) {
+    stat_out_mode = true;
+  } else {
+    stat_out_mode =
+        SetConsoleMode(h_out, out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+  }
+  if (has_evtp_mode(err_mode)) {
+    stat_err_mode = true;
+  } else {
+    stat_err_mode =
+        SetConsoleMode(h_err, err_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+  }
+
+  mode_set_success = stat_out_mode && stat_err_mode;
+}
+
+bool console::has_evtp_mode(DWORD dw_mode) {
+  return (dw_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
+}
+
+void console::redirect_stream(_iobuf *stream) {
+  static_cast<void>(freopen_s(&dummy_out, "CONOUT$", "w", stream));
+}
+
+bool console::wv_owns_console{};
+bool console::mode_set_success{};
+DWORD console::out_mode = 0;
+DWORD console::err_mode = 0;
+HANDLE console::h_out;
+HANDLE console::h_err;
+FILE *console::dummy_out;
 
 #else
 
-void console::init_console() {
+void console::capture_console() {
   std::cout.flush();
   std::cerr.flush();
 };
 
 void console::free_console() {}
-
-bool console::is_console_mode_set = true;
+void console::attach(std::string /*attach_location*/) {}
+bool console::mode_set_success{true};
 
 #endif // defined(_WIN32) #else
 #endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -143,21 +143,21 @@ bool console::user_owns_console() {
 }
 
 void console::get_ex_console_modes() {
-  GetConsoleMode(h_out, &out_mode);
-  GetConsoleMode(h_err, &err_mode);
+  GetConsoleMode(handles.out, &modes.out);
+  GetConsoleMode(handles.err, &modes.err);
 }
 
 void console::get_output_handles() {
-  if (h_out && h_err) {
+  if (handles.out && handles.err) {
     return;
   }
-  h_out = GetStdHandle(STD_OUTPUT_HANDLE);
-  h_err = GetStdHandle(STD_ERROR_HANDLE);
+  handles.out = GetStdHandle(STD_OUTPUT_HANDLE);
+  handles.err = GetStdHandle(STD_ERROR_HANDLE);
 }
 
 void console::reset_user_modes() {
-  SetConsoleMode(h_out, out_mode);
-  SetConsoleMode(h_err, err_mode);
+  SetConsoleMode(handles.out, modes.out);
+  SetConsoleMode(handles.err, modes.err);
 }
 
 bool console::set_evtp_modes() {
@@ -167,17 +167,17 @@ bool console::set_evtp_modes() {
   }
   BOOL stat_out_mode = 0;
   BOOL stat_err_mode = 0;
-  if (has_evtp_mode(out_mode)) {
+  if (has_evtp_mode(modes.out)) {
     stat_out_mode = 1;
   } else {
-    DWORD new_mode = out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    stat_out_mode = SetConsoleMode(h_out, new_mode);
+    DWORD new_mode = modes.out | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    stat_out_mode = SetConsoleMode(handles.out, new_mode);
   }
-  if (has_evtp_mode(err_mode)) {
+  if (has_evtp_mode(modes.err)) {
     stat_err_mode = 1;
   } else {
-    DWORD new_mode = err_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    stat_err_mode = SetConsoleMode(h_err, new_mode);
+    DWORD new_mode = modes.err | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    stat_err_mode = SetConsoleMode(handles.err, new_mode);
   };
   return (stat_out_mode != 0) && (stat_err_mode != 0);
 }
@@ -192,10 +192,8 @@ void console::redirect_o_stream(_iobuf *stream) {
 
 bool console::wv_owns_console{};
 bool console::stat_out_modes{};
-DWORD console::out_mode = 0;
-DWORD console::err_mode = 0;
-HANDLE console::h_out;
-HANDLE console::h_err;
+modes_t console::modes{0, 0};
+handles_t console::handles{};
 
 #endif // !defined(_WIN32) #else
 #endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -52,7 +52,7 @@ std::string console::set_colour(int color, std::string message) {
   if (!is_console_mode_set) {
     return message;
   };
-  message = "\x1B[" + std::to_string(color) + "m" + message + "\033[0m";
+  message = "\033[" + std::to_string(color) + "m" + message + "\033[0m";
   return message;
 }
 

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -38,7 +38,9 @@ colours_t console::colours{33, 31};
 #include <handleapi.h>
 #include <io.h>
 #include <windows.h>
-
+#ifdef _MSC_VER
+#pragma comment(lib, "ole32.lib")
+#endif
 void console::init_console() {
   std::cout.flush();
   std::cerr.flush();

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -63,7 +63,9 @@ colours_t console::colours{33, 31};
 #define WIN32_LEAN_AND_MEAN
 #endif
 #ifdef _MSC_VER
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601
+#endif
 #endif
 
 #include <io.h>

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -31,6 +31,20 @@
 #include "webview/utility/console.hh"
 #include <iostream>
 
+// We repeat this from console.hh because MSVC is still complaining/erroring
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif // WIN32_LEAN_AND_MEAN
+#ifdef _MSC_VER
+#define _WIN32_WINNT 0x0601
+#endif // _MSC_VER
+
+#include <io.h>
+#include <windows.h>
+
+#endif // defined(_WIN32)
+
 using namespace webview::utility;
 
 std::mutex console::mutex;
@@ -63,6 +77,8 @@ void console::info(std::string message) {
 };
 
 std::string console::set_colour(int color, std::string message) {
+  // Windows failed to register ASCI escape console mode, so don't
+  // try to format the message string.
   if (!mode_set_success) {
     return message;
   };

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -192,8 +192,8 @@ void console::redirect_o_stream(_iobuf *stream) {
 
 bool console::wv_owns_console{};
 bool console::stat_out_modes{};
-modes_t console::modes{0, 0};
-handles_t console::handles{};
+console_modes_t console::modes{0, 0};
+console_handles_t console::handles{};
 
 #endif // !defined(_WIN32) #else
 #endif // defined(__cplusplus) && !defined(WEBVIEW_HEADER)

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -56,7 +56,7 @@ std::string console::set_colour(int color, std::string message) {
   return message;
 }
 
-colours_t console::colours{33, 31};
+colours_t console::colours{93, 91, 90};
 
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -113,7 +113,7 @@ void console::init_console() {
   is_console_mode_set = stat_out && stat_err;
 
   info("Webview has attached the Windows console.\nIf you wish to mangage the "
-       "console, call `AttachConsole` before `webview_create`");
+       "console, call `AttachConsole` before `webview_create` in your code.");
   wv_has_console = true;
 };
 

--- a/core/src/utility/console.cc
+++ b/core/src/utility/console.cc
@@ -32,6 +32,14 @@
 
 using namespace webview::utility;
 
+void console::info(std::string message) {
+  init_console();
+  std::string prefix = "[WEBVIEW][INFO]: ";
+  message = set_colour(colours.dim, prefix + message);
+  printf("%s\n", message.c_str());
+  free_console();
+};
+
 void console::warn(std::string message) {
   init_console();
   std::string prefix = "[WEBVIEW][WARNING]: ";


### PR DESCRIPTION
This PR adds the utility to print to console a formatted:
- yellow warning message (stdout)
- red error message (stderr)
- dimmed info message (stdout)

It is part of a series of PR's focussed on improving the Webview user experience.

**A user is defined as:**
- Somebody consuming Webview directly in their C/C++ project
- Somebody developing a Webview binding for a specific language
- Somebody consuming Webview through a specific language binding

**The PR series is:**
- #1278 
- #1283
  (**depends:** #1278)
- Guarantee thread safety from the public API (In progress)
  (**depends:** #1278)

Developed on the pattern in #1273