### PR TITLE
Use void return type internally in objc::release()

### DIFF
--- a/core/include/webview/detail/platform/darwin/objc/memory.hh
+++ b/core/include/webview/detail/platform/darwin/objc/memory.hh
@@ -53,7 +53,7 @@ inline id retain(id object) {
 
 inline void release(id object) {
   using namespace literals;
-  msg_send<id>(object, "release"_sel);
+  msg_send<void>(object, "release"_sel);
 }
 
 } // namespace objc


### PR DESCRIPTION
Corrects the return type used with `msg_send()` in `objc::release()`. This correction has no impact on behavior.