### PR TITLE
Remove set_owns_window()

### DIFF
--- a/core/include/webview/detail/backends/cocoa_webkit.hh
+++ b/core/include/webview/detail/backends/cocoa_webkit.hh
@@ -89,7 +89,7 @@ using namespace webkit;
 class cocoa_wkwebview_engine : public engine_base {
 public:
   cocoa_wkwebview_engine(bool debug, void *window)
-      : m_app{NSApplication_get_sharedApplication()} {
+      : engine_base{!window}, m_app{NSApplication_get_sharedApplication()} {
     window_init(window);
     window_settings(debug);
     dispatch_size_default();
@@ -548,7 +548,6 @@ private:
   void window_init(void *window) {
     objc::autoreleasepool arp;
 
-    set_owns_window(!window);
     m_window = static_cast<id>(window);
     if (!owns_window()) {
       return;

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -99,7 +99,7 @@ private:
 
 class gtk_webkit_engine : public engine_base {
 public:
-  gtk_webkit_engine(bool debug, void *window) {
+  gtk_webkit_engine(bool debug, void *window) : engine_base{!window} {
     window_init(window);
     window_settings(debug);
     dispatch_size_default();
@@ -272,7 +272,6 @@ private:
 #endif
 
   void window_init(void *window) {
-    set_owns_window(!window);
     m_window = static_cast<GtkWidget *>(window);
     if (owns_window()) {
       if (!gtk_compat::init_check()) {

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -311,7 +311,7 @@ private:
 
 class win32_edge_engine : public engine_base {
 public:
-  win32_edge_engine(bool debug, void *window) {
+  win32_edge_engine(bool debug, void *window) : engine_base{!window} {
     window_init(window);
     window_settings(debug);
     dispatch_size_default();
@@ -508,7 +508,6 @@ protected:
 
 private:
   void window_init(void *window) {
-    set_owns_window(!window);
     if (!is_webview2_available()) {
       throw exception{WEBVIEW_ERROR_MISSING_DEPENDENCY,
                       "WebView2 is unavailable"};

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -45,6 +45,8 @@ namespace detail {
 
 class engine_base {
 public:
+  engine_base(bool owns_window) : m_owns_window{owns_window} {}
+
   virtual ~engine_base() = default;
 
   noresult navigate(const std::string &url) {
@@ -343,8 +345,6 @@ protected:
   }
 
   void set_default_size_guard(bool guarded) { m_is_size_set = guarded; }
-
-  void set_owns_window(bool owns_window) { m_owns_window = owns_window; }
 
   bool owns_window() const { return m_owns_window; }
 


### PR DESCRIPTION
Passing a flag in the constructor of `engine_base` is less error-prone.