### PR TITLE
Fix `webview_set_html` event ordering for win32_edge

### DIFF
--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -483,12 +483,6 @@ protected:
         set_default_size_guard(false);
         dispatch_size_default();
       }
-      // We navigate to the user string after the event queue is drained so that the
-      // user's init function is not prematurely made redundant.
-      if (user_html != "") {
-        m_webview->NavigateToString(widen_string(user_html).c_str());
-        user_html = "";
-      }
     }
     // TODO: There's a non-zero chance that we didn't get the script ID.
     //       We need to convey the error somehow.
@@ -712,6 +706,12 @@ private:
                     nullptr, hInstance, this);
     if (!m_message_window) {
       throw exception{WEBVIEW_ERROR_INVALID_STATE, "Message window is null"};
+    }
+    // We navigate to the user string after the window is initialised so that the
+    // user's init function is not prematurely made redundant.
+    if (user_html != "") {
+      m_webview->NavigateToString(widen_string(user_html).c_str());
+      user_html = "";
     }
   }
 

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -456,7 +456,8 @@ protected:
   }
 
   noresult set_html_impl(const std::string &html) override {
-    user_html = html;
+    dispatch(
+        [=]() { m_webview->NavigateToString(widen_string(html).c_str()); });
     return {};
   }
 
@@ -707,12 +708,6 @@ private:
     if (!m_message_window) {
       throw exception{WEBVIEW_ERROR_INVALID_STATE, "Message window is null"};
     }
-    // We navigate to the user string after the window is initialised so that the
-    // user's init function is not prematurely made redundant.
-    if (user_html != "") {
-      m_webview->NavigateToString(widen_string(user_html).c_str());
-      user_html = "";
-    }
   }
 
   void window_settings(bool debug) {
@@ -902,7 +897,6 @@ private:
   mswebview2::loader m_webview2_loader;
   int m_dpi{};
   bool m_is_window_shown{};
-  std::string user_html = "";
 };
 
 } // namespace detail

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -456,7 +456,7 @@ protected:
   }
 
   noresult set_html_impl(const std::string &html) override {
-    m_webview->NavigateToString(widen_string(html).c_str());
+    user_html = html;
     return {};
   }
 
@@ -482,6 +482,12 @@ protected:
       if (!m_is_window_shown) {
         set_default_size_guard(false);
         dispatch_size_default();
+      }
+      // We navigate to the user string after the event queue is drained so that the
+      // user's init function is not prematurely made redundant.
+      if (user_html != "") {
+        m_webview->NavigateToString(widen_string(user_html).c_str());
+        user_html = "";
       }
     }
     // TODO: There's a non-zero chance that we didn't get the script ID.
@@ -896,6 +902,7 @@ private:
   mswebview2::loader m_webview2_loader;
   int m_dpi{};
   bool m_is_window_shown{};
+  std::string user_html = "";
 };
 
 } // namespace detail


### PR DESCRIPTION
This PR fixes an issue on win32 where `webview_init` silently fails if called after `webview_set_html`.

The `NavigateToString` method causes the HTML document to be parsed, thus invalidating future calls to the `AddScriptToExecuteOnDocumentCreated` method. By dispatching `NavigateToString`, we ensure that it is put at the end of the pre-blocking event-loop queue.

This normalises `webview_init` behaviour across OS platforms.