### PR TITLE
Improve unbind behaviour to be more as expected

### DIFF
--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -163,7 +163,7 @@ window.__webview__.onUnbind(" +
       flag.second.store(true);
     }
     unbind_cv.notify_all();
-    resolve_is_complete.clear();
+
     return terminate_impl();
   }
   noresult dispatch(std::function<void()> f) { return dispatch_impl(f); }
@@ -438,7 +438,7 @@ private:
     std::mutex mtx;
     std::unique_lock<std::mutex> lock(mtx);
 
-    std::list<std::string> bind_list;
+    std::list<std::string> bind_list{};
     for (auto &atomic_flag : resolve_is_complete) {
       const std::string &name = atomic_flag.first;
       if (js.find(name + "(") != std::string::npos) {

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -183,8 +183,7 @@ window.__webview__.onUnbind(" +
     std::unique_lock<std::mutex> lock(mtx);
     auto included_binds = eval_includes_binds(js);
     for (auto &name : included_binds) {
-      auto found = resolve_is_complete.find(name);
-      found->second.store(false);
+      resolve_is_complete.find(name)->second.store(false);
     }
 
     return eval_impl(js);

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -116,6 +116,13 @@ window.__webview__.onBind(" +
     if (found == bindings.end()) {
       return error_info{WEBVIEW_ERROR_NOT_FOUND};
     }
+
+    // Notify that a binding was created if the init script has already
+    // set things up.
+    eval("if (window.__webview__) {\n\
+window.__webview__.onUnbind(" +
+         json_escape(name) + ")\n\
+}");
     unbind_cv.wait_for(lock, std::chrono::milliseconds(20),
                        atomic_acquire(&resolve_is_complete.at(name)));
     if (is_terminating) {
@@ -124,12 +131,6 @@ window.__webview__.onBind(" +
     resolve_is_complete.at(name).store(true);
     bindings.erase(found);
     replace_bind_script();
-    // Notify that a binding was created if the init script has already
-    // set things up.
-    eval("if (window.__webview__) {\n\
-window.__webview__.onUnbind(" +
-         json_escape(name) + ")\n\
-}");
     return {};
   }
 


### PR DESCRIPTION
**The issue:**
When calling `webview_unbind`, the c++ reference to the callback function is immediately destroyed. Any preceding calls to the bound function within the same tick will thus never reach the callback function (or `webview_return` aka `resolve`), which is unexpected. eg.
```c++
webview_bind(w, "jsFn", c_bound_fn, arg);
webview_eval(w, "jsFn().then(val => {...});");
webview_unbind(w, "jsFn");
```
The expectation here is that the evaluated function would be allowed to complete within a sane timespan, ie. the user thinks that they are done with `jsFn`, and now they can safely unbind it.

Alternatively, if `jsFn` is called from the browser directly, the potential exists that `webview_unbind` gets called between the time of `jsFn()` and the promise resolving via `webview_return`. This could cause JS to wait indefinitely for a promise that never resolves.

**The resolution:**
We assume a sane timespan of 20millseconds `ts` for a bound function to return to Webview after being called.
- We atomically flag each instance of a bound function usage.
- We immediately destroy the JS binding at `webview_unbind`
- We wait the thread for `ts` or the atomic completion flag (whichever is sooner) before destroying the c++ bind reference.

**Post-word:**
This PR provides much improved behaviour, but it does not eliminate the risk of callback functions that run longer than `ts` causing a JS promise to hang indefinitely.

To eliminate that risk, we will need to call `resolve("callbackId", 1, nullptr)` from within `unbind` so that the JS promise will be forced to error (which provides the user a catch handle). We however have no handle to "callbackId" within `unbind`, so that issue is scoped for another PR.