### PR TITLE
navigation listener

### DIFF
--- a/core/include/webview/api.h
+++ b/core/include/webview/api.h
@@ -245,6 +245,31 @@ WEBVIEW_API webview_error_t webview_return(webview_t w, const char *id,
  */
 WEBVIEW_API const webview_version_info_t *webview_version(void);
 
+/**
+ * Add a navigation callback function.
+ *
+ * @param w The webview instance.
+ * @param fn The callback function to call on events
+ * @param arg A user defined data pointer passed to the callback
+ * 
+ * @since 0.1.x
+ */
+WEBVIEW_API webview_error_t webview_add_navigation_listener(webview_t w,
+                                                            navigation_fn_t fn,
+                                                            void *arg);
+
+/**
+ * Remove a navigation callback function.
+ *
+ * @param w The webview instance.
+ * @param fn The callback function to call on events
+ * @param arg A user defined data pointer passed to the callback
+ * 
+ * @since 0.1.x
+ */
+WEBVIEW_API webview_error_t
+webview_remove_navigation_listener(webview_t w, navigation_fn_t fn, void *arg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/include/webview/c_api_impl.hh
+++ b/core/include/webview/c_api_impl.hh
@@ -190,6 +190,27 @@ WEBVIEW_API webview_error_t webview_navigate(webview_t w, const char *url) {
   return api_filter([=] { return cast_to_webview(w)->navigate(url); });
 }
 
+WEBVIEW_API webview_error_t webview_add_navigation_listener(webview_t w,
+                                                            navigation_fn_t fn,
+                                                            void *arg) {
+  using namespace webview::detail;
+  if (!fn) {
+    return WEBVIEW_ERROR_INVALID_ARGUMENT;
+  }
+  return api_filter(
+      [=] { return cast_to_webview(w)->add_navigation_listener(fn, arg); });
+}
+
+WEBVIEW_API webview_error_t
+webview_remove_navigation_listener(webview_t w, navigation_fn_t fn, void *arg) {
+  using namespace webview::detail;
+  if (!fn) {
+    return WEBVIEW_ERROR_INVALID_ARGUMENT;
+  }
+  return api_filter(
+      [=] { return cast_to_webview(w)->remove_navigation_listener(fn, arg); });
+}
+
 WEBVIEW_API webview_error_t webview_set_html(webview_t w, const char *html) {
   using namespace webview::detail;
   if (!html) {

--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -117,6 +117,7 @@ public:
         g_signal_handlers_disconnect_by_data(GTK_WINDOW(m_window), this);
         gtk_window_close(GTK_WINDOW(m_window));
         on_window_destroyed(true);
+        m_webview = nullptr; // Destroyed with window
       } else {
         gtk_compat::window_remove_child(GTK_WINDOW(m_window),
                                         GTK_WIDGET(m_webview));
@@ -297,6 +298,7 @@ private:
       auto on_window_destroy = +[](GtkWidget *, gpointer arg) {
         auto *w = static_cast<gtk_webkit_engine *>(arg);
         w->m_window = nullptr;
+        w->m_webview = nullptr; // destroyed with window
         w->on_window_destroyed();
       };
       g_signal_connect(G_OBJECT(m_window), "destroy",

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -72,9 +72,10 @@ public:
       return true;
     }
 
-    void call(std::string uri, webview_navigation_event_t type) const {
+    void call(engine_base *webview, std::string uri,
+              webview_navigation_event_t type) const {
       if (m_callback) {
-        m_callback(uri.c_str(), type, m_arg);
+        m_callback(webview, uri.c_str(), type, m_arg);
       }
     }
 
@@ -397,7 +398,7 @@ protected:
   void notify_navigation_listeners(const std::string &uri,
                                    webview_navigation_event_t type) {
     for (auto &ctx : m_navigation_listeners) {
-      ctx.call(uri, type);
+      ctx.call(this, uri, type);
     }
   }
 

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -56,6 +56,52 @@ public:
     return navigate_impl(url);
   }
 
+  class navigation_ctx_t {
+  public:
+    navigation_ctx_t(navigation_fn_t callback, void *arg)
+        : m_callback(callback), m_arg(arg) {}
+
+    navigation_ctx_t(const navigation_ctx_t &other) = default;
+    navigation_ctx_t(navigation_ctx_t &&other) = default;
+
+    bool operator==(const navigation_ctx_t &other) const {
+      if (m_arg != other.m_arg)
+        return false;
+      if (m_callback != other.m_callback)
+        return false;
+      return true;
+    }
+
+    void call(std::string uri, webview_navigation_event_t type) const {
+      if (m_callback) {
+        m_callback(uri.c_str(), type, m_arg);
+      }
+    }
+
+  private:
+    // This function is called upon execution of the bound JS function
+    navigation_fn_t m_callback;
+    // This user-supplied argument is passed to the callback
+    void *m_arg;
+  };
+
+  noresult add_navigation_listener(navigation_fn_t fn, void *arg) {
+    navigation_ctx_t ctx(fn, arg);
+    for (const auto &var : m_navigation_listeners) {
+      if (var == ctx) {
+        return {};
+      }
+    }
+    m_navigation_listeners.emplace_back(std::move(ctx));
+    return {};
+  }
+
+  noresult remove_navigation_listener(navigation_fn_t fn, void *arg) {
+    navigation_ctx_t ctx(fn, arg);
+    m_navigation_listeners.remove(std::move(ctx));
+    return {};
+  }
+
   using binding_t = std::function<void(std::string, std::string, void *)>;
   class binding_ctx_t {
   public:
@@ -348,6 +394,13 @@ protected:
 
   bool owns_window() const { return m_owns_window; }
 
+  void notify_navigation_listeners(const std::string &uri,
+                                   webview_navigation_event_t type) {
+    for (auto &ctx : m_navigation_listeners) {
+      ctx.call(uri, type);
+    }
+  }
+
 private:
   static std::atomic_uint &window_ref_count() {
     static std::atomic_uint ref_count{0};
@@ -363,6 +416,8 @@ private:
     }
     return 0;
   }
+
+  std::list<navigation_ctx_t> m_navigation_listeners;
 
   std::map<std::string, binding_ctx_t> bindings;
   user_script *m_bind_script{};

--- a/core/include/webview/detail/platform/darwin/cocoa/NSURL.hh
+++ b/core/include/webview/detail/platform/darwin/cocoa/NSURL.hh
@@ -54,6 +54,10 @@ inline id NSURL_URLWithString(const std::string &string) {
   return NSURL_URLWithString(NSString_stringWithUTF8String(string));
 }
 
+inline id NSURL_URLAsString(id url) {
+  return objc::msg_send<id>(url, objc::selector("absoluteString"));
+}
+
 } // namespace cocoa
 } // namespace detail
 } // namespace webview

--- a/core/include/webview/detail/platform/darwin/webkit/WKWebView.hh
+++ b/core/include/webview/detail/platform/darwin/webkit/WKWebView.hh
@@ -64,6 +64,15 @@ inline void WKWebView_set_UIDelegate(id self, id ui_delegate) {
   objc::msg_send<void>(self, objc::selector("setUIDelegate:"), ui_delegate);
 }
 
+inline id WKWebView_get_NavigationDelegate(id self) {
+  return objc::msg_send<id>(self, objc::selector("navigationDelegate"));
+}
+
+inline void WKWebView_set_NavigationDelegate(id self, id nav_delegate) {
+  objc::msg_send<void>(self, objc::selector("setNavigationDelegate:"),
+                       nav_delegate);
+}
+
 inline id WKWebView_loadHTMLString(id self, id string, id base_url) {
   return objc::msg_send<id>(self, objc::selector("loadHTMLString:baseURL:"),
                             string, base_url);

--- a/core/include/webview/types.h
+++ b/core/include/webview/types.h
@@ -78,4 +78,20 @@ typedef enum {
   WEBVIEW_HINT_FIXED
 } webview_hint_t;
 
+/// Navigation events
+typedef enum {
+  /// Navigation to a new URI started, no contents yet.
+  WEBVIEW_LOAD_STARTED,
+  /// Navigation redirected to another URI
+  WEBVIEW_LOAD_REDIRECTED,
+  /// Navigation started loading contents for URI
+  WEBVIEW_LOAD_COMMITTED,
+  /// Navigation finished, URI contents loaded
+  WEBVIEW_LOAD_FINISHED
+} webview_navigation_event_t;
+
+/// Navigation callback function type
+typedef void (*navigation_fn_t)(const char *uri,
+                                webview_navigation_event_t type, void *arg);
+
 #endif // WEBVIEW_TYPES_H

--- a/core/include/webview/types.h
+++ b/core/include/webview/types.h
@@ -91,7 +91,7 @@ typedef enum {
 } webview_navigation_event_t;
 
 /// Navigation callback function type
-typedef void (*navigation_fn_t)(const char *uri,
+typedef void (*navigation_fn_t)(webview_t webview, const char *uri,
                                 webview_navigation_event_t type, void *arg);
 
 #endif // WEBVIEW_TYPES_H


### PR DESCRIPTION
A new take on #942

* Now notify for all navigation events (start, redirect, commit and finish)
* Tested linux, windows and mac so far

Possible TODO:
* Add a second callback for navigation failures?