### PR TITLE
Update set_size() documentation

### DIFF
--- a/core/include/webview/api.h
+++ b/core/include/webview/api.h
@@ -129,8 +129,8 @@ WEBVIEW_API webview_error_t webview_set_title(webview_t w, const char *title);
  * Updates the size of the native window.
  *
  * Remarks:
- * - Subsequent calls to this functions may have differences in behavior across
- *   versions of GTK and windowing systems (X11/Wayland).
+ * - Subsequent calls to this function may behave inconsistently across
+ *   different versions of GTK and windowing systems (X11/Wayland).
  * - Using WEBVIEW_HINT_MAX for setting the maximum window size is not
  *   supported with GTK 4 because X11-specific functions such as
  *   gtk_window_set_geometry_hints were removed. This option has no effect


### PR DESCRIPTION
Removes some details about expected behavior of `webview_set_size()` due to inconsistencies observed when using GTK 4.

The documentation states the following:

> GTK 4 can set a default/initial window size if done early enough;
> otherwise, this function has no effect. GTK 4 (unlike 3) can't resize
> a window after it has been set up.

Observations when calling `webview_set_size()` with `WEBVIEW_HINT_NONE`:

Ubuntu  | GTK     | Window  | Can set new size?
--      | ---     | ------- | -----------------
24.04.2 | 4.14.2  | X11     | If different from what was previously set
24.04.2 | 4.14.2  | Wayland | If user hasn't resized by hand
24.04.2 | 3.24.41 | X11     | Yes
24.04.2 | 3.24.41 | Wayland | Yes
22.04.5 | 4.6.9   | X11     | If different from what was previously set
22.04.5 | 4.6.9   | Wayland | Yes
22.04.5 | 3.24.33 | X11     | Yes
22.04.5 | 3.24.33 | Wayland | Yes

Closes #1320