### PR TITLE
Use GTK compat function with WEBVIEW_HINT_FIXED

### DIFF
--- a/core/include/webview/detail/backends/gtk_webkitgtk.hh
+++ b/core/include/webview/detail/backends/gtk_webkitgtk.hh
@@ -182,9 +182,9 @@ protected:
 
   noresult set_size_impl(int width, int height, webview_hint_t hints) override {
     gtk_window_set_resizable(GTK_WINDOW(m_window), hints != WEBVIEW_HINT_FIXED);
-    if (hints == WEBVIEW_HINT_NONE) {
+    if (hints == WEBVIEW_HINT_NONE || hints == WEBVIEW_HINT_FIXED) {
       gtk_compat::window_set_size(GTK_WINDOW(m_window), width, height);
-    } else if (hints == WEBVIEW_HINT_FIXED || hints == WEBVIEW_HINT_MIN) {
+    } else if (hints == WEBVIEW_HINT_MIN) {
       gtk_widget_set_size_request(m_window, width, height);
     } else if (hints == WEBVIEW_HINT_MAX) {
       gtk_compat::window_set_max_size(GTK_WINDOW(m_window), width, height);


### PR DESCRIPTION
`gtk_widget_set_size_request()` was called when `WEBVIEW_HINT_FIXED` was passed into `webview_set_size()`. That function is meant to set a minimum size.

Instead we can call `gtk_window_set_default_size()` (GTK 4) or `gtk_window_resize()` (GTK 3).