### PR TITLE
Fix Policy CMP0174 warning on Windows

### DIFF
--- a/cmake/webview.cmake
+++ b/cmake/webview.cmake
@@ -84,8 +84,7 @@ function(webview_fetch_mswebview2 VERSION)
     endif()
     set(FC_NAME microsoft_web_webview2)
     FetchContent_Declare(${FC_NAME}
-        URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
-        CONFIGURE_COMMAND "")
+        URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}")
     FetchContent_MakeAvailable(${FC_NAME})
     set(MSWebView2_ROOT "${${FC_NAME}_SOURCE_DIR}")
     set(MSWebView2_ROOT "${MSWebView2_ROOT}" PARENT_SCOPE)


### PR DESCRIPTION
According to CMake documentation, the ``CONFIGURE_COMMAND`` (here set to an empty string) is a no-op:
<img width="790" height="187" alt="image" src="https://github.com/user-attachments/assets/ce91fb12-5922-4368-a3e9-96bf740b29f1" />

Since CMake version 3.31, this causes a warning (example from [my CI](https://github.com/WasabiThumb/jwebview/actions/runs/17625142027/job/50080009204)):
```text
CMake Warning (dev) at C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:1564 (cmake_parse_arguments):
  The CONFIGURE_COMMAND keyword was followed by an empty string or no value
  at all.  Policy CMP0174 is not set, so cmake_parse_arguments() will unset
  the ARG_CONFIGURE_COMMAND variable rather than setting it to an empty
  string.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:2145:EVAL:2 (__FetchContent_doPopulation)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:2145 (cmake_language)
  C:/Program Files/CMake/share/cmake-3.31/Modules/FetchContent.cmake:2384 (__FetchContent_Populate)
  D:/a/jwebview/jwebview/natives/build/cmake/_deps/webview-src/cmake/webview.cmake:95 (FetchContent_MakeAvailable)
  D:/a/jwebview/jwebview/natives/build/cmake/_deps/webview-src/cmake/webview.cmake:76 (webview_fetch_mswebview2)
  D:/a/jwebview/jwebview/natives/build/cmake/_deps/webview-src/cmake/internal.cmake:161 (webview_find_dependencies)
  D:/a/jwebview/jwebview/natives/build/cmake/_deps/webview-src/CMakeLists.txt:12 (webview_init)
```

Simply removing this keyword silences the warning.