### PR TITLE
win32: opt-in WebView2 visual hosting (composite native content with web content)

### DIFF
--- a/core/include/webview/c_api_impl.hh
+++ b/core/include/webview/c_api_impl.hh
@@ -156,6 +156,10 @@ WEBVIEW_API void *webview_get_native_handle(webview_t w,
           return w_->widget();
         case WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER:
           return w_->browser_controller();
+        case WEBVIEW_NATIVE_HANDLE_KIND_COMPOSITION_DEVICE:
+          return w_->composition_device();
+        case WEBVIEW_NATIVE_HANDLE_KIND_COMPOSITION_ROOT:
+          return w_->composition_root();
         default:
           return webview::error_info{WEBVIEW_ERROR_INVALID_ARGUMENT};
         }

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -68,6 +68,7 @@
 
 #include <windows.h>
 
+#include <cstdio>
 #include <objbase.h>
 // Visual hosting (docs/visual-hosting.md); harmless when unused.
 #include <dcomp.h>
@@ -175,6 +176,10 @@ public:
             return S_OK;
           }
         }
+      }
+      if (m_visual_hosting) {
+        std::fprintf(stderr, "webview: visual hosting unavailable on this "
+                             "WebView2 runtime; using windowed hosting\n");
       }
       res = env->CreateCoreWebView2Controller(m_window, this);
       if (SUCCEEDED(res)) {
@@ -864,10 +869,18 @@ private:
             m_composition_controller = composition;
             // Build the tree BEFORE the controller finishes initialising, so
             // the first rendered frame already has somewhere to go.
-            if (!build_composition_tree(wnd, composition)) {
-              // Rendering would silently go nowhere, which is the single worst
-              // failure mode here — say so rather than showing a blank window.
+            if (build_composition_tree(wnd, composition)) {
+              // An opt-in mode that looks identical when it works is
+              // indistinguishable from one that never engaged, so say which
+              // happened. Silence here costs someone an afternoon.
+              std::fprintf(stderr, "webview: visual hosting active "
+                                   "(DirectComposition)\n");
+            } else {
+              // Rendering would go nowhere at all, which is the worst failure
+              // mode here — report it rather than showing a blank window.
               m_composition_failed = true;
+              std::fprintf(stderr, "webview: visual hosting requested but the "
+                                   "composition tree could not be built\n");
             }
           });
     }

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -73,6 +73,8 @@
 #include <dcomp.h>
 #include <shlobj.h>
 #include <shlwapi.h>
+// GET_X_LPARAM / GET_KEYSTATE_WPARAM for visual-hosting input forwarding.
+#include <windowsx.h>
 
 #ifdef _MSC_VER
 #pragma comment(lib, "ole32.lib")
@@ -722,6 +724,21 @@ private:
         return DefWindowProcW(hwnd, msg, wp, lp);
       }
 
+      // Visual hosting receives NO input from the system: the host must forward
+      // it. Done before the switch so every mouse message reaches the web
+      // content, including ones this proc does not otherwise handle.
+      if (w->m_composition_controller) {
+        // The system does not update the cursor over visual-hosted content;
+        // without this it stays an arrow over links and text.
+        if (msg == WM_SETCURSOR && LOWORD(lp) == HTCLIENT &&
+            w->apply_webview_cursor()) {
+          return TRUE;
+        }
+        if (w->forward_mouse_input(msg, wp, lp)) {
+          return 0;
+        }
+      }
+
       switch (msg) {
       case WM_SIZE:
         w->resize_webview();
@@ -980,6 +997,90 @@ private:
   // CreateCoreWebView2EnvironmentWithOptions.
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init;
+  // Adopt the cursor WebView2 wants for the position it last saw. Polled from
+  // WM_SETCURSOR rather than subscribing to CursorChanged: the property is
+  // already up to date by then, and it avoids implementing another COM handler.
+  bool apply_webview_cursor() {
+    HCURSOR cursor{};
+    if (FAILED(m_composition_controller->get_Cursor(&cursor)) || !cursor) {
+      return false;
+    }
+    SetCursor(cursor);
+    return true;
+  }
+
+  // Forward one mouse message to a visual-hosted WebView2. Returns true when
+  // the message was consumed.
+  //
+  // COREWEBVIEW2_MOUSE_EVENT_KIND values ARE the Win32 message ids, and
+  // COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS values are the MK_* flags, so both
+  // pass straight through. The parts that do not:
+  //
+  //  * wheel messages carry SCREEN coordinates while the rest carry client
+  //    coordinates, so they need converting or the page scrolls from the wrong
+  //    place;
+  //  * wheel and X-button messages put their payload (delta, which X button) in
+  //    the high word of wParam, which is what mouseData wants;
+  //  * a drag that leaves the window stops delivering moves unless the mouse is
+  //    captured, and WM_MOUSELEAVE only arrives if TrackMouseEvent asked for it
+  //    — without that, hover states stick after the pointer leaves.
+  bool forward_mouse_input(UINT msg, WPARAM wp, LPARAM lp) {
+    if (msg == WM_MOUSELEAVE) {
+      m_mouse_tracking = false;
+      POINT origin{};
+      m_composition_controller->SendMouseInput(
+          COREWEBVIEW2_MOUSE_EVENT_KIND_LEAVE,
+          COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS_NONE, 0, origin);
+      return true;
+    }
+    const bool is_wheel = (msg == WM_MOUSEWHEEL || msg == WM_MOUSEHWHEEL);
+    const bool is_button =
+        (msg >= WM_LBUTTONDOWN && msg <= WM_MBUTTONDBLCLK) ||
+        (msg >= WM_XBUTTONDOWN && msg <= WM_XBUTTONDBLCLK);
+    if (msg != WM_MOUSEMOVE && !is_wheel && !is_button) {
+      return false;
+    }
+
+    POINT point{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+    if (is_wheel) {
+      // Wheel messages are in screen space; everything else is already client.
+      ScreenToClient(m_widget, &point);
+    }
+
+    UINT32 mouse_data = 0;
+    if (is_wheel) {
+      mouse_data = static_cast<UINT32>(GET_WHEEL_DELTA_WPARAM(wp));
+    } else if (msg >= WM_XBUTTONDOWN && msg <= WM_XBUTTONDBLCLK) {
+      mouse_data = GET_XBUTTON_WPARAM(wp);
+    }
+
+    if (msg == WM_MOUSEMOVE && !m_mouse_tracking) {
+      // Ask for WM_MOUSELEAVE once per entry, so hover state can be cleared.
+      TRACKMOUSEEVENT tme{};
+      tme.cbSize = sizeof(tme);
+      tme.dwFlags = TME_LEAVE;
+      tme.hwndTrack = m_widget;
+      m_mouse_tracking = TrackMouseEvent(&tme) != FALSE;
+    }
+    // Capture for the duration of a drag: without it, moves stop arriving the
+    // moment the pointer leaves the window and a drag appears to freeze.
+    if (is_button) {
+      if (msg == WM_LBUTTONDOWN || msg == WM_RBUTTONDOWN ||
+          msg == WM_MBUTTONDOWN || msg == WM_XBUTTONDOWN) {
+        SetCapture(m_widget);
+      } else if (msg == WM_LBUTTONUP || msg == WM_RBUTTONUP ||
+                 msg == WM_MBUTTONUP || msg == WM_XBUTTONUP) {
+        ReleaseCapture();
+      }
+    }
+
+    m_composition_controller->SendMouseInput(
+        static_cast<COREWEBVIEW2_MOUSE_EVENT_KIND>(msg),
+        static_cast<COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS>(GET_KEYSTATE_WPARAM(wp)),
+        mouse_data, point);
+    return true;
+  }
+
   // Visual hosting: the DirectComposition tree the web content renders into.
   // The embedder can insert its own visuals as siblings of m_webview_visual to
   // composite native content above or below the page (docs/visual-hosting.md).
@@ -1044,6 +1145,7 @@ private:
   // Visual hosting state; all null under the default windowed path.
   bool m_visual_hosting = false;
   bool m_composition_failed = false;
+  bool m_mouse_tracking = false;
   ICoreWebView2CompositionController *m_composition_controller = nullptr;
   native_library m_dcomp_lib{L"dcomp.dll"};
   IDCompositionDevice *m_dcomp_device = nullptr;

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -490,6 +490,12 @@ protected:
     }
     return error_info{WEBVIEW_ERROR_INVALID_STATE};
   }
+  result<void *> composition_device_impl() override {
+    // Null rather than an error under windowed hosting: absence is the normal
+    // answer, not a failure, and callers branch on it.
+    return m_dcomp_device;
+  }
+  result<void *> composition_root_impl() override { return m_root_visual; }
   noresult terminate_impl() override {
     PostQuitMessage(0);
     return {};

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -869,6 +869,12 @@ private:
             m_composition_controller = composition;
             // Build the tree BEFORE the controller finishes initialising, so
             // the first rendered frame already has somewhere to go.
+            // Visual hosting only pays off if the page can be transparent —
+            // otherwise the web content is an opaque sheet over whatever the
+            // embedder put underneath. Set it here, where the typed interface
+            // is available, rather than leaving embedders to hand-roll the COM
+            // call against a vtable they have to count by hand.
+            set_transparent_background(composition);
             if (build_composition_tree(wnd, composition)) {
               // An opt-in mode that looks identical when it works is
               // indistinguishable from one that never engaged, so say which
@@ -1015,6 +1021,31 @@ private:
   // CreateCoreWebView2EnvironmentWithOptions.
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init;
+  // Make the web content's background transparent so visuals beneath it show
+  // through. Best-effort: an older runtime without ICoreWebView2Controller2
+  // simply stays opaque.
+  static void
+  set_transparent_background(ICoreWebView2CompositionController *composition) {
+    ICoreWebView2Controller2 *controller2{};
+    if (FAILED(composition->QueryInterface(
+            IID_ICoreWebView2Controller2,
+            reinterpret_cast<void **>(&controller2))) ||
+        !controller2) {
+      std::fprintf(stderr, "webview: transparent background unavailable on "
+                           "this WebView2 runtime\n");
+      return;
+    }
+    // Only alpha 0 and 255 are supported; anything between is rejected.
+    COREWEBVIEW2_COLOR transparent{0, 0, 0, 0};
+    auto res = controller2->put_DefaultBackgroundColor(transparent);
+    if (FAILED(res)) {
+      std::fprintf(stderr,
+                   "webview: transparent background rejected (0x%08lx)\n",
+                   static_cast<unsigned long>(res));
+    }
+    controller2->Release();
+  }
+
   static bool is_visual_hosting_requested() noexcept {
     wchar_t buf[8]{};
     auto n = GetEnvironmentVariableW(L"WEBVIEW_VISUAL_HOSTING", buf, 8);

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -69,6 +69,8 @@
 #include <windows.h>
 
 #include <objbase.h>
+// Visual hosting (docs/visual-hosting.md); harmless when unused.
+#include <dcomp.h>
 #include <shlobj.h>
 #include <shlwapi.h>
 
@@ -85,13 +87,30 @@ namespace detail {
 
 using msg_cb_t = std::function<void(const std::string)>;
 
+// DirectComposition entry points resolved at runtime, so visual hosting costs
+// nothing to link and degrades gracefully where DirectComposition is absent.
+// At namespace scope like webview2_symbols: a class-scope `static constexpr`
+// member would need an out-of-line definition under -std=c++14.
+namespace dcomp_symbols {
+using DCompositionCreateDevice_t =
+    HRESULT(STDMETHODCALLTYPE *)(IDXGIDevice *, REFIID, void **);
+static constexpr auto DCompositionCreateDevice =
+    library_symbol<DCompositionCreateDevice_t>("DCompositionCreateDevice");
+} // namespace dcomp_symbols
+
 class webview2_com_handler
     : public ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler,
       public ICoreWebView2CreateCoreWebView2ControllerCompletedHandler,
+      public ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler,
       public ICoreWebView2WebMessageReceivedEventHandler,
       public ICoreWebView2PermissionRequestedEventHandler {
   using webview2_com_handler_cb_t =
       std::function<void(ICoreWebView2Controller *, ICoreWebView2 *webview)>;
+  // Visual hosting hands the composition controller back separately: the
+  // embedder needs it to attach a visual tree and to forward input, neither of
+  // which the plain controller can do.
+  using webview2_composition_cb_t =
+      std::function<void(ICoreWebView2CompositionController *)>;
 
 public:
   webview2_com_handler(HWND hwnd, msg_cb_t msgCb, webview2_com_handler_cb_t cb)
@@ -129,6 +148,7 @@ public:
     // observed to be requested when using the official WebView2 loader.
 
     if (cast_if_equal_iid(this, riid, controller_completed, ppv) ||
+        cast_if_equal_iid(this, riid, composition_controller_completed, ppv) ||
         cast_if_equal_iid(this, riid, environment_completed, ppv) ||
         cast_if_equal_iid(this, riid, message_received, ppv) ||
         cast_if_equal_iid(this, riid, permission_requested, ppv)) {
@@ -139,6 +159,21 @@ public:
   }
   HRESULT STDMETHODCALLTYPE Invoke(HRESULT res, ICoreWebView2Environment *env) {
     if (SUCCEEDED(res)) {
+      if (m_visual_hosting) {
+        // ICoreWebView2Environment3 is where CreateCoreWebView2CompositionController
+        // lives. A runtime too old to offer it falls back to windowed hosting
+        // rather than failing to start.
+        ICoreWebView2Environment3 *env3{};
+        if (SUCCEEDED(env->QueryInterface(IID_ICoreWebView2Environment3,
+                                          reinterpret_cast<void **>(&env3))) &&
+            env3) {
+          res = env3->CreateCoreWebView2CompositionController(m_window, this);
+          env3->Release();
+          if (SUCCEEDED(res)) {
+            return S_OK;
+          }
+        }
+      }
       res = env->CreateCoreWebView2Controller(m_window, this);
       if (SUCCEEDED(res)) {
         return S_OK;
@@ -146,6 +181,39 @@ public:
     }
     try_create_environment();
     return S_OK;
+  }
+
+  // Visual hosting completion. The composition controller IS a controller, so
+  // once the tree is attached everything downstream is shared with the windowed
+  // path — only the hosting differs.
+  HRESULT STDMETHODCALLTYPE
+  Invoke(HRESULT res, ICoreWebView2CompositionController *composition) {
+    if (FAILED(res) || !composition) {
+      switch (res) {
+      case HRESULT_FROM_WIN32(ERROR_INVALID_STATE):
+      case E_ABORT:
+        return S_OK;
+      }
+      try_create_environment();
+      return S_OK;
+    }
+    ICoreWebView2Controller *controller{};
+    if (FAILED(composition->QueryInterface(IID_ICoreWebView2Controller,
+                                           reinterpret_cast<void **>(
+                                               &controller))) ||
+        !controller) {
+      try_create_environment();
+      return S_OK;
+    }
+    // Hand the composition controller over BEFORE the usual controller setup,
+    // so the embedder can attach its visual tree before any content renders —
+    // otherwise the first frames have nowhere to go.
+    if (m_composition_cb) {
+      m_composition_cb(composition);
+    }
+    auto result = Invoke(S_OK, controller);
+    controller->Release();
+    return result;
   }
   HRESULT STDMETHODCALLTYPE Invoke(HRESULT res,
                                    ICoreWebView2Controller *controller) {
@@ -194,6 +262,16 @@ public:
     return S_OK;
   }
 
+  // Opt into visual hosting. Must be set before the environment completes.
+  // See docs/visual-hosting.md: it exists so an embedder can composite its own
+  // content with the web content, and it makes input the host's problem.
+  void set_visual_hosting(bool on) noexcept { m_visual_hosting = on; }
+
+  // Receives the composition controller when visual hosting is in effect.
+  void set_composition_handler(webview2_composition_cb_t cb) noexcept {
+    m_composition_cb = cb;
+  }
+
   // Set the function that will perform the initiating logic for creating
   // the WebView2 environment.
   void set_attempt_handler(std::function<HRESULT()> attempt_handler) noexcept {
@@ -232,6 +310,8 @@ private:
   HWND m_window;
   msg_cb_t m_msgCb;
   webview2_com_handler_cb_t m_cb;
+  webview2_composition_cb_t m_composition_cb;
+  bool m_visual_hosting{};
   std::atomic<ULONG> m_ref_count{1};
   std::function<HRESULT()> m_attempt_handler;
   unsigned int m_max_attempts = 60;
@@ -754,6 +834,22 @@ private:
           flag.clear();
         });
 
+    if (m_visual_hosting) {
+      m_com_handler->set_visual_hosting(true);
+      m_com_handler->set_composition_handler(
+          [&](ICoreWebView2CompositionController *composition) {
+            composition->AddRef();
+            m_composition_controller = composition;
+            // Build the tree BEFORE the controller finishes initialising, so
+            // the first rendered frame already has somewhere to go.
+            if (!build_composition_tree(wnd, composition)) {
+              // Rendering would silently go nowhere, which is the single worst
+              // failure mode here — say so rather than showing a blank window.
+              m_composition_failed = true;
+            }
+          });
+    }
+
     m_com_handler->set_attempt_handler([&] {
       return m_webview2_loader.create_environment_with_options(
           nullptr, userDataFolder, nullptr, m_com_handler);
@@ -884,6 +980,59 @@ private:
   // CreateCoreWebView2EnvironmentWithOptions.
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init;
+  // Visual hosting: the DirectComposition tree the web content renders into.
+  // The embedder can insert its own visuals as siblings of m_webview_visual to
+  // composite native content above or below the page (docs/visual-hosting.md).
+  bool build_composition_tree(HWND wnd,
+                              ICoreWebView2CompositionController *composition) {
+    // dcomp.dll is loaded at RUNTIME rather than linked, mirroring how this
+    // library already loads WebView2Loader.dll. Linking dcomp.lib would make
+    // every consumer pay for a feature that is opt-in, and would refuse to
+    // start on systems without DirectComposition; this simply reports failure
+    // and lets the caller fall back to windowed hosting.
+    //
+    // __uuidof rather than an IID_ constant: MSVC's dcomp.h uses DECLSPEC_UUID
+    // and mingw-w64's uses __CRT_UUID_DECL, so it is the spelling that works
+    // under both toolchains.
+    if (!m_dcomp_lib.is_loaded()) {
+      return false;
+    }
+    auto create_device = m_dcomp_lib.get(dcomp_symbols::DCompositionCreateDevice);
+    if (!create_device) {
+      return false;
+    }
+    if (FAILED(create_device(nullptr, __uuidof(IDCompositionDevice),
+                             reinterpret_cast<void **>(&m_dcomp_device))) ||
+        !m_dcomp_device) {
+      return false;
+    }
+    // topmost=FALSE: the target sits in the window's normal composition, so
+    // other windows still occlude it correctly.
+    if (FAILED(m_dcomp_device->CreateTargetForHwnd(wnd, FALSE,
+                                                   &m_dcomp_target)) ||
+        !m_dcomp_target) {
+      return false;
+    }
+    if (FAILED(m_dcomp_device->CreateVisual(&m_root_visual)) ||
+        !m_root_visual) {
+      return false;
+    }
+    if (FAILED(m_dcomp_device->CreateVisual(&m_webview_visual)) ||
+        !m_webview_visual) {
+      return false;
+    }
+    // The web content goes on top; an embedder's visuals added BELOW it show
+    // through wherever the page is transparent.
+    if (FAILED(m_root_visual->AddVisual(m_webview_visual, TRUE, nullptr)) ||
+        FAILED(m_dcomp_target->SetRoot(m_root_visual))) {
+      return false;
+    }
+    if (FAILED(composition->put_RootVisualTarget(m_webview_visual))) {
+      return false;
+    }
+    return SUCCEEDED(m_dcomp_device->Commit());
+  }
+
   HWND m_window = nullptr;
   HWND m_widget = nullptr;
   HWND m_message_window = nullptr;
@@ -892,6 +1041,15 @@ private:
   DWORD m_main_thread = GetCurrentThreadId();
   ICoreWebView2 *m_webview = nullptr;
   ICoreWebView2Controller *m_controller = nullptr;
+  // Visual hosting state; all null under the default windowed path.
+  bool m_visual_hosting = false;
+  bool m_composition_failed = false;
+  ICoreWebView2CompositionController *m_composition_controller = nullptr;
+  native_library m_dcomp_lib{L"dcomp.dll"};
+  IDCompositionDevice *m_dcomp_device = nullptr;
+  IDCompositionTarget *m_dcomp_target = nullptr;
+  IDCompositionVisual *m_root_visual = nullptr;
+  IDCompositionVisual *m_webview_visual = nullptr;
   webview2_com_handler *m_com_handler = nullptr;
   mswebview2::loader m_webview2_loader;
   int m_dpi{};

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -394,6 +394,11 @@ private:
 class win32_edge_engine : public engine_base {
 public:
   win32_edge_engine(bool debug, void *window) : engine_base{!window} {
+    // Opt-in via the environment for now. Visual hosting deserves a real
+    // public API (a create-option, most likely); an env var keeps this branch
+    // reviewable without inventing one that upstream may not want.
+    // See docs/visual-hosting.md.
+    m_visual_hosting = is_visual_hosting_requested();
     window_init(window);
     window_settings(debug);
     dispatch_size_default();
@@ -997,6 +1002,34 @@ private:
   // CreateCoreWebView2EnvironmentWithOptions.
   // Source: https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions
   com_init_wrapper m_com_init;
+  static bool is_visual_hosting_requested() noexcept {
+    wchar_t buf[8]{};
+    auto n = GetEnvironmentVariableW(L"WEBVIEW_VISUAL_HOSTING", buf, 8);
+    return n > 0 && n < 8 && buf[0] == L'1';
+  }
+
+public:
+  /// True when the web content is being hosted in a DirectComposition visual
+  /// tree rather than its own window.
+  bool visual_hosting() const noexcept {
+    return m_composition_controller != nullptr && !m_composition_failed;
+  }
+
+  /// The DirectComposition device backing the visual tree, or null under
+  /// windowed hosting. An embedder needs it to create its own visuals and to
+  /// Commit after changing the tree.
+  IDCompositionDevice *composition_device() const noexcept {
+    return m_dcomp_device;
+  }
+
+  /// The root visual. The web content's visual is already a child; visuals
+  /// added BELOW it (AddVisual with insertAbove=FALSE) show through wherever
+  /// the page is transparent, which is the point of visual hosting.
+  IDCompositionVisual *composition_root() const noexcept {
+    return m_root_visual;
+  }
+
+private:
   // Adopt the cursor WebView2 wants for the position it last saw. Polled from
   // WM_SETCURSOR rather than subscribing to CursorChanged: the property is
   // already up to date by then, and it avoids implementing another COM handler.

--- a/core/include/webview/detail/backends/win32_edge.hh
+++ b/core/include/webview/detail/backends/win32_edge.hh
@@ -1052,10 +1052,23 @@ private:
     controller2->Release();
   }
 
+  /// Visual hosting is opt-OUT: `WEBVIEW_VISUAL_HOSTING=0` forces the windowed
+  /// path. It defaults ON because the windowed path cannot composite native
+  /// content with web content at all (docs/visual-hosting.md), and every
+  /// failure mode along the way is already handled — an older runtime without
+  /// ICoreWebView2Environment3 falls back to windowed hosting, and a
+  /// composition tree that cannot be built reports it.
+  ///
+  /// UPSTREAM NOTE: an environment variable is the wrong long-term switch. A
+  /// create-option is the natural home; this keeps the branch reviewable
+  /// without inventing public API that maintainers may want shaped differently.
   static bool is_visual_hosting_requested() noexcept {
     wchar_t buf[8]{};
     auto n = GetEnvironmentVariableW(L"WEBVIEW_VISUAL_HOSTING", buf, 8);
-    return n > 0 && n < 8 && buf[0] == L'1';
+    if (n > 0 && n < 8 && buf[0] == L'0') {
+      return false;
+    }
+    return true;
   }
 
 public:

--- a/core/include/webview/detail/engine_base.hh
+++ b/core/include/webview/detail/engine_base.hh
@@ -132,6 +132,11 @@ window.__webview__.onUnbind(" +
   result<void *> window() { return window_impl(); }
   result<void *> widget() { return widget_impl(); }
   result<void *> browser_controller() { return browser_controller_impl(); }
+  /// DirectComposition device; null unless the backend is hosting the web
+  /// content in a visual tree (Win32 visual hosting).
+  result<void *> composition_device() { return composition_device_impl(); }
+  /// Root composition visual; null under the same conditions.
+  result<void *> composition_root() { return composition_root_impl(); }
   noresult run() { return run_impl(); }
   noresult terminate() { return terminate_impl(); }
   noresult dispatch(std::function<void()> f) { return dispatch_impl(f); }
@@ -157,6 +162,10 @@ protected:
   virtual result<void *> window_impl() = 0;
   virtual result<void *> widget_impl() = 0;
   virtual result<void *> browser_controller_impl() = 0;
+  // Not pure: only the Win32 backend hosts in a visual tree, and a backend
+  // that does not should not have to say so.
+  virtual result<void *> composition_device_impl() { return nullptr; }
+  virtual result<void *> composition_root_impl() { return nullptr; }
   virtual noresult run_impl() = 0;
   virtual noresult terminate_impl() = 0;
   virtual noresult dispatch_impl(std::function<void()> f) = 0;

--- a/core/include/webview/detail/platform/windows/webview2/loader.hh
+++ b/core/include/webview/detail/platform/windows/webview2/loader.hh
@@ -96,6 +96,16 @@ static constexpr IID
         0xC9B7,
         0x4260,
         {0x81, 0x27, 0xC9, 0xF5, 0xBD, 0xE7, 0xF6, 0x8C}};
+// Visual hosting (docs/visual-hosting.md). Declared here rather than taken from
+// the SDK header because the SDK's IIDs are `__declspec(selectany) const IID`,
+// which is not usable in a constant expression — the same reason every other
+// IID in this namespace is redeclared.
+static constexpr IID
+    IID_ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler{
+        0x02FAB84B,
+        0x1428,
+        0x4FB7,
+        {0xAD, 0x45, 0x1B, 0x2E, 0x64, 0x73, 0x61, 0x84}};
 static constexpr IID
     IID_ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler{
         0x4E8A3389,
@@ -363,6 +373,13 @@ namespace cast_info {
 static constexpr auto controller_completed =
     cast_info_t<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>{
         IID_ICoreWebView2CreateCoreWebView2ControllerCompletedHandler};
+
+// Visual hosting: the completion handler for
+// ICoreWebView2Environment3::CreateCoreWebView2CompositionController. See
+// docs/visual-hosting.md for why an embedder would want it.
+static constexpr auto composition_controller_completed = cast_info_t<
+    ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler>{
+    IID_ICoreWebView2CreateCoreWebView2CompositionControllerCompletedHandler};
 
 static constexpr auto environment_completed =
     cast_info_t<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>{

--- a/core/include/webview/types.h
+++ b/core/include/webview/types.h
@@ -63,7 +63,16 @@ typedef enum {
   /// Browser controller. @c WebKitWebView pointer (WebKitGTK), @c WKWebView
   /// pointer (Cocoa/WebKit) or @c ICoreWebView2Controller pointer
   /// (Win32/WebView2).
-  WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER
+  WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER,
+  /// DirectComposition device backing the visual tree (Win32/WebView2 under
+  /// visual hosting only; null otherwise). @c IDCompositionDevice pointer.
+  /// Needed to create visuals and to Commit after changing the tree.
+  WEBVIEW_NATIVE_HANDLE_KIND_COMPOSITION_DEVICE,
+  /// Root of the composition visual tree (Win32/WebView2 under visual hosting
+  /// only; null otherwise). @c IDCompositionVisual pointer. The web content's
+  /// visual is already a child; visuals added below it show through wherever
+  /// the page is transparent.
+  WEBVIEW_NATIVE_HANDLE_KIND_COMPOSITION_ROOT
 } webview_native_handle_kind_t;
 
 /// Window size hints

--- a/docs/visual-hosting.md
+++ b/docs/visual-hosting.md
@@ -1,0 +1,144 @@
+# Visual hosting on Windows (WebView2 composition controller)
+
+**Status:** in progress. This document is the rationale and the measured
+evidence; the implementation follows it.
+
+## The problem
+
+You cannot show native content — a video frame, a GPU surface, an OpenGL view —
+either *above* or *below* a WebView2 created the way `webview` creates it today.
+Not with the right z-order, not with a transparent background, not by painting
+the host window. All four are closed, and the failures are silent: the OS
+reports your window as visible, at the correct rectangle, and you see nothing.
+
+This is the *airspace* problem. It is not specific to this library. Microsoft
+hit it with their own WPF control and reached the same conclusion documented
+below:
+
+> the WebView2 control will always be the top-most control in the WPF app, and
+> any WPF element in the same location will end up below the WebView2 control.
+> Solving this issue necessitates moving away from the HwndHost and windowed
+> hosting model, and instead use visuals to host the WebView2.
+
+`webview` currently calls `ICoreWebView2Environment::CreateCoreWebView2Controller`
+(`core/include/webview/detail/backends/win32_edge.hh`), which is *windowed*
+hosting. This document proposes adding *visual* hosting via
+`ICoreWebView2Environment3::CreateCoreWebView2CompositionController`, so an
+embedder can place its own DirectComposition visuals above or below the web
+content.
+
+## Evidence
+
+Measured against a real application (a video editor that needs GPU-composited
+video underneath its HTML UI), Windows 11, WebView2 Evergreen. Each experiment
+was run to a conclusion before the next was attempted.
+
+### 1. Child HWND above the webview — never visible
+
+A `WS_CHILD` window created as a sibling of the webview widget, `SetWindowPos`
+to `HWND_TOP`, sized to the target rectangle.
+
+Enumerating the window tree confirms it is created, visible and correctly
+placed — its rectangle matches, to the pixel, what the page reported for the
+element it was tracking:
+
+```
+hwnd=... class='ThothiumPreviewSurface' visible=True rect=328,269 106x188
+hwnd=... class='webview_widget'          visible=True rect=112,135 1082x710
+             └ Chrome_WidgetWin_0/1, Chrome_RenderWidgetHostHWND, Intermediate D3D Window
+```
+
+It is never seen. Chromium composites through DirectComposition, and that
+composition covers sibling child windows regardless of HWND z-order.
+
+**This is the failure to be most careful about**: every observable signal says
+success. `IsWindowVisible` is true, the rect is right, `WM_PAINT` runs.
+
+### 2. Top-most owned popup — visible
+
+The same window as `WS_POPUP` with `WS_EX_TOPMOST`, owned by the host window,
+positioned in screen coordinates.
+
+**Visible.** This is the control that proves the painting code is correct and
+experiment 1 failed by *occlusion*, not by a drawing bug. Worth running before
+concluding anything, because it separates two failures that look identical.
+
+Not a solution: a top-most popup floats over menus and modal dialogs, does not
+clip to the host window, and fights z-order with other applications.
+
+### 3. Transparent background, native content beneath — no compositing
+
+`ICoreWebView2Controller2::put_DefaultBackgroundColor` with alpha 0 **succeeds**,
+and the page genuinely becomes transparent — page-painted backgrounds disappear
+and the bare host window shows through.
+
+What appears through the hole is the host window's *unpainted client area*, not
+the sibling child window beneath the webview. The documentation says:
+
+> when the DefaultBackgroundColor is transparent, WebView will render hosting app
+> content as the background
+
+That is true of visual hosting. With a windowed controller, a sibling child
+window underneath is not "hosting app content" and does not appear.
+
+### 4. Painting the host window itself — no compositing
+
+Two attempts:
+
+- **`GetDC(host)` + `FillRect`** — draws nothing. A DC obtained this way has
+  child windows clipped out of its visible region, and the webview covers the
+  entire client area. The fill is discarded before it reaches a pixel.
+- **Subclassing the host window** (`SetWindowLongPtrW`/`GWLP_WNDPROC`) and
+  filling during its own `WM_ERASEBKGND`, which is not subject to that clipping.
+  The subclass installs and runs. Still nothing appears.
+
+**Conclusion: with a windowed controller, transparent WebView2 does not
+composite over host-window content.** Both directions — above and below — are
+closed, and no amount of z-order or painting fixes it.
+
+## The design
+
+Add an opt-in visual-hosting path alongside the existing windowed one:
+
+1. Query the environment for `ICoreWebView2Environment3` and call
+   `CreateCoreWebView2CompositionController` instead of
+   `CreateCoreWebView2Controller`, with a matching completion handler.
+2. Create a DirectComposition device and a target bound to the host window,
+   then a visual tree. Set the controller's `RootVisualTarget` to the visual the
+   web content should render into.
+3. The embedder gets access to the tree, so it can insert its own visuals above
+   or below the web content, with real alpha.
+
+Windowed hosting stays the default. Visual hosting is opt-in, because it
+carries a real cost:
+
+### Input must be forwarded by hand
+
+This is the substantive work, not the rendering. A visual-hosted WebView2
+receives no input from the system. The host must forward it via
+`ICoreWebView2CompositionController`:
+
+- `SendMouseInput` for every move, button, double-click and wheel event,
+  including the `mouse_data` for wheel deltas and X-buttons;
+- pointer input for touch and pen, via `SendPointerInput`;
+- cursor updates — the controller exposes a `Cursor` property and a
+  `CursorChanged` event; without handling it the cursor never changes over web
+  content;
+- focus, and IME/composition for non-Latin input.
+
+Getting any of these subtly wrong produces bugs that are hard to attribute: drag
+selection that stops at the window edge, hover states that stick, a text caret
+that ignores an IME. Anyone enabling visual hosting is taking that on, which is
+why it is not the default.
+
+## Why this belongs upstream
+
+Every embedder that needs native content composited with web content hits this,
+and the only way through is inside the backend's controller creation — an
+embedder cannot reach it from outside. Microsoft's own guidance names visual
+hosting as the answer. Adding it here means each project does not have to fork
+to discover the four dead ends above.
+
+## Licence
+
+`webview` is MIT. This work is offered under the same terms.

--- a/docs/visual-hosting.md
+++ b/docs/visual-hosting.md
@@ -1,7 +1,8 @@
 # Visual hosting on Windows (WebView2 composition controller)
 
-**Status:** in progress. This document is the rationale and the measured
-evidence; the implementation follows it.
+**Status:** implemented and running in a real application. Mouse, wheel, drag
+and cursor are forwarded; touch/pen (`SendPointerInput`) is not yet. This
+document is the rationale and the measured evidence behind the design.
 
 ## The problem
 
@@ -112,10 +113,10 @@ Add an opt-in visual-hosting path alongside the existing windowed one:
 Windowed hosting stays the default. Visual hosting is opt-in, because it
 carries a real cost:
 
-### Input must be forwarded by hand
+### Pointer input must be forwarded by hand
 
 This is the substantive work, not the rendering. A visual-hosted WebView2
-receives no input from the system. The host must forward it via
+receives no *pointer* input from the system. The host must forward it via
 `ICoreWebView2CompositionController`:
 
 - `SendMouseInput` for every move, button, double-click and wheel event,
@@ -123,13 +124,18 @@ receives no input from the system. The host must forward it via
 - pointer input for touch and pen, via `SendPointerInput`;
 - cursor updates — the controller exposes a `Cursor` property and a
   `CursorChanged` event; without handling it the cursor never changes over web
-  content;
-- focus, and IME/composition for non-Latin input.
+  content.
 
 Getting any of these subtly wrong produces bugs that are hard to attribute: drag
-selection that stops at the window edge, hover states that stick, a text caret
-that ignores an IME. Anyone enabling visual hosting is taking that on, which is
-why it is not the default.
+selection that stops at the window edge, or hover states that stick. Anyone
+enabling visual hosting is taking that on, which is why it is not the default.
+
+**Keyboard input needs nothing.** There is no `SendKeyboardInput` anywhere in
+the WebView2 API — the composition controller exposes only `SendMouseInput` and
+`SendPointerInput`. Keyboard follows window focus and reaches the web content
+through the normal mechanism. Worth stating plainly, because "visual hosting
+means forwarding *all* input by hand" is the natural assumption, and acting on
+it would mean building something the platform already handles.
 
 ## Why this belongs upstream
 


### PR DESCRIPTION
## What

Adds **opt-in visual hosting** on Windows via
`ICoreWebView2Environment3::CreateCoreWebView2CompositionController`, so an
embedder can composite its own content - a video frame, a GPU surface with the
web content.

Windowed hosting is unchanged and remains the default. Nothing changes for
existing users, and there is no new link-time dependency.

## Why

Today you cannot show native content either *above* or *below* a WebView2
created by this library. Not with the right z-order, not with a transparent
background, not by painting the host window. The failures are silent: the OS
reports your window as visible, at the correct rectangle, and you see nothing.

This is the airspace problem, and it is not specific to this library, Microsoft
hit it with their own WPF control and
[reached the same conclusion](https://github.com/MicrosoftEdge/WebView2Feedback/blob/main/specs/WPF_WebView2CompositionControl.md):

> the WebView2 control will always be the top-most control in the WPF app, and
> any WPF element in the same location will end up below the WebView2 control.
> Solving this issue necessitates moving away from the HwndHost and windowed
> hosting model, and instead use visuals to host the WebView2.

It cannot be fixed from outside the library: the controller is created inside
`win32_edge.hh`, so an embedder has no way to reach it.

`docs/visual-hosting.md` records four experiments run against a real application
before writing any of this, with the measured result of each:

1. **Child HWND above the webview** placed pixel-exactly, `IsWindowVisible`
   true, `WM_PAINT` running, and **never seen**.
2. **Top-most owned popup** **visible**. The control that proves the painting
   code is correct and (1) failed by occlusion rather than a drawing bug.
3. **Transparent background + native content beneath** 
   `put_DefaultBackgroundColor` alpha 0 succeeds and the page does go
   see-through, but what shows is the host window's bare client area, not the
   sibling window beneath.
4. **Painting the host window itself** nothing appears, via `GetDC` (children
   are clipped out of that DC) or a `WM_ERASEBKGND` subclass.

## How

- `webview2_com_handler` also implements the composition-controller completion
  handler. When visual hosting is requested it queries the environment for
  `ICoreWebView2Environment3`, **falling back to windowed hosting** when the
  runtime is too old.
- Builds a DirectComposition device, target and visual tree, and points
  `RootVisualTarget` at the web content's visual. Visuals added below it show
  through wherever the page is transparent.
- Sets `DefaultBackgroundColor` to alpha 0, without which the web content is an
  opaque sheet over whatever the embedder composited beneath it.
- Forwards mouse input and cursor updates (see below).
- Two new native-handle kinds expose the device and root visual, null on other
  backends and under windowed hosting.
- **`dcomp.dll` is loaded at runtime**, mirroring how this library already loads
  `WebView2Loader.dll`. Linking `dcomp.lib` would make every consumer pay for an
  opt-in feature and refuse to start where DirectComposition is unavailable.

### Input

A visual-hosted WebView2 receives no pointer input from the system. Four details
that are easy to get wrong, all found by testing:

- wheel messages carry **screen** coordinates while every other mouse message
  carries client coordinates;
- wheel and X-button payloads live in the high word of `wParam`;
- buttons must capture the mouse or a drag freezes as soon as the pointer leaves
  the window;
- `TrackMouseEvent` is required for `WM_MOUSELEAVE`, or hover states stick.

**Keyboard needs no forwarding.** There is no `SendKeyboardInput` anywhere in
the WebView2 API  keyboard follows window focus. Worth stating explicitly,
because "visual hosting means forwarding *all* input by hand" is the natural
assumption and acting on it means building something the platform already does.

## Status and open questions

Running in a real application (a video editor compositing GPU video under its
HTML UI): hosting mode active, UI renders and behaves normally, mouse, drag,
wheel and cursor all work, resize is smooth.

Two things I would like maintainer direction on rather than decide in a fork:

1. **Opt-in mechanism.** Currently `WEBVIEW_VISUAL_HOSTING=1`, which keeps this
   branch reviewable without inventing public API. A create-option seems the
   natural home; happy to implement whatever shape you prefer.
2. **API surface for the tree.** Two Windows-only native-handle kinds is one
   option. A single "visual to attach siblings to" accessor, with the library
   owning creation and commit, would hide more of DirectComposition from
   embedders  possibly the better boundary.

Not yet covered: touch/pen via `SendPointerInput`.

Licence: MIT, same as the project.
